### PR TITLE
Use correct finalizer_policy for logging

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1183,8 +1183,8 @@ struct controller_impl {
       );
    }
 
-   finalizer_policy_ptr active_finalizer_policy(block_num_type block_num)const {
-      block_state_ptr bsp = fetch_bsp_on_head_branch_by_num(block_num);
+   finalizer_policy_ptr active_finalizer_policy(const block_id_type& id, block_num_type block_num)const {
+      block_state_ptr bsp = fetch_bsp_on_branch_by_num(id, block_num);
       if (bsp) {
          return bsp->active_finalizer_policy;
       }
@@ -5372,8 +5372,8 @@ finalizer_policy_ptr controller::head_active_finalizer_policy()const {
    });
 }
 
-finalizer_policy_ptr controller::active_finalizer_policy(block_num_type block_num) const {
-   return my->active_finalizer_policy(block_num);
+finalizer_policy_ptr controller::active_finalizer_policy(const block_id_type& id, block_num_type block_num) const {
+   return my->active_finalizer_policy(id, block_num);
 }
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1183,6 +1183,14 @@ struct controller_impl {
       );
    }
 
+   finalizer_policy_ptr active_finalizer_policy(block_num_type block_num)const {
+      block_state_ptr bsp = fetch_bsp_on_head_branch_by_num(block_num);
+      if (bsp) {
+         return bsp->active_finalizer_policy;
+      }
+      return nullptr;
+   }
+
    block_state_ptr fetch_bsp(const block_id_type& id) const {
       return fork_db.apply<block_state_ptr>(
          overloaded{
@@ -5363,6 +5371,11 @@ finalizer_policy_ptr controller::head_active_finalizer_policy()const {
       return head->active_finalizer_policy;
    });
 }
+
+finalizer_policy_ptr controller::active_finalizer_policy(block_num_type block_num) const {
+   return my->active_finalizer_policy(block_num);
+}
+
 
 bool controller::light_validation_allowed() const {
    return my->light_validation_allowed();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -267,6 +267,8 @@ namespace eosio::chain {
 
          // returns nullptr pre-savanna
          finalizer_policy_ptr                       head_active_finalizer_policy()const;
+         // returns nullptr pre-savanna, thread-safe, block_num according to forkdb head
+         finalizer_policy_ptr                       active_finalizer_policy(block_num_type block_num)const;
 
          void set_if_irreversible_block_id(const block_id_type& id);
          uint32_t if_irreversible_block_num() const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -267,8 +267,8 @@ namespace eosio::chain {
 
          // returns nullptr pre-savanna
          finalizer_policy_ptr                       head_active_finalizer_policy()const;
-         // returns nullptr pre-savanna, thread-safe, block_num according to forkdb head
-         finalizer_policy_ptr                       active_finalizer_policy(block_num_type block_num)const;
+         // returns nullptr pre-savanna, thread-safe, block_num according to branch curresponding to id
+         finalizer_policy_ptr                       active_finalizer_policy(const block_id_type& id, block_num_type block_num)const;
 
          void set_if_irreversible_block_id(const block_id_type& id);
          uint32_t if_irreversible_block_num() const;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -708,7 +708,7 @@ public:
       if (vote_logger.is_enabled(fc::log_level::info) || _update_vote_block_metrics) {
          if (block->contains_extension(quorum_certificate_extension::extension_id())) {
             const auto& qc_ext = block->extract_extension<quorum_certificate_extension>();
-            if (const auto& active_finalizers = chain.active_finalizer_policy(qc_ext.qc.block_num)) {
+            if (const auto& active_finalizers = chain.active_finalizer_policy(id, qc_ext.qc.block_num)) {
                const auto& qc = qc_ext.qc.data;
                log_missing_votes(block, id, active_finalizers, qc);
                update_vote_block_metrics(block->block_num(), active_finalizers, qc);

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -707,8 +707,8 @@ public:
       }
       if (vote_logger.is_enabled(fc::log_level::info) || _update_vote_block_metrics) {
          if (block->contains_extension(quorum_certificate_extension::extension_id())) {
-            if (const auto& active_finalizers = chain.head_active_finalizer_policy()) {
-               const auto& qc_ext = block->extract_extension<quorum_certificate_extension>();
+            const auto& qc_ext = block->extract_extension<quorum_certificate_extension>();
+            if (const auto& active_finalizers = chain.active_finalizer_policy(qc_ext.qc.block_num)) {
                const auto& qc = qc_ext.qc.data;
                log_missing_votes(block, id, active_finalizers, qc);
                update_vote_block_metrics(block->block_num(), active_finalizers, qc);


### PR DESCRIPTION
The active finalizer policy associated with the qc should be used when logging the qc, not the head block finalizer policy.

Resolves #103 