### PR TITLE
Increase max proposers to match max finalizers

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5283,6 +5283,8 @@ int64_t controller_impl::set_proposed_producers( vector<producer_authority> prod
    if (producers.empty())
       return -1; // INSTANT_FINALITY depends on DISALLOW_EMPTY_PRODUCER_SCHEDULE
 
+   EOS_ASSERT(producers.size() <= config::max_proposers, wasm_execution_error,
+              "Producer schedule exceeds the maximum proposer count for this chain");
    assert(pending);
 
    producer_authority_schedule sch;
@@ -5301,6 +5303,8 @@ int64_t controller_impl::set_proposed_producers( vector<producer_authority> prod
 }
 
 int64_t controller_impl::set_proposed_producers_legacy( vector<producer_authority> producers ) {
+   EOS_ASSERT(producers.size() <= config::max_producers, wasm_execution_error,
+              "Producer schedule exceeds the maximum producer count for this chain");
    const auto& gpo = db.get<global_property_object>();
    auto cur_block_num = chain_head.block_num() + 1;
 

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -127,7 +127,7 @@ const static uint32_t   default_abi_serializer_max_time_us = 15*1000; ///< defau
  */
 const static int producer_repetitions = 12;
 const static int max_producers = 125; // pre-savanna producer (proposer) limit
-const static int max_proposers = 64*1024; // savanna max proposer (producer) limit
+const static int max_proposers = 64*1024; // savanna proposer (producer) limit
 
 const static size_t maximum_tracked_dpos_confirmations = 1024;     ///<
 static_assert(maximum_tracked_dpos_confirmations >= ((max_producers * 2 / 3) + 1) * producer_repetitions, "Settings never allow for DPOS irreversibility" );

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -126,7 +126,8 @@ const static uint32_t   default_abi_serializer_max_time_us = 15*1000; ///< defau
  *  The number of sequential blocks produced by a single producer
  */
 const static int producer_repetitions = 12;
-const static int max_producers = 125;
+const static int max_producers = 125; // pre-savanna producer (proposer) limit
+const static int max_proposers = 64*1024; // savanna max proposer (producer) limit
 
 const static size_t maximum_tracked_dpos_confirmations = 1024;     ///<
 static_assert(maximum_tracked_dpos_confirmations >= ((max_producers * 2 / 3) + 1) * producer_repetitions, "Settings never allow for DPOS irreversibility" );

--- a/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
@@ -5,8 +5,8 @@
 
 namespace eosio::chain {
 
-static_assert(std::numeric_limits<uint8_t>::max() >= config::max_producers - 1);
-using producer_auth_differ = fc::ordered_diff<producer_authority, uint8_t>;
+static_assert(std::numeric_limits<uint16_t>::max() >= config::max_proposers - 1);
+using producer_auth_differ = fc::ordered_diff<producer_authority, uint16_t>;
 using producer_auth_diff_t = producer_auth_differ::diff_result;
 
 struct proposer_policy_diff {

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -44,7 +44,6 @@ namespace eosio { namespace chain { namespace webassembly {
    }
 
    int64_t set_proposed_producers_common( apply_context& context, vector<producer_authority> && producers, bool validate_keys ) {
-      EOS_ASSERT(producers.size() <= config::max_producers, wasm_execution_error, "Producer schedule exceeds the maximum producer count for this chain");
       EOS_ASSERT( producers.size() > 0
                   || !context.control.is_builtin_activated( builtin_protocol_feature_t::disallow_empty_producer_schedule ),
                   wasm_execution_error,


### PR DESCRIPTION
Increase the maximum number of proposer (producers) in Savanna from 125 to 64K. This matches the maximum number of allowed finalizers.