### PR TITLE
remove `hardware_destructive_interference_size` to silence `interference-size` warning

### DIFF
--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -25,7 +25,6 @@ namespace eosio { namespace chain {
    // Use instead of std::atomic when std::atomic does not support type
    template <typename T>
    class large_atomic {
-      alignas(hardware_destructive_interference_size)
       mutable std::mutex mtx;
       T value{};
    public:


### PR DESCRIPTION
with gcc13 there are a deluge of warnings,
```
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
   28 |       alignas(hardware_destructive_interference_size)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: its value can vary between compiler versions or with different ‘-mtune’ or ‘-mcpu’ flags
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: if this use is part of a public ABI, change it to instead use a constant variable you define
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: the default value for the current CPU tuning is 64 bytes
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: you can stabilize this value with ‘--param hardware_destructive_interference_size=64’, or disable this warning with ‘-Wno-interference-size’
```

For now, remove the `alignas(hardware_destructive_interference_size)` as part of `large_atomic` as suggested in https://github.com/AntelopeIO/spring/pull/34#discussion_r1567228650