### PR TITLE
Fix a different signedness warning in ordered_diff_moveable_test

### DIFF
--- a/libraries/libfc/test/test_ordered_diff.cpp
+++ b/libraries/libfc/test/test_ordered_diff.cpp
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(ordered_diff_moveable_test) try {
       auto result = ordered_diff<count_moves>::diff(source, target);
       source = ordered_diff<count_moves>::apply_diff(std::move(source), std::move(result));
       BOOST_TEST(source == target);
-      BOOST_TEST(count_moves::num_moves == 1);
+      BOOST_TEST(count_moves::num_moves == 1u);
    }
 
 } FC_LOG_AND_RETHROW();


### PR DESCRIPTION
Fix
```
libraries/libfc/test/test_ordered_diff.cpp:195:7:   required from here
libraries/boost/libs/test/include/boost/test/tools/assertion.hpp:72:13: warning: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Wsign-compare] 
```