### PR TITLE
Add support to run unit tests in both Legacy and Savanna (Part 1)

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -618,6 +618,14 @@ namespace eosio::testing {
 
    };
 
+   class savanna_tester : public tester {
+   public:
+      savanna_tester();
+   };
+
+   using legacy_tester = tester;
+   using testers = boost::mpl::list<legacy_tester, savanna_tester>;
+
    class tester_no_disable_deferred_trx : public tester {
    public:
       tester_no_disable_deferred_trx(): tester(setup_policy::full_except_do_not_disable_deferred_trx) {
@@ -757,6 +765,14 @@ namespace eosio::testing {
       }
    };
 
+   class savanna_validating_tester : public validating_tester {
+   public:
+      savanna_validating_tester();
+   };
+
+   using legacy_validating_tester = validating_tester;
+   using validating_testers = boost::mpl::list<legacy_validating_tester, savanna_validating_tester>;
+
    // -------------------------------------------------------------------------------------
    // creates and manages a set of `bls_public_key` used for finalizers voting and policies
    // Supports initial transition to Savanna.
@@ -863,6 +879,12 @@ namespace eosio::testing {
 
          BOOST_REQUIRE_EQUAL(t.lib_block->block_num(), pt_block->block_num());
          return finalizer_policy{}.apply_diff(*fin_policy_diff);
+      }
+
+      void activate_savanna(size_t first_key_idx) {
+         set_node_finalizers(first_key_idx, pubkeys.size());
+         set_finalizer_policy(first_key_idx);
+         transition_to_savanna();
       }
 
       Tester&                 t;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1396,6 +1396,12 @@ namespace eosio::testing {
       execute_setup_policy(policy);
    }
 
+   savanna_tester::savanna_tester() {
+      // Activate Savanna consensus
+      finalizer_keys fin_keys(*this, 4u /* num_keys */, 4u /* finset_size */);
+      fin_keys.activate_savanna(0u /* first_key_idx */);
+   }
+
    unique_ptr<controller> validating_tester::create_validating_node(controller::config vcfg, const genesis_state& genesis, bool use_genesis, deep_mind_handler* dmlog) {
       unique_ptr<controller> validating_node = std::make_unique<controller>(vcfg, make_protocol_feature_set(), genesis.compute_chain_id());
       validating_node->add_indices();
@@ -1411,6 +1417,12 @@ namespace eosio::testing {
          validating_node->startup( [](){}, []() { return false; } );
       }
       return validating_node;
+   }
+
+   savanna_validating_tester::savanna_validating_tester() {
+      // Activate Savanna consensus
+      finalizer_keys fin_keys(*this, 4u /* num_keys */, 4u /* finset_size */);
+      fin_keys.activate_savanna(0u /* first_key_idx */);
    }
 
    bool fc_exception_message_is::operator()( const fc::exception& ex ) {


### PR DESCRIPTION
This PR (and subsequent ones) addresses those requirements:
* for any unit test which can be run in both Legacy and Savanna (majority of our unit tests are), we would like CICD to run it in both modes,
* for any tests which can be only run in Legacy or Savanna, place in a separate file,
* we want to easily turn off and remove Legacy testing some time in the future

This is the first PR which demonstrates how running both modes can be achieved. After it is approved, it will be applied to other tests.
 
Both `BOOST_AUTO_TEST_CASE_TEMPLATE` and `BOOST_FIXTURE_TEST_CASE_TEMPLATE` work. Either involves about the same amount of coding. If an original test already use `tester chain;` declaration, `BOOST_AUTO_TEST_CASE_TEMPLATE` requires fewer changes; if it uses a fixture, `BOOST_FIXTURE_TEST_CASE_TEMPLATE` can be used, but it requires adding `this` or `T` in front of methods.

```
BOOST_AUTO_TEST_CASE_TEMPLATE( missing_sigs, T, validating_testers ) { try {
   T chain;
   chain.create_accounts( {"alice"_n} );

BOOST_FIXTURE_TEST_CASE_TEMPLATE( missing_sigs, T, validating_testers, T ) { try {
   this->create_accounts( {"alice"_n} );
   or
   T::create_accounts( {"alice"_n} );
```
   

Partially resolves https://github.com/AntelopeIO/spring/issues/11