### PR TITLE
silence `interference-size` warning

### DIFF
--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -22,6 +22,12 @@ namespace eosio { namespace chain {
    [[maybe_unused]] constexpr std::size_t hardware_destructive_interference_size  = 64;
 #endif
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Winterference-size"
+#endif
    // Use instead of std::atomic when std::atomic does not support type
    template <typename T>
    class large_atomic {
@@ -49,6 +55,9 @@ namespace eosio { namespace chain {
 
       auto make_accessor() { return accessor{mtx, value}; }
    };
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
    template <typename T>
    class copyable_atomic {


### PR DESCRIPTION
with gcc13 there are a deluge of warnings,
```
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
   28 |       alignas(hardware_destructive_interference_size)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: its value can vary between compiler versions or with different ‘-mtune’ or ‘-mcpu’ flags
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: if this use is part of a public ABI, change it to instead use a constant variable you define
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: the default value for the current CPU tuning is 64 bytes
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: you can stabilize this value with ‘--param hardware_destructive_interference_size=64’, or disable this warning with ‘-Wno-interference-size’
```

This is one way to silence them.

The usage of `hardware_destructive_interference_size` in net_plugin does not cause a warning, as the warning only is set to fire in a header (or module export).