### PR TITLE
Create IF versions of applicable unittests

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -66,8 +66,9 @@ namespace eosio::testing {
       preactivate_feature_only,
       preactivate_feature_and_new_bios,
       old_wasm_parser,
-      full_except_do_not_disable_deferred_trx,
-      full
+      full_pre_savanna_except_do_not_disable_deferred_trx,
+      full_pre_savanna,
+      full                    // savanna consensus activated
    };
 
    std::ostream& operator<<(std::ostream& os, setup_policy p);
@@ -538,7 +539,8 @@ namespace eosio::testing {
 
    class tester : public base_tester {
    public:
-      tester(setup_policy policy = setup_policy::full, db_read_mode read_mode = db_read_mode::HEAD, std::optional<uint32_t> genesis_max_inline_action_size = std::optional<uint32_t>{}) {
+      tester(setup_policy policy = setup_policy::full, db_read_mode read_mode = db_read_mode::HEAD,
+             std::optional<uint32_t> genesis_max_inline_action_size = std::optional<uint32_t>{}) {
          init(policy, read_mode, genesis_max_inline_action_size);
       }
 
@@ -608,7 +610,7 @@ namespace eosio::testing {
 
    class tester_no_disable_deferred_trx : public tester {
    public:
-      tester_no_disable_deferred_trx(): tester(setup_policy::full_except_do_not_disable_deferred_trx) {
+      tester_no_disable_deferred_trx(): tester(setup_policy::full_pre_savanna_except_do_not_disable_deferred_trx) {
       }
    };
 
@@ -741,7 +743,7 @@ namespace eosio::testing {
 
    class validating_tester_no_disable_deferred_trx : public validating_tester {
    public:
-      validating_tester_no_disable_deferred_trx(): validating_tester({}, nullptr, setup_policy::full_except_do_not_disable_deferred_trx) {
+      validating_tester_no_disable_deferred_trx(): validating_tester({}, nullptr, setup_policy::full_pre_savanna_except_do_not_disable_deferred_trx) {
       }
    };
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -294,6 +294,13 @@ namespace eosio::testing {
             if (policy == setup_policy::full) {
                // Activate Savanna consensus
                // --------------------------
+               constexpr size_t num_keys    = 4u;
+               constexpr size_t finset_size = 4u;
+               constexpr size_t first_key_idx = 0u;
+               finalizer_keys fin_keys(*this, num_keys, finset_size); // Create finalizer keys
+               fin_keys.set_node_finalizers(first_key_idx, num_keys); // set finalizers on current node
+               fin_keys.set_finalizer_policy(first_key_idx); // set active finalizer policy
+               fin_keys.transition_to_savanna();
             }
             break;
          }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -234,22 +234,26 @@ namespace eosio::testing {
       };
 
       switch (policy) {
-         case setup_policy::old_bios_only: {
+         case setup_policy::old_bios_only:
+         {
             set_before_preactivate_bios_contract();
             break;
          }
-         case setup_policy::preactivate_feature_only: {
+         case setup_policy::preactivate_feature_only:
+         {
             schedule_preactivate_protocol_feature();
             produce_block(); // block production is required to activate protocol feature
             break;
          }
-         case setup_policy::preactivate_feature_and_new_bios: {
+         case setup_policy::preactivate_feature_and_new_bios:
+         {
             schedule_preactivate_protocol_feature();
             produce_block();
             set_before_producer_authority_bios_contract();
             break;
          }
-         case setup_policy::old_wasm_parser: {
+         case setup_policy::old_wasm_parser:
+         {
             schedule_preactivate_protocol_feature();
             produce_block();
             set_before_producer_authority_bios_contract();
@@ -273,18 +277,24 @@ namespace eosio::testing {
             set_bios_contract();
             break;
          }
+         case setup_policy::full_pre_savanna_except_do_not_disable_deferred_trx:
+         case setup_policy::full_pre_savanna:
          case setup_policy::full:
-         case setup_policy::full_except_do_not_disable_deferred_trx: {
+         {
             schedule_preactivate_protocol_feature();
             produce_block();
             set_before_producer_authority_bios_contract();
-            if( policy == setup_policy::full ) {
-               preactivate_all_builtin_protocol_features();
-            } else {
+            if( policy == setup_policy::full_pre_savanna_except_do_not_disable_deferred_trx) {
                preactivate_all_but_disable_deferred_trx();
+            } else {
+               preactivate_all_builtin_protocol_features();
             }
             produce_block();
             set_bios_contract();
+            if (policy == setup_policy::full) {
+               // Activate Savanna consensus
+               // --------------------------
+            }
             break;
          }
          case setup_policy::none:

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -841,7 +841,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, validating_tester_no_disable_defer
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
-   tester chain(setup_policy::full);
+   tester chain(setup_policy::full_pre_savanna);
 
    std::vector<signed_block_ptr> blocks;
    blocks.push_back(chain.produce_block());
@@ -979,7 +979,7 @@ void call_test(Tester& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cp
 }
 
 BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
-   validating_tester t;
+   validating_tester t{ {}, nullptr, setup_policy::full_pre_savanna };
    t.produce_blocks(2);
 
    ilog( "create account" );
@@ -1580,7 +1580,7 @@ BOOST_AUTO_TEST_CASE(transaction_tests_before_disable_trxs_protocol_features) { 
  * transaction tests after before disable_trxs_protocol_features are activated
  *************************************************************************************/
 BOOST_AUTO_TEST_CASE(transaction_tests_after_disable_trxs_protocol_features) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    transaction_tests<validating_tester>(chain);
 } FC_LOG_AND_RETHROW() }
 
@@ -1590,7 +1590,7 @@ BOOST_AUTO_TEST_CASE(transaction_tests_after_disable_trxs_protocol_features) { t
 BOOST_AUTO_TEST_CASE(inline_action_with_over_4k_limit) { try {
    const uint32_t _4k = 4 * 1024;
    tester chain(setup_policy::full, db_read_mode::HEAD, {_4k + 100});
-   tester chain2(setup_policy::full, db_read_mode::HEAD, {_4k + 100});
+   tester chain2(setup_policy::full_pre_savanna, db_read_mode::HEAD, {_4k + 100});
    signed_block_ptr block;
    for (int n=0; n < 2; ++n) {
       block = chain.produce_block();
@@ -1617,7 +1617,7 @@ BOOST_AUTO_TEST_CASE(inline_action_with_over_4k_limit) { try {
  *************************************************************************************/
 BOOST_AUTO_TEST_CASE(inline_action_objective_limit) { try {
    const uint32_t _4k = 4 * 1024;
-   tester chain(setup_policy::full, db_read_mode::HEAD, {_4k});
+   tester chain(setup_policy::full_pre_savanna, db_read_mode::HEAD, {_4k});
    chain.produce_blocks(2);
    chain.create_account( "testapi"_n );
    chain.produce_blocks(100);
@@ -1639,8 +1639,8 @@ BOOST_AUTO_TEST_CASE(inline_action_objective_limit) { try {
 
 BOOST_AUTO_TEST_CASE(deferred_inline_action_limit) { try {
    const uint32_t _4k = 4 * 1024;
-   tester chain(setup_policy::full_except_do_not_disable_deferred_trx, db_read_mode::HEAD, {_4k + 100});
-   tester chain2(setup_policy::full_except_do_not_disable_deferred_trx, db_read_mode::HEAD, {_4k + 100});
+   tester chain(setup_policy::full_pre_savanna_except_do_not_disable_deferred_trx, db_read_mode::HEAD, {_4k + 100});
+   tester chain2(setup_policy::full_pre_savanna_except_do_not_disable_deferred_trx, db_read_mode::HEAD, {_4k + 100});
    signed_block_ptr block;
    for (int n=0; n < 2; ++n) {
       block = chain.produce_block();
@@ -3714,7 +3714,7 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, validating_tester) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(action_results_tests) { try {
-   validating_tester t;
+   validating_tester t{ {}, nullptr, setup_policy::full_pre_savanna };
    t.produce_blocks(2);
    t.create_account( "test"_n );
    t.set_code( "test"_n, test_contracts::action_results_wasm() );
@@ -3823,7 +3823,7 @@ static const char get_code_hash_wast[] = R"=====(
 )=====";
 
 BOOST_AUTO_TEST_CASE(get_code_hash_tests) { try {
-   validating_tester t;
+   validating_tester t{ {}, nullptr, setup_policy::full_pre_savanna };
    t.produce_blocks(2);
    t.create_account("gethash"_n);
    t.create_account("test"_n);
@@ -3861,7 +3861,7 @@ BOOST_AUTO_TEST_CASE(get_code_hash_tests) { try {
 
 // test set_finalizer host function serialization and tester set_finalizers
 BOOST_AUTO_TEST_CASE(initial_set_finalizer_test) { try {
-   validating_tester t;
+   validating_tester t{ {}, nullptr, setup_policy::full_pre_savanna };
 
    // Create finalizer keys
    constexpr size_t num_finalizers = 21;
@@ -3911,7 +3911,7 @@ BOOST_AUTO_TEST_CASE(initial_set_finalizer_test) { try {
 void test_finality_transition(const vector<account_name>& accounts,
                               const base_tester::finalizer_policy_input& input,
                               bool lib_advancing_expected) {
-   validating_tester t;
+   validating_tester t{ {}, nullptr, setup_policy::full_pre_savanna };
 
    t.produce_block();
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -841,7 +841,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, validating_tester_no_disable_defer
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
-   tester chain(setup_policy::full_pre_savanna);
+   tester chain;
 
    std::vector<signed_block_ptr> blocks;
    blocks.push_back(chain.produce_block());
@@ -1590,7 +1590,7 @@ BOOST_AUTO_TEST_CASE(transaction_tests_after_disable_trxs_protocol_features) { t
 BOOST_AUTO_TEST_CASE(inline_action_with_over_4k_limit) { try {
    const uint32_t _4k = 4 * 1024;
    tester chain(setup_policy::full, db_read_mode::HEAD, {_4k + 100});
-   tester chain2(setup_policy::full_pre_savanna, db_read_mode::HEAD, {_4k + 100});
+   tester chain2(setup_policy::full, db_read_mode::HEAD, {_4k + 100});
    signed_block_ptr block;
    for (int n=0; n < 2; ++n) {
       block = chain.produce_block();

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -91,7 +91,7 @@ BOOST_FIXTURE_TEST_CASE( delegate_auth, validating_tester ) { try {
 
 BOOST_AUTO_TEST_CASE(update_auths) {
 try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    chain.create_account(name("alice"));
    chain.create_account(name("bob"));
 
@@ -225,7 +225,7 @@ try {
 
 BOOST_AUTO_TEST_CASE(update_auth_unknown_private_key) {
    try {
-      validating_tester chain;
+      validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
       chain.create_account(name("alice"));
 
       // public key with no corresponding private key
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(update_auth_unknown_private_key) {
 }
 
 BOOST_AUTO_TEST_CASE(link_auths) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    chain.create_accounts({name("alice"),name("bob")});
 
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(link_auths) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    chain.create_account(name("alice"));
 
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
 
 BOOST_AUTO_TEST_CASE(create_account) {
 try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    chain.create_account(name("joe"));
    chain.produce_block();
 
@@ -367,7 +367,7 @@ try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( any_auth ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    chain.create_accounts( {name("alice"), name("bob")} );
    chain.produce_block();
 
@@ -463,7 +463,7 @@ try {
 
 BOOST_AUTO_TEST_CASE(stricter_auth) {
 try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    chain.produce_block();
 
@@ -512,7 +512,7 @@ try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( linkauth_special ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    const auto& tester_account = "tester"_n;
    std::vector<transaction_id_type> ids;
@@ -553,7 +553,7 @@ BOOST_AUTO_TEST_CASE( linkauth_special ) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE(delete_auth) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    const auto& tester_account = "tester"_n;
 

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -9,7 +9,7 @@ BOOST_AUTO_TEST_SUITE(block_tests)
 
 BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
 {
-   tester main;
+   tester main(setup_policy::full_pre_savanna);
 
    // First we create a valid block with valid transaction
    main.create_account("newacc"_n);
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
    copy_b->producer_signature = main.get_private_key(config::system_account_name, "active").sign(sig_digest);
 
    // Push block with invalid transaction to other chain
-   tester validator;
+   tester validator(setup_policy::full_pre_savanna);
    auto btf = validator.control->create_block_handle_future( copy_b->calculate_id(), copy_b );
    validator.control->abort_block();
    controller::block_report br;
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
 
 BOOST_AUTO_TEST_CASE(block_with_invalid_tx_mroot_test)
 {
-   tester main;
+   tester main(setup_policy::full_pre_savanna);
 
    // First we create a valid block with valid transaction
    main.create_account("newacc"_n);
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_mroot_test)
    copy_b->producer_signature = main.get_private_key(config::system_account_name, "active").sign(sig_digest);
 
    // Push block with invalid transaction to other chain
-   tester validator;
+   tester validator(setup_policy::full_pre_savanna);
    auto btf = validator.control->create_block_handle_future( copy_b->calculate_id(), copy_b );
    validator.control->abort_block();
    controller::block_report br;
@@ -128,7 +128,7 @@ std::pair<signed_block_ptr, signed_block_ptr> corrupt_trx_in_block(validating_te
 BOOST_AUTO_TEST_CASE(trusted_producer_test)
 {
    flat_set<account_name> trusted_producers = { "defproducera"_n, "defproducerc"_n };
-   validating_tester main(trusted_producers);
+   validating_tester main(trusted_producers, nullptr, setup_policy::full_pre_savanna);
    // only using validating_tester to keep the 2 chains in sync, not to validate that the validating_node matches the main node,
    // since it won't be
    main.skip_validate = true;
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(trusted_producer_test)
 BOOST_AUTO_TEST_CASE(trusted_producer_verify_2nd_test)
 {
    flat_set<account_name> trusted_producers = { "defproducera"_n, "defproducerc"_n };
-   validating_tester main(trusted_producers);
+   validating_tester main(trusted_producers, nullptr, setup_policy::full_pre_savanna);
    // only using validating_tester to keep the 2 chains in sync, not to validate that the validating_node matches the main node,
    // since it won't be
    main.skip_validate = true;
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(trusted_producer_verify_2nd_test)
 BOOST_AUTO_TEST_CASE(untrusted_producer_test)
 {
    flat_set<account_name> trusted_producers = { "defproducera"_n, "defproducerc"_n };
-   validating_tester main(trusted_producers);
+   validating_tester main(trusted_producers, nullptr, setup_policy::full_pre_savanna);
    // only using validating_tester to keep the 2 chains in sync, not to validate that the validating_node matches the main node,
    // since it won't be
    main.skip_validate = true;
@@ -211,8 +211,8 @@ BOOST_AUTO_TEST_CASE(untrusted_producer_test)
 BOOST_AUTO_TEST_CASE(broadcasted_block_test)
 {
 
-  tester producer_node;
-  tester receiving_node;
+  tester producer_node(setup_policy::full_pre_savanna);
+  tester receiving_node(setup_policy::full_pre_savanna);
 
   signed_block_ptr bcasted_blk_by_prod_node;
   signed_block_ptr bcasted_blk_by_recv_node;

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -57,6 +57,8 @@ std::vector<genesis_account> test_genesis( {
 
 class bootseq_tester : public validating_tester {
 public:
+   bootseq_tester() : validating_tester({}, nullptr, setup_policy::full_pre_savanna) {};
+
    void deploy_contract( bool call_init = true ) {
       set_code( config::system_account_name, test_contracts::eosio_system_wasm() );
       set_abi( config::system_account_name, test_contracts::eosio_system_abi() );

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -16,7 +16,7 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_SUITE(chain_tests)
 
 BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
-   validating_tester tester;
+   validating_tester tester{ {}, nullptr, setup_policy::full_pre_savanna };
 
    const auto new_key = get_public_key(name("newkey"), config::active_name.to_string());
 
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( replace_account_keys ) try {
-   validating_tester tester;
+   validating_tester tester{ {}, nullptr, setup_policy::full_pre_savanna };
    const name usr = config::system_account_name;
    const name active_permission = config::active_name;
    const auto& rlm = tester.control->get_resource_limits_manager();
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE( replace_account_keys ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( decompressed_size_over_limit ) try {
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
 
    // build a transaction, add cf data, sign
    cf_action                        cfa;
@@ -151,8 +151,8 @@ BOOST_AUTO_TEST_CASE( decompressed_size_under_limit ) try {
 
 // verify accepted_block signals validated blocks
 BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
-   tester chain;
-   tester validator;
+   tester chain(setup_policy::full_pre_savanna);
+   tester validator(setup_policy::full_pre_savanna);
 
    signed_block_ptr accepted_block;
    block_id_type accepted_id;

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -63,7 +63,7 @@ class currency_tester : public validating_tester {
          return trace;
       }
 
-      currency_tester(setup_policy p = setup_policy::full)
+      currency_tester(setup_policy p = setup_policy::full_pre_savanna)
          :validating_tester({}, nullptr, p), abi_ser(json::from_string(test_contracts::eosio_token_abi()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ))
       {
          create_account( "eosio.token"_n);
@@ -93,7 +93,7 @@ class currency_tester : public validating_tester {
 
 class pre_disable_deferred_trx_currency_tester : public currency_tester {
    public:
-      pre_disable_deferred_trx_currency_tester() : currency_tester(setup_policy::full_except_do_not_disable_deferred_trx) {}
+      pre_disable_deferred_trx_currency_tester() : currency_tester(setup_policy::full_pre_savanna_except_do_not_disable_deferred_trx) {}
 };
 
 const name currency_tester::eosio_token = "eosio.token"_n;

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
    // Simple tests of undo infrastructure
    BOOST_AUTO_TEST_CASE(undo_test) {
       try {
-         validating_tester test;
+         validating_tester test{ {}, nullptr, setup_policy::full_pre_savanna };
 
          // Bypass read-only restriction on state DB access for this unit test which really needs to mutate the DB to properly conduct its test.
          eosio::chain::database& db = const_cast<eosio::chain::database&>( test.control->db() );
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
    // Test the block fetching methods on database, fetch_bock_by_id, and fetch_block_by_number
    BOOST_AUTO_TEST_CASE(get_blocks) {
       try {
-         validating_tester test;
+         validating_tester test{ {}, nullptr, setup_policy::full_pre_savanna };
          vector<block_id_type> block_ids;
 
          const uint32_t num_of_blocks_to_prod = 200;

--- a/unittests/deep_mind_tests.cpp
+++ b/unittests/deep_mind_tests.cpp
@@ -49,7 +49,7 @@ struct deep_mind_log_fixture
 
 struct deep_mind_tester : deep_mind_log_fixture, validating_tester
 {
-   deep_mind_tester() : validating_tester({}, &deep_mind_logger, setup_policy::full) {}
+   deep_mind_tester() : validating_tester({}, &deep_mind_logger, setup_policy::full_pre_savanna) {}
 };
 
 namespace {

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -212,7 +212,7 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester_no_disabl
 
 // test link to permission with delay directly on it
 BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    const auto& tester_account = "tester"_n;
 
    create_accounts(chain);
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 
 // test link to permission with delay on permission which is parent of min permission (special logic in permission_object::satisfies)
 BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    const auto& tester_account = "tester"_n;
 
@@ -441,7 +441,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 
 // test link to permission with delay on permission between min permission and authorizing permission it
 BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    const auto& tester_account = "tester"_n;
 
    create_accounts(chain);
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 
 // test removing delay on permission
 BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    const auto& tester_account = "tester"_n;
 
@@ -713,7 +713,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
 // test removing delay on permission based on heirarchy delay
 BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    const auto& tester_account = "tester"_n;
 
@@ -875,7 +875,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
 // test moving link with delay on permission
 BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    const auto& tester_account = "tester"_n;
 
@@ -1040,7 +1040,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
 // test link with unlink
 BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    const auto& tester_account = "tester"_n;
 
    create_accounts(chain);
@@ -1199,7 +1199,7 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
 // test moving link with delay on permission's parent
 BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    const auto& tester_account = "tester"_n;
 
    create_accounts(chain);
@@ -1860,7 +1860,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
 BOOST_AUTO_TEST_CASE( max_transaction_delay_create ) { try {
    //assuming max transaction delay is 45 days (default in config.hpp)
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
 
    const auto& tester_account = "tester"_n;
 
@@ -1882,7 +1882,7 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_create ) { try {
 
 BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
    //assuming max transaction delay is 45 days (default in config.hpp)
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    const auto& tester_account = "tester"_n;
 
    create_accounts(chain);

--- a/unittests/eosvmoc_limits_tests.cpp
+++ b/unittests/eosvmoc_limits_tests.cpp
@@ -82,7 +82,7 @@ static eosvmoc::config make_eosvmoc_config_without_limits() {
 
 // test all limits are not set for tests
 BOOST_AUTO_TEST_CASE( limits_not_set ) { try {
-   validating_tester chain;
+   validating_tester chain{ {}, nullptr, setup_policy::full_pre_savanna };
    auto& cfg = chain.get_config();
 
    BOOST_REQUIRE(cfg.eosvmoc_config.cpu_limit == std::nullopt);

--- a/unittests/finality_test_cluster.hpp
+++ b/unittests/finality_test_cluster.hpp
@@ -28,7 +28,8 @@ struct finality_node_t : public eosio::testing::tester {
    eosio::testing::finalizer_keys<tester>  finkeys;
    size_t                                  cur_key{0}; // index of key used in current policy
 
-   finality_node_t() : finkeys(*this) {}
+   finality_node_t() : eosio::testing::tester(eosio::testing::setup_policy::full_pre_savanna),
+                       finkeys(*this) {}
 
    size_t last_vote_index() const {
       assert(!votes.empty());

--- a/unittests/finalizer_update_tests.cpp
+++ b/unittests/finalizer_update_tests.cpp
@@ -31,7 +31,7 @@ static void ensure_next_block_finalizer_policy(validating_tester& t,
 // to take effect.
 // ---------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(savanna_set_finalizer_single_test) { try {
-   validating_tester t;
+   validating_tester t{ {}, nullptr, setup_policy::full_pre_savanna };
    size_t num_keys    = 22;
    size_t finset_size = 21;
 
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(savanna_set_finalizer_single_test) { try {
 // at the same time.
 // ---------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(savanna_set_finalizer_multiple_test) { try {
-   validating_tester t;
+   validating_tester t{ {}, nullptr, setup_policy::full_pre_savanna };
    size_t num_keys    = 50;
    size_t finset_size = 21;
 

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -18,7 +18,7 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_SUITE(forked_tests)
 
 BOOST_AUTO_TEST_CASE( irrblock ) try {
-   tester c;
+   tester c(setup_policy::full_pre_savanna);
    c.produce_blocks(10);
    auto r = c.create_accounts( {"dan"_n,"sam"_n,"pam"_n,"scott"_n} );
    auto res = c.set_producers( {"dan"_n,"sam"_n,"pam"_n,"scott"_n} );
@@ -34,7 +34,7 @@ struct fork_tracker {
 };
 
 BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
-   tester bios;
+   tester bios(setup_policy::full_pre_savanna);
    bios.produce_block();
    bios.produce_block();
    bios.create_accounts( {"a"_n,"b"_n,"c"_n,"d"_n,"e"_n} );
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE( forking ) try {
-   tester c;
+   tester c(setup_policy::full_pre_savanna);
    while (c.control->head_block_num() < 3) {
       c.produce_block();
    }
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE( forking ) try {
  *  the highest last irreversible block over one that is longer.
  */
 BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
-   tester c;
+   tester c(setup_policy::full_pre_savanna);
    while (c.control->head_block_num() < 11) {
       c.produce_block();
    }
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( read_modes ) try {
-   tester c;
+   tester c(setup_policy::full_pre_savanna);
    c.produce_block();
    c.produce_block();
    auto r = c.create_accounts( {"dan"_n,"sam"_n,"pam"_n} );
@@ -408,7 +408,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
       return (db.find<account_object, by_name>( n ) != nullptr);
    };
 
-   tester main;
+   tester main(setup_policy::full_pre_savanna);
 
    main.create_accounts( {"producer1"_n, "producer2"_n} );
    main.produce_block();
@@ -514,7 +514,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( reopen_forkdb ) try {
-   tester c1;
+   tester c1(setup_policy::full_pre_savanna);
 
    c1.create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
    c1.produce_block();
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE( reopen_forkdb ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
-   tester c;
+   tester c(setup_policy::full_pre_savanna);
    while (c.control->head_block_num() < 3) {
       c.produce_block();
    }

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -395,7 +395,7 @@ struct permission_visitor {
 
 BOOST_AUTO_TEST_CASE(authority_checker)
 { try {
-   testing::validating_tester test;
+   testing::validating_tester test{ {}, nullptr, setup_policy::full_pre_savanna };
    auto a = test.get_public_key(name("a"), "active");
    auto b = test.get_public_key(name("b"), "active");
    auto c = test.get_public_key(name("c"), "active");
@@ -718,7 +718,7 @@ BOOST_AUTO_TEST_CASE(alphabetic_sort)
 
 BOOST_AUTO_TEST_CASE(transaction_test) { try {
 
-   testing::validating_tester test;
+   testing::validating_tester test{ {}, nullptr, setup_policy::full_pre_savanna };
    signed_transaction trx;
 
    fc::variant pretty_trx = fc::mutable_variant_object()
@@ -883,7 +883,7 @@ BOOST_AUTO_TEST_CASE(signed_int_test) { try {
 
 BOOST_AUTO_TEST_CASE(transaction_metadata_test) { try {
 
-   testing::validating_tester test;
+   testing::validating_tester test{ {}, nullptr, setup_policy::full_pre_savanna };
    signed_transaction trx;
 
    fc::variant pretty_trx = fc::mutable_variant_object()
@@ -1220,7 +1220,7 @@ BOOST_AUTO_TEST_CASE(stable_priority_queue_test) {
 #endif
 #ifndef __SANITIZE_ADDRESS__
 BOOST_AUTO_TEST_CASE(bad_alloc_test) {
-   tester t; // force a controller to be constructed and set the new_handler
+   tester t(setup_policy::full_pre_savanna); // force a controller to be constructed and set the new_handler
    int* ptr = nullptr;
    const auto fail = [&]() {
       ptr = new int[std::numeric_limits<int64_t>::max()/16];

--- a/unittests/params_tests.cpp
+++ b/unittests/params_tests.cpp
@@ -14,7 +14,7 @@ using mvo = mutable_variant_object;
  */
 class params_tester : public tester {
 public:
-   params_tester() : tester(){}
+   params_tester() : tester(setup_policy::full_pre_savanna){}
    params_tester(setup_policy policy) : tester(policy){}
 
    void setup(){

--- a/unittests/partitioned_block_log_tests.cpp
+++ b/unittests/partitioned_block_log_tests.cpp
@@ -32,11 +32,13 @@ std::filesystem::path get_retained_dir(const eosio::chain::controller::config& c
    return retained_dir;
 }
 
+using namespace eosio::testing;
+
 struct restart_from_block_log_test_fixture {
    eosio::testing::tester chain;
    uint32_t               cutoff_block_num;
 
-   restart_from_block_log_test_fixture() {
+   restart_from_block_log_test_fixture() : chain(setup_policy::full_pre_savanna) {
       using namespace eosio::chain;
       chain.create_account("replay1"_n);
       chain.produce_blocks(1);
@@ -179,7 +181,7 @@ BOOST_AUTO_TEST_CASE(test_split_log_all_in_retained_new_default) {
 BOOST_AUTO_TEST_CASE(test_split_log_util1) {
    fc::temp_directory temp_dir;
 
-   eosio::testing::tester chain;
+   eosio::testing::tester chain(setup_policy::full_pre_savanna);
    chain.produce_blocks(160);
 
    uint32_t head_block_num = chain.control->head_block_num();
@@ -430,7 +432,7 @@ BOOST_AUTO_TEST_CASE(test_split_from_v1_log) {
 
 void trim_blocklog_front(uint32_t version) {
    blocklog_version_setter set_version(version);
-   eosio::testing::tester  chain;
+   eosio::testing::tester  chain(setup_policy::full_pre_savanna);
    chain.produce_blocks(10);
    chain.produce_blocks(20);
    chain.close();
@@ -464,7 +466,7 @@ BOOST_AUTO_TEST_CASE(test_trim_blocklog_front_v2) { trim_blocklog_front(2); }
 
 BOOST_AUTO_TEST_CASE(test_blocklog_split_then_merge) {
 
-   eosio::testing::tester chain;
+   eosio::testing::tester chain(setup_policy::full_pre_savanna);
    chain.produce_blocks(160);
    chain.close();
 

--- a/unittests/payloadless_tests.cpp
+++ b/unittests/payloadless_tests.cpp
@@ -19,7 +19,8 @@ using namespace eosio::testing;
 using namespace fc;
 
 class payloadless_tester : public validating_tester {
-
+public:
+   payloadless_tester() : validating_tester{ {}, nullptr, setup_policy::full_pre_savanna } {}
 };
 
 BOOST_AUTO_TEST_SUITE(payloadless_tests)

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
-   tester c;
+   tester c(setup_policy::full_pre_savanna);
 
    c.create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
    c.produce_block();
@@ -602,7 +602,7 @@ BOOST_AUTO_TEST_CASE( large_authority_overflow_test ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( extra_signatures_test ) try {
-   tester main;
+   tester main(setup_policy::full_pre_savanna);
 
    main.create_accounts( {"alice"_n} );
    main.produce_block();

--- a/unittests/read_only_trx_tests.cpp
+++ b/unittests/read_only_trx_tests.cpp
@@ -13,7 +13,7 @@ using namespace fc;
 using mvo = fc::mutable_variant_object;
 
 struct read_only_trx_tester : validating_tester {
-   read_only_trx_tester() {
+   read_only_trx_tester() : validating_tester{ {}, nullptr, setup_policy::full_pre_savanna } {
       produce_block();
    };
 

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -87,14 +87,14 @@ class replay_tester : public base_tester {
 BOOST_AUTO_TEST_SUITE(restart_chain_tests)
 
 BOOST_AUTO_TEST_CASE(test_existing_state_without_block_log) {
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
 
    std::vector<signed_block_ptr> blocks;
    blocks.push_back(chain.produce_block());
    blocks.push_back(chain.produce_block());
    blocks.push_back(chain.produce_block());
 
-   tester other;
+   tester other(setup_policy::full_pre_savanna);
    for (const auto& new_block : blocks) {
       other.push_block(new_block);
    }
@@ -117,14 +117,14 @@ BOOST_AUTO_TEST_CASE(test_existing_state_without_block_log) {
 }
 
 BOOST_AUTO_TEST_CASE(test_restart_with_different_chain_id) {
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
 
    std::vector<signed_block_ptr> blocks;
    blocks.push_back(chain.produce_block());
    blocks.push_back(chain.produce_block());
    blocks.push_back(chain.produce_block());
 
-   tester other;
+   tester other(setup_policy::full_pre_savanna);
    for (const auto& new_block : blocks) {
       other.push_block(new_block);
    }
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_restart_with_different_chain_id) {
 }
 
 BOOST_AUTO_TEST_CASE(test_restart_from_block_log) {
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
 
    chain.create_account("replay1"_n);
    chain.produce_blocks(1);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(test_restart_from_block_log) {
 }
 
 BOOST_AUTO_TEST_CASE(test_light_validation_restart_from_block_log) {
-   tester chain(setup_policy::full);
+   tester chain(setup_policy::full_pre_savanna);
 
    chain.create_account("testapi"_n);
    chain.create_account("dummy"_n);

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -188,7 +188,7 @@ namespace {
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_exhaustive_snapshot, SNAPSHOT_SUITE, snapshot_suites)
 {
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
 
    // Create 2 accounts
    chain.create_accounts({"snapshot"_n, "snapshot1"_n});
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_exhaustive_snapshot, SNAPSHOT_SUITE, snapshot
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_replay_over_snapshot, SNAPSHOT_SUITE, snapshot_suites)
 {
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
    const std::filesystem::path parent_path = chain.get_config().blocks_dir.parent_path();
 
    chain.create_account("snapshot"_n);
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_replay_over_snapshot, SNAPSHOT_SUITE, snapsho
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_chain_id_in_snapshot, SNAPSHOT_SUITE, snapshot_suites)
 {
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
    const std::filesystem::path parent_path = chain.get_config().blocks_dir.parent_path();
 
    chain.create_account("snapshot"_n);
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_pending_schedule_snapshot, SNAPSHOT_SUITE, sn
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_block_log, SNAPSHOT_SUITE, snapshot_suites)
 {
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
    const std::filesystem::path parent_path = chain.get_config().blocks_dir.parent_path();
 
    chain.create_account("snapshot"_n);
@@ -609,7 +609,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
 BOOST_AUTO_TEST_CASE(json_snapshot_validity_test)
 {
    auto ordinal = 0;
-   tester chain;
+   tester chain(setup_policy::full_pre_savanna);
 
    // prep the chain
    chain.create_account("snapshot"_n);

--- a/unittests/special_accounts_tests.cpp
+++ b/unittests/special_accounts_tests.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_SUITE(special_account_tests)
 BOOST_FIXTURE_TEST_CASE(accounts_exists, tester)
 { try {
 
-      tester test;
+      tester test(eosio::testing::setup_policy::full_pre_savanna);
       chain::controller *control = test.control.get();
       const chain::database& chain1_db = control->db();
 

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -72,6 +72,8 @@ public:
    using tester::tester;
    using deltas_vector = vector<eosio::state_history::table_delta>;
 
+   table_deltas_tester() : tester{ setup_policy::full_pre_savanna } {}
+
    pair<bool, deltas_vector::iterator> find_table_delta(const std::string &name, bool full_snapshot = false) {
       v = eosio::state_history::create_deltas(control->db(), full_snapshot);;
 
@@ -452,7 +454,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
 }
 
    BOOST_AUTO_TEST_CASE(test_deltas) {
-      tester main;
+      tester main(setup_policy::full_pre_savanna);
 
       auto v = eosio::state_history::create_deltas(main.control->db(), false);
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -655,7 +655,7 @@ BOOST_FIXTURE_TEST_CASE( check_global_reset, validating_tester ) try {
 //Make sure we can create a wasm with maximum pages, but not grow it any
 BOOST_DATA_TEST_CASE( big_memory, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
    validating_tester t(flat_set<account_name>{}, {}, policy);
-   if(policy != setup_policy::full)
+   if(policy != setup_policy::full && policy != setup_policy::full_pre_savanna)
       t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
    t.produce_blocks(2);


### PR DESCRIPTION
The issue mentions that transition to Savanna should be the default, so my idea was to have the setup_policy do the transition to Savanna by default.

```
enum class setup_policy {
      none,
      old_bios_only,
      preactivate_feature_only,
      preactivate_feature_and_new_bios,
      old_wasm_parser,
      full_pre_savanna_except_do_not_disable_deferred_trx,
      full_pre_savanna,
      full                    // savanna consensus activated
   };
```

I have started updating the tests so that where the setup_policy was not specified (so currently savanna is not activated), we stay the same by specifying `full_pre_savanna`.

But I didn't add the transition to Savanna yet:
https://github.com/AntelopeIO/spring/blob/5f0b736ff6e27dc09421ead1b5a063ab80d65a53/libraries/testing/tester.cpp#L294-L297