### PR TITLE
Make getLatestSnapshot() and removeState() member functions of Node

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -8,6 +8,7 @@ import json
 import shlex
 import signal
 import sys
+import shutil
 from pathlib import Path
 from typing import List
 from dataclasses import InitVar, dataclass, field, is_dataclass, asdict
@@ -536,6 +537,21 @@ class Node(Transactions):
     def scheduleSnapshotAt(self, sbn):
         param = { "start_block_num": sbn, "end_block_num": sbn }
         return self.processUrllibRequest("producer", "schedule_snapshot", param)
+
+    def getLatestSnapshot(self):
+       snapshotDir = os.path.join(Utils.getNodeDataDir(self.nodeId), "snapshots")
+       snapshotDirContents = os.listdir(snapshotDir)
+       assert len(snapshotDirContents) > 0
+       # disregard snapshot schedule config in same folder
+       snapshotScheduleDB = "snapshot-schedule.json"
+       if snapshotScheduleDB in snapshotDirContents: snapshotDirContents.remove(snapshotScheduleDB)
+       snapshotDirContents.sort()
+       return os.path.join(snapshotDir, snapshotDirContents[-1])
+
+    def removeState(self):
+       dataDir = Utils.getNodeDataDir(self.nodeId)
+       state = os.path.join(dataDir, "state")
+       shutil.rmtree(state, ignore_errors=True)
 
     @staticmethod
     def findStderrFiles(path):

--- a/tests/nodeos_irreversible_mode_test.py
+++ b/tests/nodeos_irreversible_mode_test.py
@@ -50,23 +50,10 @@ def recoverBackedupBlksDir(nodeId):
    shutil.rmtree(existingBlocksDir, ignore_errors=True)
    shutil.copytree(backedupBlocksDir, existingBlocksDir)
 
-def getLatestSnapshot(nodeId):
-   snapshotDir = os.path.join(Utils.getNodeDataDir(nodeId), "snapshots")
-   snapshotDirContents = os.listdir(snapshotDir)
-   assert len(snapshotDirContents) > 0
-   snapshotDirContents.sort()
-   return os.path.join(snapshotDir, snapshotDirContents[-1])
-
-
 def removeReversibleBlks(nodeId):
    dataDir = Utils.getNodeDataDir(nodeId)
    reversibleBlks = os.path.join(dataDir, "blocks", "reversible")
    shutil.rmtree(reversibleBlks, ignore_errors=True)
-
-def removeState(nodeId):
-   dataDir = Utils.getNodeDataDir(nodeId)
-   state = os.path.join(dataDir, "state")
-   shutil.rmtree(state, ignore_errors=True)
 
 def getHeadLibAndForkDbHead(node: Node):
    info = node.getInfo()
@@ -375,9 +362,9 @@ try:
          nodeToTest.kill(signal.SIGTERM)
 
          # Start from clean data dir, recover back up blocks, and then relaunch with irreversible snapshot
-         removeState(nodeIdOfNodeToTest)
+         nodeToTest.removeState()
          recoverBackedupBlksDir(nodeIdOfNodeToTest) # this function will delete the existing blocks dir first
-         relaunchNode(nodeToTest, chainArg=" --snapshot {}".format(getLatestSnapshot(nodeIdOfNodeToTest)), addSwapFlags={"--read-mode": speculativeReadMode})
+         relaunchNode(nodeToTest, chainArg=" --snapshot {}".format(nodeToTest.getLatestSnapshot()), addSwapFlags={"--read-mode": speculativeReadMode})
          confirmHeadLibAndForkDbHeadOfSpecMode(nodeToTest)
          # Ensure it automatically replays "reversible blocks", i.e. head lib and fork db should be the same
          headLibAndForkDbHeadAfterRelaunch = getHeadLibAndForkDbHead(nodeToTest)
@@ -395,7 +382,7 @@ try:
 
          # Relaunch the node again (using the same snapshot)
          # This time ensure it automatically replays both "irreversible blocks" and "reversible blocks", i.e. the end result should be the same as before shutdown
-         removeState(nodeIdOfNodeToTest)
+         nodeToTest.removeState()
          relaunchNode(nodeToTest)
          headLibAndForkDbHeadAfterRelaunch = getHeadLibAndForkDbHead(nodeToTest)
          assert headLibAndForkDbHeadBeforeShutdown == headLibAndForkDbHeadAfterRelaunch, \
@@ -419,8 +406,8 @@ try:
          nodeToTest.kill(signal.SIGTERM)
 
          # Start from clean data dir and then relaunch with irreversible snapshot, no block log means that fork_db will be reset
-         removeState(nodeIdOfNodeToTest)
-         relaunchNode(nodeToTest, chainArg=" --snapshot {}".format(getLatestSnapshot(nodeIdOfNodeToTest)), addSwapFlags={"--read-mode": speculativeReadMode, "--block-log-retain-blocks":"0"})
+         nodeToTest.removeState()
+         relaunchNode(nodeToTest, chainArg=" --snapshot {}".format(nodeToTest.getLatestSnapshot()), addSwapFlags={"--read-mode": speculativeReadMode, "--block-log-retain-blocks":"0"})
          confirmHeadLibAndForkDbHeadOfSpecMode(nodeToTest)
          # Ensure it does not replay "reversible blocks", i.e. head and lib should be different
          headLibAndForkDbHeadAfterRelaunch = getHeadLibAndForkDbHead(nodeToTest)
@@ -438,7 +425,7 @@ try:
 
          # Relaunch the node again (using the same snapshot)
          # The end result should be the same as before shutdown
-         removeState(nodeIdOfNodeToTest)
+         nodeToTest.removeState()
          relaunchNode(nodeToTest)
          headLibAndForkDbHeadAfterRelaunch2 = getHeadLibAndForkDbHead(nodeToTest)
          assert headLibAndForkDbHeadAfterRelaunch == headLibAndForkDbHeadAfterRelaunch2, \

--- a/tests/nodeos_snapshot_diff_test.py
+++ b/tests/nodeos_snapshot_diff_test.py
@@ -58,20 +58,6 @@ trxGenLauncher=None
 
 snapshotScheduleDB = "snapshot-schedule.json"
 
-def getLatestSnapshot(nodeId):
-    snapshotDir = os.path.join(Utils.getNodeDataDir(nodeId), "snapshots")
-    snapshotDirContents = os.listdir(snapshotDir)
-    assert len(snapshotDirContents) > 0
-    # disregard snapshot schedule config in same folder
-    if snapshotScheduleDB in snapshotDirContents: snapshotDirContents.remove(snapshotScheduleDB)
-    snapshotDirContents.sort()
-    return os.path.join(snapshotDir, snapshotDirContents[-1])
-
-def removeState(nodeId):
-    dataDir = Utils.getNodeDataDir(nodeId)
-    state = os.path.join(dataDir, "state")
-    shutil.rmtree(state, ignore_errors=True)
-
 try:
     TestHelper.printSystemInfo("BEGIN")
     cluster.setWalletMgr(walletMgr)
@@ -165,14 +151,14 @@ try:
     nodeSnap.kill(signal.SIGTERM)
 
     Print("Convert snapshot to JSON")
-    snapshotFile = getLatestSnapshot(snapshotNodeId)
+    snapshotFile = nodeSnap.getLatestSnapshot()
     Utils.processLeapUtilCmd("snapshot to-json --input-file {}".format(snapshotFile), "snapshot to-json", silentErrors=False)
     snapshotFile = snapshotFile + ".json"
 
     Print("Trim programmable blocklog to snapshot head block num and relaunch programmable node")
     nodeProg.kill(signal.SIGTERM)
     output=cluster.getBlockLog(progNodeId, blockLogAction=BlockLogAction.trim, first=0, last=ret_head_block_num, throwException=True)
-    removeState(progNodeId)
+    nodeProg.removeState()
     nodeProg.rmFromCmd('--p2p-peer-address')
     isRelaunchSuccess = nodeProg.relaunch(chainArg="--replay", addSwapFlags={}, timeout=relaunchTimeout)
     assert isRelaunchSuccess, "Failed to relaunch programmable node"
@@ -188,7 +174,7 @@ try:
     nodeProg.kill(signal.SIGTERM)
 
     Print("Convert snapshot to JSON")
-    progSnapshotFile = getLatestSnapshot(progNodeId)
+    progSnapshotFile = nodeProg.getLatestSnapshot()
     Utils.processLeapUtilCmd("snapshot to-json --input-file {}".format(progSnapshotFile), "snapshot to-json", silentErrors=False)
     progSnapshotFile = progSnapshotFile + ".json"
 
@@ -197,7 +183,7 @@ try:
     output=cluster.getBlockLog(irrNodeId, blockLogAction=BlockLogAction.trim, first=0, last=ret_head_block_num, throwException=True)
 
     Print("Relaunch irreversible node in irreversible mode")
-    removeState(irrNodeId)
+    nodeIrr.removeState()
     nodeIrr.rmFromCmd('--p2p-peer-address')
     swapFlags = {"--read-mode":"irreversible", "--p2p-max-nodes-per-host":"0", "--max-clients":"0", "--allowed-connection":"none"}
     isRelaunchSuccess = nodeIrr.relaunch(chainArg="--replay", addSwapFlags=swapFlags, timeout=relaunchTimeout)
@@ -214,7 +200,7 @@ try:
     nodeIrr.kill(signal.SIGTERM)
 
     Print("Convert snapshot to JSON")
-    irrSnapshotFile = getLatestSnapshot(irrNodeId)
+    irrSnapshotFile = nodeIrr.getLatestSnapshot()
     Utils.processLeapUtilCmd("snapshot to-json --input-file {}".format(irrSnapshotFile), "snapshot to-json", silentErrors=False)
     irrSnapshotFile = irrSnapshotFile + ".json"
 

--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -52,13 +52,6 @@ testSuccessful=False
 WalletdName=Utils.EosWalletName
 shipTempDir=None
 
-def getLatestSnapshot(nodeId):
-    snapshotDir = os.path.join(Utils.getNodeDataDir(nodeId), "snapshots")
-    snapshotDirContents = os.listdir(snapshotDir)
-    assert len(snapshotDirContents) > 0
-    snapshotDirContents.sort()
-    return os.path.join(snapshotDir, snapshotDirContents[-1])
-
 try:
     TestHelper.printSystemInfo("BEGIN")
 
@@ -230,7 +223,7 @@ try:
 
     Print("Test starting ship from snapshot")
     Utils.rmNodeDataDir(shipNodeNum)
-    isRelaunchSuccess = shipNode.relaunch(chainArg=" --snapshot {}".format(getLatestSnapshot(shipNodeNum)))
+    isRelaunchSuccess = shipNode.relaunch(chainArg=" --snapshot {}".format(shipNode.getLatestSnapshot()))
     assert isRelaunchSuccess, "relaunch from snapshot failed"
 
     afterSnapshotBlockNum = shipNode.getBlockNum()


### PR DESCRIPTION
Move `getLatestSnapshot()` and `removeState()` out from `nodeos_irreversible_mode_test.py`, `nodeos_snapshot_diff_test.py`, and `ship_streamer_test.py`; make them as member functions of `Node` for reuse.

Resolved https://github.com/AntelopeIO/spring/issues/43