### PR TITLE
upgrade to libsecp256k1 v0.5.0; improves k1 signing performance ~10%

### DIFF
--- a/libraries/libfc/secp256k1/CMakeLists.txt
+++ b/libraries/libfc/secp256k1/CMakeLists.txt
@@ -10,7 +10,7 @@ target_compile_definitions(secp256k1-internal INTERFACE ENABLE_MODULE_RECOVERY=1
                                                         COMB_TEETH=6
                                                         ECMULT_WINDOW_SIZE=15
                                                         SECP256K1_STATIC=1)
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
   target_compile_definitions(secp256k1-internal INTERFACE USE_ASM_X86_64=1)
 endif()
 

--- a/libraries/libfc/secp256k1/CMakeLists.txt
+++ b/libraries/libfc/secp256k1/CMakeLists.txt
@@ -5,7 +5,9 @@ add_library(secp256k1-internal INTERFACE)
 target_include_directories(secp256k1-internal INTERFACE secp256k1/src)
 
 target_compile_definitions(secp256k1-internal INTERFACE ENABLE_MODULE_RECOVERY=1
-                                                        ECMULT_GEN_PREC_BITS=4
+                                                        ENABLE_MODULE_EXTRAKEYS=1
+                                                        COMB_BLOCKS=11
+                                                        COMB_TEETH=6
                                                         ECMULT_WINDOW_SIZE=15
                                                         SECP256K1_STATIC=1)
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)


### PR DESCRIPTION
Time for another awesome libsecp256k1 update. v0.5.0 improves signing performance by about ~10% in my tests. The improvement is via `https://github.com/bitcoin-core/secp256k1/pull/1058`