### PR TITLE
template `fc::listener`'s Executor

### DIFF
--- a/plugins/state_history_plugin/tests/session_test.cpp
+++ b/plugins/state_history_plugin/tests/session_test.cpp
@@ -205,7 +205,7 @@ struct test_server : mock_state_history_plugin {
       };
 
       // Create and launch a listening port
-      auto server = std::make_shared<fc::listener<tcp, decltype(create_session)>>(
+      auto server = std::make_shared<fc::listener<tcp, decltype(ship_ioc), decltype(create_session)>>(
                         ship_ioc, logger, boost::posix_time::milliseconds(100), "", local_address, "", create_session);
       server->do_accept();
       local_address = server->acceptor().local_endpoint();


### PR DESCRIPTION
There is a bit of a threading trap with `fc::listener`'s current implementation. Consider usage something along the lines of,
```c++
named_thread_pool<struct ship>   thread_pool;  //running on multiple threads
std::list<connection> connections;

fc::create_listener<Protocol>(thread_pool.get_executor(), _log, accept_timeout, address, "", [this](Protocol::socket&& socket) {
   connections.emplace_back(new connection(std::move(socket)));
});
```
While the callback will never be called across multiple threads at once (ensuring `connections` will never be touched by multiple threads simultaneously _here at this location_), presumably somewhere else in the code needs to remove items from `connections` which, without any form of additional synchronization, would be a problem.

What one might be tempted to do is something very asio-like via a `strand` and `bind_executor`,
```c++
named_thread_pool<struct ship>   thread_pool;  //running on multiple threads
std::list<connection> connections;
boost::asio::strand<...> connections_strand = boost::asio::make_strand(thread_pool.get_exexcutor());

fc::create_listener<Protocol>(thread_pool.get_executor(), _log, accept_timeout, address, "", boost::asio::bind_executor(connections_strand, [this](Protocol::socket&& socket) {
   connections.emplace_back(new connection(std::move(socket)));
}));
```
Despite this compiling and running, this does not work as expected because `fc::listener` does not honor the associated executor of its callback.

So instead what could work is something like,
```c++
named_thread_pool<struct ship>   thread_pool;  //running on multiple threads
std::list<connection> connections;
boost::asio::strand<...> connections_strand = boost::asio::make_strand(thread_pool.get_exexcutor());

fc::create_listener<Protocol>(connections_strand, _log, accept_timeout, address, "", [this](Protocol::socket&& socket) {
   connections.emplace_back(new connection(std::move(socket)));
});
```
but this won't compile currently because `fc::listener` assumes only an `io_context` not any executor type.

Template the executor type passed to `fc::listener` so a strand can be passed.