### PR TITLE
IF: Use proposer diffs in instant_finality_extension

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -79,38 +79,15 @@ const finalizer_policy& block_header_state::get_last_proposed_finalizer_policy()
    return *active_finalizer_policy;
 }
 
-finalizer_policy_diff block_header_state::calculate_finalizer_policy_diff(const finalizer_policy& new_policy) const {
-   return get_last_proposed_finalizer_policy().create_diff(new_policy);
-}
-
-finalizer_policy block_header_state::calculate_finalizer_policy(const finalizer_policy_diff& diff) const {
-   finalizer_policy result = get_last_proposed_finalizer_policy();
-   result.apply_diff(diff);
-   return result;
-}
-
-proposer_policy_diff block_header_state::calculate_proposer_policy_diff(const proposer_policy& new_policy) const {
+// The last proposed proposer policy, if none proposed then the active proposer policy
+const proposer_policy& block_header_state::get_last_proposed_proposer_policy() const {
    if (proposer_policies.empty()) {
       assert(active_proposer_policy);
-      return active_proposer_policy->create_diff(new_policy);
+      return *active_proposer_policy;
    }
    auto it = proposer_policies.rbegin();
    assert(it != proposer_policies.rend());
-   return it->second->create_diff(new_policy);
-}
-
-proposer_policy block_header_state::calculate_proposer_policy(const proposer_policy_diff& diff) const {
-   if (proposer_policies.empty()) {
-      assert(active_proposer_policy);
-      proposer_policy result = *active_proposer_policy;
-      result.apply_diff(diff);
-      return result;
-   }
-   auto it = proposer_policies.rbegin();
-   assert(it != proposer_policies.rend());
-   proposer_policy result = *it->second;
-   result.apply_diff(diff);
-   return result;
+   return *it->second;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -151,7 +128,7 @@ void finish_next(const block_header_state& prev,
 
    std::optional<proposer_policy> new_proposer_policy;
    if (if_ext.new_proposer_policy_diff) {
-      new_proposer_policy = prev.calculate_proposer_policy(*if_ext.new_proposer_policy_diff);
+      new_proposer_policy = prev.get_last_proposed_proposer_policy().apply_diff(*if_ext.new_proposer_policy_diff);
    }
    if (new_proposer_policy) {
       // called when assembling the block
@@ -207,7 +184,7 @@ void finish_next(const block_header_state& prev,
    }
 
    if (if_ext.new_finalizer_policy_diff) {
-      finalizer_policy new_finalizer_policy = prev.calculate_finalizer_policy(*if_ext.new_finalizer_policy_diff);
+      finalizer_policy new_finalizer_policy = prev.get_last_proposed_finalizer_policy().apply_diff(*if_ext.new_finalizer_policy_diff);
 
       // a new `finalizer_policy` was proposed in the previous block, and is present in the previous
       // block's header extensions.
@@ -258,11 +235,11 @@ block_header_state block_header_state::next(block_header_state_input& input) con
    // ------------------
    std::optional<finalizer_policy_diff> new_finalizer_policy_diff;
    if (input.new_finalizer_policy) {
-      new_finalizer_policy_diff = calculate_finalizer_policy_diff(*input.new_finalizer_policy);
+      new_finalizer_policy_diff = get_last_proposed_finalizer_policy().create_diff(*input.new_finalizer_policy);
    }
    std::optional<proposer_policy_diff> new_proposer_policy_diff;
    if (input.new_proposer_policy) {
-      new_proposer_policy_diff = calculate_proposer_policy_diff(*input.new_proposer_policy);
+      new_proposer_policy_diff = get_last_proposed_proposer_policy().create_diff(*input.new_proposer_policy);
    }
    instant_finality_extension new_if_ext { input.most_recent_ancestor_with_qc,
                                            std::move(new_finalizer_policy_diff),

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -73,8 +73,7 @@ block_state_ptr block_state::create_if_genesis_block(const block_state_legacy& b
    assert(bsp.block->contains_header_extension(instant_finality_extension::extension_id())); // required by transition mechanism
    instant_finality_extension if_ext = bsp.block->extract_header_extension<instant_finality_extension>();
    assert(if_ext.new_finalizer_policy_diff); // required by transition mechanism
-   result.active_finalizer_policy = std::make_shared<finalizer_policy>();
-   result.active_finalizer_policy->apply_diff(std::move(*if_ext.new_finalizer_policy_diff));
+   result.active_finalizer_policy = std::make_shared<finalizer_policy>(finalizer_policy{}.apply_diff(std::move(*if_ext.new_finalizer_policy_diff)));
    result.active_proposer_policy = std::make_shared<proposer_policy>();
    result.active_proposer_policy->active_time = bsp.timestamp();
    result.active_proposer_policy->proposer_schedule = bsp.active_schedule;

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -131,10 +131,7 @@ struct block_header_state {
    const producer_authority& get_scheduled_producer(block_timestamp_type t) const;
 
    const finalizer_policy& get_last_proposed_finalizer_policy() const;
-   finalizer_policy_diff calculate_finalizer_policy_diff(const finalizer_policy& new_policy) const;
-   finalizer_policy calculate_finalizer_policy(const finalizer_policy_diff& diff) const;
-   proposer_policy_diff calculate_proposer_policy_diff(const proposer_policy& new_policy) const;
-   proposer_policy calculate_proposer_policy(const proposer_policy_diff& diff) const;
+   const proposer_policy& get_last_proposed_proposer_policy() const;
 };
 
 using block_header_state_ptr = std::shared_ptr<block_header_state>;

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -61,7 +61,7 @@ struct building_block_input {
 // this struct can be extracted from a building block
 struct block_header_state_input : public building_block_input {
    digest_type                       transaction_mroot;    // Comes from std::get<checksum256_type>(building_block::trx_mroot_or_receipt_digests)
-   std::shared_ptr<proposer_policy>  new_proposer_policy;  // Comes from building_block::new_proposer_policy
+   std::optional<proposer_policy>    new_proposer_policy;  // Comes from building_block::new_proposer_policy
    std::optional<finalizer_policy>   new_finalizer_policy; // Comes from building_block::new_finalizer_policy
    qc_claim_t                        most_recent_ancestor_with_qc; // Comes from traversing branch from parent and calling get_best_qc()
    digest_type                       finality_mroot_claim;
@@ -133,6 +133,8 @@ struct block_header_state {
    const finalizer_policy& get_last_proposed_finalizer_policy() const;
    finalizer_policy_diff calculate_finalizer_policy_diff(const finalizer_policy& new_policy) const;
    finalizer_policy calculate_finalizer_policy(const finalizer_policy_diff& diff) const;
+   proposer_policy_diff calculate_proposer_policy_diff(const proposer_policy& new_policy) const;
+   proposer_policy calculate_proposer_policy(const proposer_policy_diff& diff) const;
 };
 
 using block_header_state_ptr = std::shared_ptr<block_header_state>;

--- a/libraries/chain/include/eosio/chain/finality/finalizer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/finality/finalizer_policy.hpp
@@ -29,10 +29,13 @@ namespace eosio::chain {
 
       template <typename X>
       requires std::same_as<std::decay_t<X>, finalizer_policy_diff>
-      void apply_diff(X&& diff) {
-         generation = diff.generation;
-         threshold = diff.threshold;
-         finalizers = finalizers_differ::apply_diff(std::move(finalizers), std::forward<X>(diff).finalizers_diff);
+      [[nodiscard]] finalizer_policy apply_diff(X&& diff) const {
+         finalizer_policy result;
+         result.generation = diff.generation;
+         result.threshold = diff.threshold;
+         auto copy = finalizers;
+         result.finalizers = finalizers_differ::apply_diff(std::move(copy), std::forward<X>(diff).finalizers_diff);
+         return result;
       }
 
       // max accumulated weak weight before becoming weak_final

--- a/libraries/chain/include/eosio/chain/finality/instant_finality_extension.hpp
+++ b/libraries/chain/include/eosio/chain/finality/instant_finality_extension.hpp
@@ -12,11 +12,11 @@ struct instant_finality_extension : fc::reflect_init {
 
    instant_finality_extension() = default;
    instant_finality_extension(qc_claim_t qc_claim,
-                              std::optional<finalizer_policy_diff> new_finalizer_policy_diff,
-                              std::shared_ptr<proposer_policy> new_proposer_policy) :
+                              std::optional<finalizer_policy_diff>&& new_finalizer_policy_diff,
+                              std::optional<proposer_policy_diff>&& new_proposer_policy_diff) :
       qc_claim(qc_claim),
       new_finalizer_policy_diff(std::move(new_finalizer_policy_diff)),
-      new_proposer_policy(std::move(new_proposer_policy))
+      new_proposer_policy_diff(std::move(new_proposer_policy_diff))
    {}
 
    void reflector_init() const {
@@ -27,9 +27,9 @@ struct instant_finality_extension : fc::reflect_init {
 
    qc_claim_t                              qc_claim;
    std::optional<finalizer_policy_diff>    new_finalizer_policy_diff;
-   std::shared_ptr<proposer_policy>        new_proposer_policy;
+   std::optional<proposer_policy_diff>     new_proposer_policy_diff;
 };
 
 } /// eosio::chain
 
-FC_REFLECT( eosio::chain::instant_finality_extension, (qc_claim)(new_finalizer_policy_diff)(new_proposer_policy) )
+FC_REFLECT( eosio::chain::instant_finality_extension, (qc_claim)(new_finalizer_policy_diff)(new_proposer_policy_diff) )

--- a/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
@@ -5,16 +5,41 @@
 
 namespace eosio::chain {
 
+static_assert(std::numeric_limits<uint8_t>::max() >= config::max_producers - 1);
+using producer_auth_differ = fc::ordered_diff<producer_authority, uint8_t>;
+using producer_auth_diff_t = producer_auth_differ::diff_result;
+
+struct proposer_policy_diff {
+   uint32_t                    version = 0; ///< sequentially incrementing version number of producer_authority_schedule
+   block_timestamp_type        active_time; // block when schedule will become active
+   producer_auth_diff_t        producer_auth_diff;
+};
+
 struct proposer_policy {
-   constexpr static uint8_t    current_schema_version = 1;
-   uint8_t                     schema_version {current_schema_version};
    // Useful for light clients, not necessary for nodeos
    block_timestamp_type        active_time; // block when schedule will become active
    producer_authority_schedule proposer_schedule;
+
+   proposer_policy_diff create_diff(const proposer_policy& target) const {
+      return {.version = target.proposer_schedule.version,
+              .active_time = target.active_time,
+              .producer_auth_diff = producer_auth_differ::diff(proposer_schedule.producers, target.proposer_schedule.producers)};
+   }
+
+   template <typename X>
+   requires std::same_as<std::decay_t<X>, proposer_policy_diff>
+   void apply_diff(X&& diff) {
+      proposer_schedule.version = diff.version;
+      active_time = diff.active_time;
+      proposer_schedule.producers = producer_auth_differ::apply_diff(std::move(proposer_schedule.producers),
+                                                                     std::forward<X>(diff).producer_auth_diff);
+   }
 };
 
 using proposer_policy_ptr = std::shared_ptr<proposer_policy>;
 
 } /// eosio::chain
 
-FC_REFLECT( eosio::chain::proposer_policy, (schema_version)(active_time)(proposer_schedule) )
+FC_REFLECT( eosio::chain::proposer_policy, (active_time)(proposer_schedule) )
+FC_REFLECT( eosio::chain::producer_auth_diff_t, (remove_indexes)(insert_indexes) )
+FC_REFLECT( eosio::chain::proposer_policy_diff, (version)(active_time)(producer_auth_diff) )

--- a/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
@@ -28,11 +28,14 @@ struct proposer_policy {
 
    template <typename X>
    requires std::same_as<std::decay_t<X>, proposer_policy_diff>
-   void apply_diff(X&& diff) {
-      proposer_schedule.version = diff.version;
-      active_time = diff.active_time;
-      proposer_schedule.producers = producer_auth_differ::apply_diff(std::move(proposer_schedule.producers),
-                                                                     std::forward<X>(diff).producer_auth_diff);
+   [[nodiscard]] proposer_policy apply_diff(X&& diff) const {
+      proposer_policy result;
+      result.proposer_schedule.version = diff.version;
+      result.active_time = diff.active_time;
+      auto copy = proposer_schedule.producers;
+      result.proposer_schedule.producers = producer_auth_differ::apply_diff(std::move(copy),
+                                                                            std::forward<X>(diff).producer_auth_diff);
+      return result;
    }
 };
 

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -861,9 +861,7 @@ namespace eosio::testing {
             auto b = produce_block();
 
          BOOST_REQUIRE_EQUAL(t.lib_block->block_num(), pt_block->block_num());
-         finalizer_policy fin_policy;
-         fin_policy.apply_diff(*fin_policy_diff);
-         return fin_policy;
+         return finalizer_policy{}.apply_diff(*fin_policy_diff);
       }
 
       Tester&                 t;

--- a/unittests/block_header_tests.cpp
+++ b/unittests/block_header_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_with_empty_values_test)
       header.header_extensions,
       instant_finality_extension::extension_id(),
       fc::raw::pack( instant_finality_extension{qc_claim_t{last_qc_block_num, is_last_strong_qc},
-                                                std::optional<finalizer_policy_diff>{}, std::shared_ptr<proposer_policy>{}} )
+                                                std::optional<finalizer_policy_diff>{}, std::optional<proposer_policy_diff>{}} )
    );
 
    std::optional<block_header_extension> ext = header.extract_header_extension(instant_finality_extension::extension_id());
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_with_empty_values_test)
    BOOST_REQUIRE_EQUAL( if_extension.qc_claim.block_num, last_qc_block_num );
    BOOST_REQUIRE_EQUAL( if_extension.qc_claim.is_strong_qc, is_last_strong_qc );
    BOOST_REQUIRE( !if_extension.new_finalizer_policy_diff );
-   BOOST_REQUIRE( !if_extension.new_proposer_policy );
+   BOOST_REQUIRE( !if_extension.new_proposer_policy_diff );
 }
 
 // test for instant_finality_extension uniqueness
@@ -46,19 +46,19 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_uniqueness_test)
       header.header_extensions,
       instant_finality_extension::extension_id(),
       fc::raw::pack( instant_finality_extension{qc_claim_t{0, false}, {std::nullopt},
-                                                std::shared_ptr<proposer_policy>{}} )
+                                                std::optional<proposer_policy_diff>{}} )
    );
 
    std::vector<finalizer_authority> finalizers { {"test description", 50, fc::crypto::blslib::bls_public_key{"PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q" }} };
    auto fin_policy = std::make_shared<finalizer_policy>();
    finalizer_policy_diff new_finalizer_policy_diff = fin_policy->create_diff(finalizer_policy{.generation = 1, .threshold = 100, .finalizers = finalizers});
 
-   proposer_policy_ptr new_proposer_policy = std::make_shared<proposer_policy>(1, block_timestamp_type{200}, producer_authority_schedule{} );
+   proposer_policy_diff new_proposer_policy_diff = proposer_policy_diff{.version = 1, .active_time = block_timestamp_type{200}, .producer_auth_diff = {}};
 
    emplace_extension(
       header.header_extensions,
       instant_finality_extension::extension_id(),
-      fc::raw::pack( instant_finality_extension{qc_claim_t{100, true}, new_finalizer_policy_diff, new_proposer_policy} )
+      fc::raw::pack( instant_finality_extension{qc_claim_t{100, true}, new_finalizer_policy_diff, new_proposer_policy_diff} )
    );
    
    BOOST_CHECK_THROW(header.validate_and_extract_header_extensions(), invalid_block_header_extension);
@@ -75,12 +75,12 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_with_values_test)
    auto fin_policy = std::make_shared<finalizer_policy>();
    finalizer_policy_diff new_finalizer_policy_diff = fin_policy->create_diff(finalizer_policy{.generation = 1, .threshold = 100, .finalizers = finalizers});
 
-   proposer_policy_ptr new_proposer_policy = std::make_shared<proposer_policy>(1, block_timestamp_type{200}, producer_authority_schedule{} );
+   proposer_policy_diff new_proposer_policy_diff = proposer_policy_diff{.version = 1, .active_time = block_timestamp_type{200}, .producer_auth_diff = {}};
 
    emplace_extension(
       header.header_extensions,
       instant_finality_extension::extension_id(),
-      fc::raw::pack( instant_finality_extension{qc_claim_t{last_qc_block_num, is_strong_qc}, new_finalizer_policy_diff, new_proposer_policy} )
+      fc::raw::pack( instant_finality_extension{qc_claim_t{last_qc_block_num, is_strong_qc}, new_finalizer_policy_diff, new_proposer_policy_diff} )
    );
 
    std::optional<block_header_extension> ext = header.extract_header_extension(instant_finality_extension::extension_id());
@@ -98,9 +98,8 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_with_values_test)
    BOOST_REQUIRE_EQUAL(if_extension.new_finalizer_policy_diff->finalizers_diff.insert_indexes[0].second.weight, 50u);
    BOOST_REQUIRE_EQUAL(if_extension.new_finalizer_policy_diff->finalizers_diff.insert_indexes[0].second.public_key.to_string(), "PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q");
 
-   BOOST_REQUIRE( !!if_extension.new_proposer_policy );
-   BOOST_REQUIRE_EQUAL(if_extension.new_proposer_policy->schema_version, 1u);
-   fc::time_point t = (fc::time_point)(if_extension.new_proposer_policy->active_time);
+   BOOST_REQUIRE( !!if_extension.new_proposer_policy_diff );
+   fc::time_point t = (fc::time_point)(if_extension.new_proposer_policy_diff->active_time);
    BOOST_REQUIRE_EQUAL(t.time_since_epoch().to_seconds(), 946684900ll);
 }
 

--- a/unittests/svnn_ibc_tests.cpp
+++ b/unittests/svnn_ibc_tests.cpp
@@ -103,8 +103,8 @@ BOOST_AUTO_TEST_SUITE(svnn_ibc)
       BOOST_CHECK(maybe_active_finalizer_policy_diff.has_value());
 
       eosio::chain::finalizer_policy_diff active_finalizer_policy_diff = maybe_active_finalizer_policy_diff.value();
-      eosio::chain::finalizer_policy active_finalizer_policy;
-      active_finalizer_policy.apply_diff(active_finalizer_policy_diff);
+      eosio::chain::finalizer_policy active_finalizer_policy =
+         eosio::chain::finalizer_policy{}.apply_diff(active_finalizer_policy_diff);
 
       BOOST_CHECK_EQUAL(active_finalizer_policy.generation, 1u);
 


### PR DESCRIPTION
Instead of placing the entire producer (proposer) schedule in the `instant_finality_extension`, only put a diff of the proposer schedule in the extension.

Along with #118 Resolves #5