### PR TITLE
IF: pack the size of the bitset

### DIFF
--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -582,7 +582,6 @@ namespace fc {
     template<typename Stream, typename T>
     inline void unpack( Stream& s, boost::dynamic_bitset<T>& value ) {
       unsigned_int size; fc::raw::unpack( s, size );
-      FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
       std::vector<T> blocks;
       fc::raw::unpack(s, blocks);
       value = { blocks.cbegin(), blocks.cend() };


### PR DESCRIPTION
Change the `pack`/`unpack` scheme for `boost::dynamic_bitset`. 

Before this PR the number of blocks of the underlying storage was packed. On `unpack` the size of the dynamic bitset was the size of the number of bits in the underlying blocks. 

With this PR, the size of the bitset is pack/unpack so that the bitset can be restored to its original size.

Note this does pack the size of the bitset and the size of the `vector` of blocks. We could reduce the packed size by packing the blocks individually and determining the number of blocks by calculating how many would be needed to hold the bitset size. It is not clear to me if the more complicated pack format is worth the reduction in packed size. This is used by `quorum_certificate` which is included in most blocks.