### PR TITLE
[1.0-beta1] P2P: Fix switch from lib catchup to head catchup

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3118,7 +3118,7 @@ namespace eosio {
       if( my_impl->dispatcher.have_block( blk_id ) ) {
          peer_dlog( this, "canceling wait, already received block ${num}, id ${id}...",
                     ("num", blk_num)("id", blk_id.str().substr(8,16)) );
-         my_impl->sync_master->sync_recv_block( shared_from_this(), blk_id, blk_num, true, fc::microseconds::maximum() );
+         my_impl->sync_master->sync_recv_block( shared_from_this(), blk_id, blk_num, false, fc::microseconds::maximum() );
          cancel_wait();
 
          pending_message_buffer.advance_read_ptr( message_length );


### PR DESCRIPTION
When syncing do not mark a block as applied until it is actually applied to the chain state. 
Reverting this commit: https://github.com/AntelopeIO/leap/commit/fdeb7fcb0f464b48d190e678104fd6042d6e10a1 with the comment "GH-2125 If we have the block in our dispatcher list then it is applied". The comment is wrong. A block that is in the dispatcher list is not necessarily applied. We can not assume that a block is applied just because we have added it to our received block list. We distinguish from received blocks and applied blocks in `sync_manager` to know the current state of syncing. The indication that the block is already applied confused `sync_manager` so that it doesn't request the correct blocks.

Introduced in https://github.com/AntelopeIO/leap/pull/2290

Resolves #141 