### PR TITLE
replace `experimental-binaries` with `spring-experimental-binaries` to avoid version conflict

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: matrix.platform != 'reproducible'
         with:
-          name: spring-dev-${{matrix.platform}}-amd64
+          name: spring-dev-deb-amd64
           path: build/spring-dev*.deb
           compression-level: 0
       - name: Upload spring package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,18 +18,18 @@ jobs:
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: 'spring-dev.*amd64.deb'
+          file: 'spring-dev.*ubuntu20\.04_amd64.deb'
           target: ${{github.sha}}
-          artifact-name: spring-dev-ubuntu20-amd64
+          artifact-name: spring-dev-amd64
           wait-for-exact-target: true
       - name: Get ubuntu22 spring-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: 'spring-dev.*amd64.deb'
+          file: 'spring-dev.*ubuntu22\.04_amd64.deb'
           target: ${{github.sha}}
-          artifact-name: spring-dev-ubuntu22-amd64
+          artifact-name: spring-dev-amd64
           wait-for-exact-target: true
       - name: Create Dockerfile
         run: |
@@ -49,5 +49,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ghcr.io/${{env.REPOSITORY_OWNER_LOWER}}/experimental-binaries:${{github.ref_name}}
+          tags: ghcr.io/${{env.REPOSITORY_OWNER_LOWER}}/spring-experimental-binaries:${{github.ref_name}}
           context: .


### PR DESCRIPTION
Change the package name that dev.deb packages are stored in to avoid a version conflict in a few releases, fixes #50

Since we have to touch all downstream users of `leap-dev.deb` -> `spring-dev.deb` anyways, this also makes another modification to eliminate a long standing inconsistency. Previously, all dev packages corresponding to a release were stored in `experimental-binaries` as if using it as a "bucket", but then the dev packages from a CI run would be stored in separate artifacts such as `leap-dev-ubuntu20-amd64` and `leap-dev-ubuntu22-amd64`. But the thing is, an artifact is actually a bucket too. So for consistency just use a single artifact: `spring-dev-deb-amd64`.

`asset-artifact-download-action` seems prepared to handle multiple files in an artifact,
https://github.com/AntelopeIO/asset-artifact-download-action/blob/87f9193fddc71d0515ee1d3cac929e0b4d6bd503/main.mjs#L79-L88