### PR TITLE
IF: Do not advance LIB past HEAD

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1408,7 +1408,7 @@ struct controller_impl {
 
       bool savanna_transistion_required = false;
       auto mark_branch_irreversible = [&, this](auto& forkdb) {
-         auto branch = savanna ? forkdb.fetch_head_branch( fork_db_head_or_pending(forkdb)->id(), irreversible_block_id)
+         auto branch = savanna ? forkdb.fetch_branch( fork_db_head_or_pending(forkdb)->id(), irreversible_block_id)
                                : forkdb.fetch_branch( fork_db_head_or_pending(forkdb)->id(), new_lib_num );
          try {
             auto should_process = [&](auto& bsp) {

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -135,7 +135,7 @@ namespace eosio::chain {
       void             remove_impl( const block_id_type& id );
       branch_t         fetch_branch_impl( const block_id_type& h, uint32_t trim_after_block_num ) const;
       block_branch_t   fetch_block_branch_impl( const block_id_type& h, uint32_t trim_after_block_num ) const;
-      branch_t         fetch_head_branch_impl( const block_id_type& h, const block_id_type& b ) const;
+      branch_t         fetch_branch_impl( const block_id_type& h, const block_id_type& b ) const;
       full_branch_t    fetch_full_branch_impl(const block_id_type& h) const;
       bsp_t            search_on_branch_impl( const block_id_type& h, uint32_t block_num, include_root_t include_root ) const;
       bsp_t            search_on_head_branch_impl( uint32_t block_num, include_root_t include_root ) const;
@@ -441,14 +441,14 @@ namespace eosio::chain {
 
    template <class BSP>
    fork_database_t<BSP>::branch_t
-   fork_database_t<BSP>::fetch_head_branch(const block_id_type& h, const block_id_type& b) const {
+   fork_database_t<BSP>::fetch_branch(const block_id_type& h, const block_id_type& b) const {
       std::lock_guard g(my->mtx);
-      return my->fetch_head_branch_impl(h, b);
+      return my->fetch_branch_impl(h, b);
    }
 
    template <class BSP>
    fork_database_t<BSP>::branch_t
-   fork_database_impl<BSP>::fetch_head_branch_impl(const block_id_type& h, const block_id_type& b) const {
+   fork_database_impl<BSP>::fetch_branch_impl(const block_id_type& h, const block_id_type& b) const {
       branch_t result;
       result.reserve(index.size());
       bool found_branch = false;

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -101,7 +101,7 @@ namespace eosio::chain {
        * root block (exclusive) to the block with an id of `h` (inclusive) by removing any
        * block states that are after block `b`. Returns empty if `b` not found on `h` branch.
        */
-      branch_t fetch_head_branch( const block_id_type& h, const block_id_type& b ) const;
+      branch_t fetch_branch( const block_id_type& h, const block_id_type& b ) const;
 
       /**
        *  Returns full branch of block_header_state pointers including the root.

--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -117,13 +117,13 @@ BOOST_AUTO_TEST_CASE(add_remove_test) try {
    BOOST_TEST(branch[1] == bsp12bb);
    BOOST_TEST(branch[2] == bsp11b);
 
-   // test fetch head branch
+   // test fetch branch providing head and lib
    BOOST_TEST(forkdb.head()->id() == root->id());
    forkdb.mark_valid(bsp13a);
    BOOST_TEST(forkdb.head()->id() == bsp13a->id());
-   branch = forkdb.fetch_head_branch(forkdb.head()->id(), bsp11c->id());
+   branch = forkdb.fetch_branch(forkdb.head()->id(), bsp11c->id());
    BOOST_TEST(branch.empty()); // bsp11c not on bsp13a branch
-   branch = forkdb.fetch_head_branch(forkdb.head()->id(), bsp12a->id());
+   branch = forkdb.fetch_branch(forkdb.head()->id(), bsp12a->id());
    BOOST_REQUIRE(branch.size() == 2);
    BOOST_TEST(branch[0] == bsp12a);
    BOOST_TEST(branch[1] == bsp11a);


### PR DESCRIPTION
It is possible that HEAD is not on the branch that contains the known LIB block. If on a fork, then only advance to our HEAD and only if on the same branch as LIB block. A node in this state should switch forks as it processes blocks allowing it to then advance LIB.

Resolves #46 