### PR TITLE
libtester: return transaction trace for `setfinalizer` host function. 

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2942,6 +2942,8 @@ struct controller_impl {
            handle_exception(wrapper);
          }
 
+         // this code is hit if an exception was thrown, and handled by `handle_exception`
+         // ------------------------------------------------------------------------------
          if (!trx->is_transient()) {
             dmlog_applied_transaction(trace);
             emit( applied_transaction, std::tie(trace, trx->packed_trx()), __FILE__, __LINE__ );

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -147,7 +147,7 @@ namespace eosio::testing {
    struct produce_block_result_t {
       signed_block_ptr                   block;
       transaction_trace_ptr              onblock_trace;
-      std::vector<transaction_trace_ptr> unapplied_transaction_traces; // unapplied from previous `push_block` not on head branch
+      std::vector<transaction_trace_ptr> unapplied_transaction_traces; // only traces of any unapplied transactions
    };
 
    /**

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -147,7 +147,7 @@ namespace eosio::testing {
    struct produce_block_result_t {
       signed_block_ptr                   block;
       transaction_trace_ptr              onblock_trace;
-      std::vector<transaction_trace_ptr> traces;         // transaction traces
+      std::vector<transaction_trace_ptr> unapplied_transaction_traces; // unapplied from previous `push_block` not on head branch
    };
 
    /**
@@ -271,19 +271,23 @@ namespace eosio::testing {
          transaction_trace_ptr       set_producer_schedule(const vector<producer_authority>& schedule);
          transaction_trace_ptr       set_producers_legacy(const vector<account_name>& producer_names);
 
+         struct set_finalizers_output_t {
+            transaction_trace_ptr        setfinalizer_trace;
+            std::vector<bls_private_key> privkeys;  // private keys of **local** finalizers
+            std::vector<bls_public_key>  pubkeys;   // public keys of all finalizers in the policy
+         };
+
          // libtester uses 1 as weight of each of the finalizer, sets (2/3 finalizers + 1)
          // as threshold, and makes all finalizers vote QC
-         std::pair<transaction_trace_ptr, std::vector<fc::crypto::blslib::bls_private_key>>
-         set_finalizers(std::span<const account_name> finalizer_names);
+         set_finalizers_output_t set_finalizers(std::span<const account_name> finalizer_names);
 
-         std::pair<transaction_trace_ptr, std::vector<fc::crypto::blslib::bls_private_key>>
-         set_finalizers(const std::vector<account_name>& names) {
+         set_finalizers_output_t set_finalizers(const std::vector<account_name>& names) {
             return set_finalizers(std::span{names.begin(), names.end()});
          }
 
          void set_node_finalizers(std::span<const account_name> finalizer_names);
 
-         std::vector<fc::crypto::blslib::bls_public_key> set_active_finalizers(std::span<const account_name> finalizer_names);
+         set_finalizers_output_t set_active_finalizers(std::span<const account_name> finalizer_names);
 
          // Finalizer policy input to set up a test: weights, threshold and local finalizers
          // which participate voting.
@@ -297,7 +301,7 @@ namespace eosio::testing {
             uint64_t                    threshold {0};
             std::vector<account_name>   local_finalizers;
          };
-         std::pair<transaction_trace_ptr, std::vector<fc::crypto::blslib::bls_private_key>> set_finalizers(const finalizer_policy_input& input);
+         set_finalizers_output_t set_finalizers(const finalizer_policy_input& input);
 
          std::optional<finalizer_policy> active_finalizer_policy(const block_id_type& id) const {
             return control->active_finalizer_policy(id);
@@ -782,11 +786,11 @@ namespace eosio::testing {
 
       // updates the finalizer_policy to the `fin_policy_size` keys starting at `first_key`
       // ----------------------------------------------------------------------------------
-      std::vector<bls_public_key> set_finalizer_policy(size_t first_key) {
+      base_tester::set_finalizers_output_t set_finalizer_policy(size_t first_key) {
          return t.set_active_finalizers({&key_names.at(first_key), fin_policy_size});
       }
 
-      std::vector<bls_public_key>  set_finalizer_policy(std::span<const size_t> indices) {
+      base_tester::set_finalizers_output_t  set_finalizer_policy(std::span<const size_t> indices) {
          assert(indices.size() == fin_policy_size);
          vector<account_name> names;
          names.reserve(fin_policy_size);

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -271,24 +271,6 @@ namespace eosio::testing {
          transaction_trace_ptr       set_producer_schedule(const vector<producer_authority>& schedule);
          transaction_trace_ptr       set_producers_legacy(const vector<account_name>& producer_names);
 
-         struct set_finalizers_output_t {
-            transaction_trace_ptr        setfinalizer_trace;
-            std::vector<bls_private_key> privkeys;  // private keys of **local** finalizers
-            std::vector<bls_public_key>  pubkeys;   // public keys of all finalizers in the policy
-         };
-
-         // libtester uses 1 as weight of each of the finalizer, sets (2/3 finalizers + 1)
-         // as threshold, and makes all finalizers vote QC
-         set_finalizers_output_t set_finalizers(std::span<const account_name> finalizer_names);
-
-         set_finalizers_output_t set_finalizers(const std::vector<account_name>& names) {
-            return set_finalizers(std::span{names.begin(), names.end()});
-         }
-
-         void set_node_finalizers(std::span<const account_name> finalizer_names);
-
-         set_finalizers_output_t set_active_finalizers(std::span<const account_name> finalizer_names);
-
          // Finalizer policy input to set up a test: weights, threshold and local finalizers
          // which participate voting.
          struct finalizer_policy_input {
@@ -301,7 +283,32 @@ namespace eosio::testing {
             uint64_t                    threshold {0};
             std::vector<account_name>   local_finalizers;
          };
+
+         struct set_finalizers_output_t {
+            transaction_trace_ptr        setfinalizer_trace;
+            std::vector<bls_private_key> privkeys;  // private keys of **local** finalizers
+            std::vector<bls_public_key>  pubkeys;   // public keys of all finalizers in the policy
+         };
+
          set_finalizers_output_t set_finalizers(const finalizer_policy_input& input);
+
+         void set_node_finalizers(std::span<const account_name> finalizer_names);
+
+         set_finalizers_output_t set_active_finalizers(std::span<const account_name> finalizer_names);
+
+         // Useful when using a single node.
+         // Set a finalizer policy with a few finalizers, all local to the current node.
+         // All have weight == 1, threshold is `num_finalizers * 2 / 3 + 1`
+         // -----------------------------------------------------------------------------
+         set_finalizers_output_t set_finalizers(std::span<const account_name> finalizer_names);
+
+         // Useful when using a single node.
+         // Set a finalizer policy with a few finalizers, all local to the current node.
+         // All have weight == 1, threshold is `num_finalizers * 2 / 3 + 1`
+         // -----------------------------------------------------------------------------
+         set_finalizers_output_t set_finalizers(const std::vector<account_name>& names) {
+            return set_finalizers(std::span{names.begin(), names.end()});
+         }
 
          std::optional<finalizer_policy> active_finalizer_policy(const block_id_type& id) const {
             return control->active_finalizer_policy(id);

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1161,6 +1161,7 @@ namespace eosio::testing {
    vector<producer_authority> base_tester::get_producer_authorities( const vector<account_name>& producer_names )const {
        // Create producer schedule
        vector<producer_authority> schedule;
+       schedule.reserve(producer_names.size());
        for (auto& producer_name: producer_names) {
           schedule.emplace_back(producer_authority{ producer_name, block_signing_authority_v0{1, {{ get_public_key( producer_name, "active" ), 1}} } });
        }
@@ -1183,7 +1184,6 @@ namespace eosio::testing {
 
       return push_action( config::system_account_name, "setprods"_n, config::system_account_name,
                           fc::mutable_variant_object()("schedule", schedule_variant));
-
    }
 
    transaction_trace_ptr base_tester::set_producers_legacy(const vector<account_name>& producer_names) {
@@ -1200,7 +1200,6 @@ namespace eosio::testing {
 
       return push_action( config::system_account_name, "setprods"_n, config::system_account_name,
                           fc::mutable_variant_object()("schedule", legacy_keys));
-
    }
 
    base_tester::set_finalizers_output_t base_tester::set_finalizers(std::span<const account_name> finalizer_names) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -413,14 +413,14 @@ namespace eosio::testing {
                trace->except->dynamic_rethrow_exception();
             }
             itr = unapplied_transactions.erase( itr );
-            res.traces.emplace_back( std::move(trace) );
+            res.unapplied_transaction_traces.emplace_back( std::move(trace) );
          }
 
          vector<transaction_id_type> scheduled_trxs;
          while ((scheduled_trxs = get_scheduled_transactions()).size() > 0 ) {
             for( const auto& trx : scheduled_trxs ) {
                auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
-               res.traces.emplace_back( trace );
+               res.unapplied_transaction_traces.emplace_back( trace );
                if( !no_throw && trace->except ) {
                   // this always throws an fc::exception, since the original exception is copied into an fc::exception
                   trace->except->dynamic_rethrow_exception();
@@ -1203,8 +1203,7 @@ namespace eosio::testing {
 
    }
 
-   std::pair<transaction_trace_ptr, std::vector<bls_private_key>>
-   base_tester::set_finalizers(std::span<const account_name> finalizer_names) {
+   base_tester::set_finalizers_output_t base_tester::set_finalizers(std::span<const account_name> finalizer_names) {
       auto num_finalizers = finalizer_names.size();
       std::vector<finalizer_policy_input::finalizer_info> finalizers_info;
       finalizers_info.reserve(num_finalizers);
@@ -1221,11 +1220,11 @@ namespace eosio::testing {
       return set_finalizers(policy_input);
    }
 
-   std::pair<transaction_trace_ptr, std::vector<bls_private_key>>
-   base_tester::set_finalizers(const finalizer_policy_input& input) {
+   base_tester::set_finalizers_output_t base_tester::set_finalizers(const finalizer_policy_input& input) {
+      set_finalizers_output_t res;
+
       chain::bls_pub_priv_key_map_t local_finalizer_keys;
       fc::variants finalizer_auths;
-      std::vector<bls_private_key> priv_keys;
 
       for (const auto& f: input.finalizers) {
          auto [privkey, pubkey, pop] = get_bls_key( f.name );
@@ -1234,8 +1233,10 @@ namespace eosio::testing {
          if( auto it = std::ranges::find_if(input.local_finalizers, [&](const auto& name) { return name == f.name; });
              it != input.local_finalizers.end()) {
             local_finalizer_keys[pubkey.to_string()] = privkey.to_string();
-            priv_keys.emplace_back(privkey);
+            res.privkeys.emplace_back(privkey);
          };
+
+         res.pubkeys.emplace_back(pubkey);
 
          finalizer_auths.emplace_back(
             fc::mutable_variant_object()
@@ -1251,14 +1252,14 @@ namespace eosio::testing {
       fin_policy_variant("threshold", input.threshold);
       fin_policy_variant("finalizers", std::move(finalizer_auths));
 
-      return { push_action( config::system_account_name, "setfinalizer"_n, config::system_account_name,
-                          fc::mutable_variant_object()("finalizer_policy", std::move(fin_policy_variant))),
-               priv_keys };
+      res.setfinalizer_trace =
+         push_action( config::system_account_name, "setfinalizer"_n, config::system_account_name,
+                      fc::mutable_variant_object()("finalizer_policy", std::move(fin_policy_variant)));
+      return res;
    }
 
    void base_tester::set_node_finalizers(std::span<const account_name> names) {
-
-      chain::bls_pub_priv_key_map_t local_finalizer_keys;
+      bls_pub_priv_key_map_t local_finalizer_keys;
       for (auto name: names) {
          auto [privkey, pubkey, pop] = get_bls_key(name);
          local_finalizer_keys[pubkey.to_string()] = privkey.to_string();
@@ -1266,20 +1267,15 @@ namespace eosio::testing {
       control->set_node_finalizer_keys(local_finalizer_keys);
    }
 
-   std::vector<bls_public_key> base_tester::set_active_finalizers(std::span<const account_name> names) {
-      std::vector<bls_public_key> pubkeys;
-      pubkeys.reserve(names.size());
+   base_tester::set_finalizers_output_t base_tester::set_active_finalizers(std::span<const account_name> names) {
       finalizer_policy_input input;
       input.finalizers.reserve(names.size());
-      for (auto name : names) {
-         auto [privkey, pubkey, pop] = get_bls_key(name);
-         pubkeys.push_back(pubkey);
+      for (auto name : names)
          input.finalizers.emplace_back(name, 1);
-      }
+
       // same as reference-contracts/.../contracts/eosio.system/src/finalizer_key.cpp#L73
       input.threshold = (names.size() * 2) / 3 + 1;
-      set_finalizers(input);
-      return pubkeys;
+      return set_finalizers(input);
    }
 
    const table_id_object* base_tester::find_table( name code, name scope, name table ) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -420,7 +420,6 @@ namespace eosio::testing {
          while ((scheduled_trxs = get_scheduled_transactions()).size() > 0 ) {
             for( const auto& trx : scheduled_trxs ) {
                auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
-               res.unapplied_transaction_traces.emplace_back( trace );
                if( !no_throw && trace->except ) {
                   // this always throws an fc::exception, since the original exception is copied into an fc::exception
                   trace->except->dynamic_rethrow_exception();

--- a/unittests/finality_test_cluster.hpp
+++ b/unittests/finality_test_cluster.hpp
@@ -155,7 +155,7 @@ public:
       // ----------------------------
       for (size_t i=0; i<nodes.size(); ++i)
          fin_policy_indices_0[i] = i * split;
-      fin_policy_pubkeys_0 = node0.finkeys.set_finalizer_policy(fin_policy_indices_0);
+      fin_policy_pubkeys_0 = node0.finkeys.set_finalizer_policy(fin_policy_indices_0).pubkeys;
 
       if (config.transition_to_savanna) {
          // transition to Savanna

--- a/unittests/finality_tests.cpp
+++ b/unittests/finality_tests.cpp
@@ -506,7 +506,7 @@ BOOST_FIXTURE_TEST_CASE(second_set_finalizers, finality_test_cluster<4>) { try {
    auto indices1 = fin_policy_indices_0;  // start from original set of indices
    assert(indices1[0] == 0);              // we used index 0 for node0 in original policy
    indices1[0] = 1;                       // update key used for node0 in policy
-   auto pubkeys1 = node0.finkeys.set_finalizer_policy(indices1);
+   auto pubkeys1 = node0.finkeys.set_finalizer_policy(indices1).pubkeys;
 
    // we need two 3-chains for the new finalizer policy to be activated
    for (size_t i=0; i<6; ++i) {

--- a/unittests/finality_tests.cpp
+++ b/unittests/finality_tests.cpp
@@ -23,14 +23,14 @@ BOOST_FIXTURE_TEST_CASE(quorum_of_votes, finality_test_cluster<4>) { try {
 // verify LIB does not advances with finalizers not voting.
 // --------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(no_votes, finality_test_cluster<4>) { try {
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
    produce_and_push_block();
    for (auto i = 0; i < 3; ++i) {
       produce_and_push_block();
       // don't process votes
 
       // when only node0 votes, LIB shouldn't advance
-      BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+      BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
    }
 } FC_LOG_AND_RETHROW() }
 
@@ -38,14 +38,14 @@ BOOST_FIXTURE_TEST_CASE(no_votes, finality_test_cluster<4>) { try {
 // verify LIB does not advances when one less than the quorum votes
 // ----------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(quorum_minus_one, finality_test_cluster<4>) { try {
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
    produce_and_push_block();
    for (auto i = 0; i < 3; ++i) {
       produce_and_push_block();
       process_votes(1, num_needed_for_quorum - 1);
 
       // when one less than required vote, LIB shouldn't advance
-      BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+      BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
    }
 } FC_LOG_AND_RETHROW() }
 
@@ -111,7 +111,7 @@ BOOST_FIXTURE_TEST_CASE(one_delayed_votes, finality_test_cluster<4>) { try {
    // block 1 (index 1) has the same QC claim as block 0. It cannot move LIB
    process_votes(1, num_needed_for_quorum, 1);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // producing, pushing, and voting a new block makes LIB moving
    process_votes(1, num_needed_for_quorum);
@@ -131,7 +131,7 @@ BOOST_FIXTURE_TEST_CASE(three_delayed_votes, finality_test_cluster<4>) { try {
       produce_and_push_block();
 
    // LIB did not advance
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // vote block 0 (index 0) to make it have a strong QC,
    // prompting LIB advacing on nodes
@@ -143,7 +143,7 @@ BOOST_FIXTURE_TEST_CASE(three_delayed_votes, finality_test_cluster<4>) { try {
    for (auto i=1; i < 4; ++i) {
       process_votes(1, num_needed_for_quorum, i);
       produce_and_push_block();
-      BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+      BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
    }
 
    // Now send votes for the last block that node0 produced (block 8). It will be
@@ -175,12 +175,12 @@ BOOST_FIXTURE_TEST_CASE(out_of_order_votes, finality_test_cluster<4>) { try {
    // block 1 (index 1) has the same QC claim as block 2. It will not move LIB
    process_votes(1, num_needed_for_quorum, 1);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // block 0 (index 0) has the same QC claim as block 2. It will not move LIB
    process_votes(1, num_needed_for_quorum, 0);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // producing, pushing, and voting a new block makes LIB moving
    process_votes(1, num_needed_for_quorum);
@@ -229,7 +229,7 @@ BOOST_FIXTURE_TEST_CASE(lost_votes, finality_test_cluster<4>) { try {
    clear_votes_and_reset_lib();
 
    produce_and_push_block();                // Produce another block
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0); // LIB doesn't advance
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u); // LIB doesn't advance
 
    process_votes(1, num_needed_for_quorum); // and propagate the votes for this new block to node0
    produce_and_push_block();
@@ -247,7 +247,7 @@ BOOST_FIXTURE_TEST_CASE(one_weak_vote, finality_test_cluster<4>) { try {
    auto next_idx = process_votes(1, num_needed_for_quorum -1); // one less strong vote than needed for quorum
    process_vote(next_idx, -1, vote_mode::weak);   // and one weak vote
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0); // weak QC (1 shy of strong) => LIB does not advance
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u); // weak QC (1 shy of strong) => LIB does not advance
 
    process_votes(1, num_needed_for_quorum); // now this provides enough strong votes for quorum
    produce_and_push_block();
@@ -263,7 +263,7 @@ BOOST_FIXTURE_TEST_CASE(quorum_minus_one_weak_vote, finality_test_cluster<4>) { 
 
    process_votes(1, num_needed_for_quorum, -1, vote_mode::weak);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0); // weak QC => LIB does not advance
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u); // weak QC => LIB does not advance
 
    process_votes(1, num_needed_for_quorum);
    produce_and_push_block();
@@ -279,7 +279,7 @@ BOOST_FIXTURE_TEST_CASE(weak_strong_weak_strong, finality_test_cluster<4>) { try
 
    process_votes(1, num_needed_for_quorum, -1, vote_mode::weak);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);           // weak QC => LIB does not advance
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);           // weak QC => LIB does not advance
 
    process_votes(1, num_needed_for_quorum);
    produce_and_push_block();
@@ -287,7 +287,7 @@ BOOST_FIXTURE_TEST_CASE(weak_strong_weak_strong, finality_test_cluster<4>) { try
 
    process_votes(1, num_needed_for_quorum, -1, vote_mode::weak);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);          // weak QC => LIB does not advance
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);          // weak QC => LIB does not advance
 
    process_votes(1, num_needed_for_quorum);
    produce_and_push_block();
@@ -303,11 +303,11 @@ BOOST_FIXTURE_TEST_CASE(weak_weak_strong_strong, finality_test_cluster<4>) { try
 
    process_votes(1, num_needed_for_quorum, -1, vote_mode::weak);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);         // weak QC => LIB does not advance
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);         // weak QC => LIB does not advance
 
    process_votes(1, num_needed_for_quorum, -1, vote_mode::weak);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);         // weak QC => LIB does not advance
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);         // weak QC => LIB does not advance
 
    process_votes(1, num_needed_for_quorum);
    produce_and_push_block();
@@ -329,12 +329,12 @@ BOOST_FIXTURE_TEST_CASE(weak_delayed_lost_vote, finality_test_cluster<4>) { try 
    // quorum of weak votes
    process_votes(1, num_needed_for_quorum, -1, vote_mode::weak);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // delay votes at index 1
    constexpr uint32_t delayed_index = 1; 
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // quorum of strong votes
    process_votes(1, num_needed_for_quorum);
@@ -343,12 +343,12 @@ BOOST_FIXTURE_TEST_CASE(weak_delayed_lost_vote, finality_test_cluster<4>) { try 
 
    // A lost vote
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // The delayed vote arrives, does not advance lib
    process_votes(1, num_needed_for_quorum, delayed_index);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // strong vote advances lib
    process_votes(1, num_needed_for_quorum);
@@ -366,7 +366,7 @@ BOOST_FIXTURE_TEST_CASE(delayed_strong_weak_lost_vote, finality_test_cluster<4>)
    // delay votes at index 1
    constexpr uint32_t delayed_index = 0;
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // quorum of strong votes
    process_votes(1, num_needed_for_quorum);
@@ -376,7 +376,7 @@ BOOST_FIXTURE_TEST_CASE(delayed_strong_weak_lost_vote, finality_test_cluster<4>)
    // quorum of weak votes
    process_votes(1, num_needed_for_quorum, -1, vote_mode::weak);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // quorum of strong votes
    process_votes(1, num_needed_for_quorum);
@@ -385,12 +385,12 @@ BOOST_FIXTURE_TEST_CASE(delayed_strong_weak_lost_vote, finality_test_cluster<4>)
 
    // A lost vote
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // The delayed vote arrives, does not advance lib
    process_votes(1, num_needed_for_quorum, delayed_index);
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
    // strong vote advances lib
    process_votes(1, num_needed_for_quorum);
@@ -432,9 +432,9 @@ BOOST_FIXTURE_TEST_CASE(unknown_proposal_votes, finality_test_cluster<4>) { try 
    process_votes(2, num_needed_for_quorum - 1);
 
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);
 
-   node1.restore_to_original_vote(0);                      // restore node1's vote at index 0 to original vote
+   node1.restore_to_original_vote(0u);                      // restore node1's vote at index 0 to original vote
    process_votes(1, 1, 0, vote_mode::strong);              // send restored vote to node0
    produce_and_push_block();                               // produce a block so the new QC can propagate
    BOOST_REQUIRE_EQUAL(num_lib_advancing(), num_nodes);
@@ -457,7 +457,7 @@ BOOST_FIXTURE_TEST_CASE(unknown_finalizer_key_votes, finality_test_cluster<4>) {
    BOOST_REQUIRE(process_vote(1, 0) == eosio::chain::vote_status::unknown_public_key);
 
    // restore to original vote
-   node1.restore_to_original_vote(0);
+   node1.restore_to_original_vote(0u);
 
    // process the original vote. LIB should advance
    process_vote(1, 0);
@@ -478,9 +478,9 @@ BOOST_FIXTURE_TEST_CASE(corrupted_signature_votes, finality_test_cluster<4>) { t
    process_votes(2, num_needed_for_quorum - 1);
 
    produce_and_push_block();
-   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0);           // because of the one corrupted vote, quorum is not reached
+   BOOST_REQUIRE_EQUAL(num_lib_advancing(), 0u);           // because of the one corrupted vote, quorum is not reached
 
-   node1.restore_to_original_vote(0);                 // restore node1's vote at index 0 to original vote
+   node1.restore_to_original_vote(0u);                 // restore node1's vote at index 0 to original vote
    process_votes(1, 1, 0, vote_mode::strong);         // send restored vote to node0
    produce_and_push_block();                          // produce a block so the new QC can propagate
    BOOST_REQUIRE_EQUAL(num_lib_advancing(), num_nodes);
@@ -504,7 +504,7 @@ BOOST_FIXTURE_TEST_CASE(second_set_finalizers, finality_test_cluster<4>) { try {
    assert(fin_policy_0);        // current finalizer policy from transition to Savanna
 
    auto indices1 = fin_policy_indices_0;  // start from original set of indices
-   assert(indices1[0] == 0);              // we used index 0 for node0 in original policy
+   assert(indices1[0] == 0u);             // we used index 0 for node0 in original policy
    indices1[0] = 1;                       // update key used for node0 in policy
    auto pubkeys1 = node0.finkeys.set_finalizer_policy(indices1).pubkeys;
 
@@ -517,8 +517,8 @@ BOOST_FIXTURE_TEST_CASE(second_set_finalizers, finality_test_cluster<4>) { try {
 
    // we just completed the two 3-chains, so the next block we produce will have the new finalizer policy activated
    produce_and_push_block();
-   node0.check_head_finalizer_policy(2, pubkeys1);
-   node1.check_head_finalizer_policy(2, pubkeys1);
+   node0.check_head_finalizer_policy(2u, pubkeys1);
+   node1.check_head_finalizer_policy(2u, pubkeys1);
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/finalizer_update_tests.cpp
+++ b/unittests/finalizer_update_tests.cpp
@@ -42,12 +42,12 @@ BOOST_AUTO_TEST_CASE(savanna_set_finalizer_single_test) { try {
    fin_keys.set_node_finalizers(0, num_keys);
 
    // run initial set_finalizer_policy() and waits until transition is complete
-   auto pubkeys0 = fin_keys.set_finalizer_policy(0);
+   auto pubkeys0 = fin_keys.set_finalizer_policy(0).pubkeys;
    fin_keys.transition_to_savanna();
 
    // run set_finalizers(), verify it becomes active after exactly two 3-chains
    // -------------------------------------------------------------------------
-   auto pubkeys1 = fin_keys.set_finalizer_policy(1);
+   auto pubkeys1 = fin_keys.set_finalizer_policy(1).pubkeys;
    t.produce_block();
    t.check_head_finalizer_policy(1, pubkeys0); // new policy should only be active until after two 3-chains
 
@@ -78,13 +78,13 @@ BOOST_AUTO_TEST_CASE(savanna_set_finalizer_multiple_test) { try {
    fin_keys.set_node_finalizers(0, num_keys);
 
    // run initial set_finalizer_policy() and waits until transition is complete
-   auto pubkeys0 = fin_keys.set_finalizer_policy(0);
+   auto pubkeys0 = fin_keys.set_finalizer_policy(0).pubkeys;
    fin_keys.transition_to_savanna();
 
    // run set_finalizers() twice in same block, verify only latest one becomes active
    // -------------------------------------------------------------------------------
    (void)fin_keys.set_finalizer_policy(1);
-   auto pubkeys2 = fin_keys.set_finalizer_policy(2);
+   auto pubkeys2 = fin_keys.set_finalizer_policy(2).pubkeys;
    t.produce_block();
    t.check_head_finalizer_policy(1, pubkeys0); // new policy should only be active until after two 3-chains
    t.produce_blocks(5);
@@ -95,12 +95,12 @@ BOOST_AUTO_TEST_CASE(savanna_set_finalizer_multiple_test) { try {
    // run a test with multiple set_finlizers in-flight during the two 3-chains they
    // take to become active
    // -----------------------------------------------------------------------------
-   auto pubkeys3 = fin_keys.set_finalizer_policy(3);
+   auto pubkeys3 = fin_keys.set_finalizer_policy(3).pubkeys;
    t.produce_block();
-   auto pubkeys4 = fin_keys.set_finalizer_policy(4);
+   auto pubkeys4 = fin_keys.set_finalizer_policy(4).pubkeys;
    t.produce_block();
    t.produce_block();
-   auto pubkeys5 = fin_keys.set_finalizer_policy(5);
+   auto pubkeys5 = fin_keys.set_finalizer_policy(5).pubkeys;
    t.produce_blocks(3);
    t.check_head_finalizer_policy(2, pubkeys2); // 5 blocks after pubkeys3 (b5 - b0), pubkeys2 should still be active
    t.produce_block();

--- a/unittests/finalizer_update_tests.cpp
+++ b/unittests/finalizer_update_tests.cpp
@@ -32,33 +32,33 @@ static void ensure_next_block_finalizer_policy(validating_tester& t,
 // ---------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(savanna_set_finalizer_single_test) { try {
    validating_tester t;
-   size_t num_keys    = 22;
-   size_t finset_size = 21;
+   size_t num_keys    = 22u;
+   size_t finset_size = 21u;
 
    // Create finalizer keys
    finalizer_keys fin_keys(t, num_keys, finset_size);
 
    // set finalizers on current node
-   fin_keys.set_node_finalizers(0, num_keys);
+   fin_keys.set_node_finalizers(0u, num_keys);
 
    // run initial set_finalizer_policy() and waits until transition is complete
-   auto pubkeys0 = fin_keys.set_finalizer_policy(0).pubkeys;
+   auto pubkeys0 = fin_keys.set_finalizer_policy(0u).pubkeys;
    fin_keys.transition_to_savanna();
 
    // run set_finalizers(), verify it becomes active after exactly two 3-chains
    // -------------------------------------------------------------------------
-   auto pubkeys1 = fin_keys.set_finalizer_policy(1).pubkeys;
+   auto pubkeys1 = fin_keys.set_finalizer_policy(1u).pubkeys;
    t.produce_block();
-   t.check_head_finalizer_policy(1, pubkeys0); // new policy should only be active until after two 3-chains
+   t.check_head_finalizer_policy(1u, pubkeys0); // new policy should only be active until after two 3-chains
 
    t.produce_blocks(3);
-   t.check_head_finalizer_policy(1, pubkeys0); // one 3-chain - new policy still should not be active
+   t.check_head_finalizer_policy(1u, pubkeys0); // one 3-chain - new policy still should not be active
 
    t.produce_blocks(2);
-   t.check_head_finalizer_policy(1, pubkeys0); // one 3-chain + 2 blocks - new policy still should not be active
+   t.check_head_finalizer_policy(1u, pubkeys0); // one 3-chain + 2 blocks - new policy still should not be active
 
    t.produce_block();
-   t.check_head_finalizer_policy(2, pubkeys1); // two 3-chain - new policy *should* be active
+   t.check_head_finalizer_policy(2u, pubkeys1); // two 3-chain - new policy *should* be active
 
 } FC_LOG_AND_RETHROW() }
 
@@ -68,57 +68,55 @@ BOOST_AUTO_TEST_CASE(savanna_set_finalizer_single_test) { try {
 // ---------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(savanna_set_finalizer_multiple_test) { try {
    validating_tester t;
-   size_t num_keys    = 50;
-   size_t finset_size = 21;
+   size_t num_keys    = 50u;
+   size_t finset_size = 21u;
 
    // Create finalizer keys
    finalizer_keys fin_keys(t, num_keys, finset_size);
 
    // set finalizers on current node
-   fin_keys.set_node_finalizers(0, num_keys);
+   fin_keys.set_node_finalizers(0u, num_keys);
 
    // run initial set_finalizer_policy() and waits until transition is complete
-   auto pubkeys0 = fin_keys.set_finalizer_policy(0).pubkeys;
+   auto pubkeys0 = fin_keys.set_finalizer_policy(0u).pubkeys;
    fin_keys.transition_to_savanna();
 
    // run set_finalizers() twice in same block, verify only latest one becomes active
    // -------------------------------------------------------------------------------
-   (void)fin_keys.set_finalizer_policy(1);
-   auto pubkeys2 = fin_keys.set_finalizer_policy(2).pubkeys;
+   (void)fin_keys.set_finalizer_policy(1u);
+   auto pubkeys2 = fin_keys.set_finalizer_policy(2u).pubkeys;
    t.produce_block();
-   t.check_head_finalizer_policy(1, pubkeys0); // new policy should only be active until after two 3-chains
+   t.check_head_finalizer_policy(1u, pubkeys0); // new policy should only be active until after two 3-chains
    t.produce_blocks(5);
-   t.check_head_finalizer_policy(1, pubkeys0); // new policy should only be active until after two 3-chains
+   t.check_head_finalizer_policy(1u, pubkeys0); // new policy should only be active until after two 3-chains
    t.produce_block();
-   t.check_head_finalizer_policy(2, pubkeys2); // two 3-chain - new policy pubkeys2 *should* be active
+   t.check_head_finalizer_policy(2u, pubkeys2); // two 3-chain - new policy pubkeys2 *should* be active
 
-   // run a test with multiple set_finlizers in-flight during the two 3-chains they
+   // run a test with multiple set_finalizers in-flight during the two 3-chains they
    // take to become active
-   // -----------------------------------------------------------------------------
-   auto pubkeys3 = fin_keys.set_finalizer_policy(3).pubkeys;
+   // ------------------------------------------------------------------------------
+   auto pubkeys3 = fin_keys.set_finalizer_policy(3u).pubkeys;
    t.produce_block();
-   auto pubkeys4 = fin_keys.set_finalizer_policy(4).pubkeys;
+   auto pubkeys4 = fin_keys.set_finalizer_policy(4u).pubkeys;
    t.produce_block();
    t.produce_block();
-   auto pubkeys5 = fin_keys.set_finalizer_policy(5).pubkeys;
+   auto pubkeys5 = fin_keys.set_finalizer_policy(5u).pubkeys;
    t.produce_blocks(3);
-   t.check_head_finalizer_policy(2, pubkeys2); // 5 blocks after pubkeys3 (b5 - b0), pubkeys2 should still be active
+   t.check_head_finalizer_policy(2u, pubkeys2); // 5 blocks after pubkeys3 (b5 - b0), pubkeys2 should still be active
    t.produce_block();
-   t.check_head_finalizer_policy(3, pubkeys3); // 6 blocks after pubkeys3 (b6 - b0), pubkeys3 should be active
+   t.check_head_finalizer_policy(3u, pubkeys3); // 6 blocks after pubkeys3 (b6 - b0), pubkeys3 should be active
    t.produce_block();
-   t.check_head_finalizer_policy(4, pubkeys4); // 6 blocks after pubkeys4 (b7 - b1), pubkeys4 should be active
+   t.check_head_finalizer_policy(4u, pubkeys4); // 6 blocks after pubkeys4 (b7 - b1), pubkeys4 should be active
 
    t.produce_block();
-   t.check_head_finalizer_policy(4, pubkeys4); // 7 blocks after pubkeys4, pubkeys4 should still be active
+   t.check_head_finalizer_policy(4u, pubkeys4); // 7 blocks after pubkeys4, pubkeys4 should still be active
    t.produce_block();
-   t.check_head_finalizer_policy(5, pubkeys5); // 6 blocks after pubkeys5 (b9 - b3), pubkeys5 should be active
+   t.check_head_finalizer_policy(5u, pubkeys5); // 6 blocks after pubkeys5 (b9 - b3), pubkeys5 should be active
 
    // and no further change
-   ensure_next_block_finalizer_policy(t, 5, pubkeys5);
-   ensure_next_block_finalizer_policy(t, 5, pubkeys5);
-   ensure_next_block_finalizer_policy(t, 5, pubkeys5);
-   ensure_next_block_finalizer_policy(t, 5, pubkeys5);
-   ensure_next_block_finalizer_policy(t, 5, pubkeys5);
+   // ---------------------
+   for (size_t i=0; i<10; ++i)
+      ensure_next_block_finalizer_policy(t, 5u, pubkeys5);
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -751,7 +751,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
 
    // produce block which will apply the unapplied transactions
    produce_block_result_t produce_block_result = c.produce_block_ex(fc::milliseconds(config::block_interval_ms), true);
-   std::vector<transaction_trace_ptr>& traces = produce_block_result.traces;
+   std::vector<transaction_trace_ptr>& traces = produce_block_result.unapplied_transaction_traces;
 
    BOOST_REQUIRE_EQUAL( 4u, traces.size() );
    BOOST_CHECK_EQUAL( trace1->id, traces.at(0)->id );


### PR DESCRIPTION
This is needed for IBC proof tests.