### PR TITLE
static_assert for fc unpack of const type

### DIFF
--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -243,9 +243,7 @@ namespace fc {
 
     template<typename Stream, typename T> inline void unpack( Stream& s, const T& vi )
     {
-       T tmp;
-       fc::raw::unpack( s, tmp );
-       FC_ASSERT( vi == tmp );
+       static_assert(not std::is_same_v<const T, const T>, "can't unpack const type");
     }
 
     template<typename Stream> inline void pack( Stream& s, const char* v ) {


### PR DESCRIPTION
Instead of generating an error at runtime with `FC_ASSERT`, generate an error at compile time for trying to `unpack` a const type.

Example error:
```
/home/heifner/ext/leap/libraries/libfc/include/fc/io/raw.hpp:249:8: error: static assertion failed due to requirement '!std::is_same_v<const eosio::chain::packed_transaction, const eosio::chain::packed_transaction>': can't unpack const type
       static_assert(not std::is_same_v<const T, const T>, "can't unpack const type");
       ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/heifner/ext/leap/plugins/net_plugin/net_plugin.cpp:3195:16: note: in instantiation of function template specialization 'fc::raw::unpack<fc::mb_datastream<1048576>, eosio::chain::packed_transaction>' requested here
      fc::raw::unpack( ds, *ptr );
               ^
1 error generated.
```

Note non-const already hits:
```
/home/heifner/ext/leap/libraries/libfc/include/fc/io/raw.hpp:360:58: error: invalid operands to binary expression ('fc::mb_datastream<1048576>' and 'eosio::testitnow')
        static inline void unpack( Stream& s, T& v ) { s >> v; }
```