### PR TITLE
[1.0-beta1 -> main] P2P: Fix switch from lib catchup to head catchup

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3118,7 +3118,7 @@ namespace eosio {
       if( my_impl->dispatcher.have_block( blk_id ) ) {
          peer_dlog( this, "canceling wait, already received block ${num}, id ${id}...",
                     ("num", blk_num)("id", blk_id.str().substr(8,16)) );
-         my_impl->sync_master->sync_recv_block( shared_from_this(), blk_id, blk_num, true, fc::microseconds::maximum() );
+         my_impl->sync_master->sync_recv_block( shared_from_this(), blk_id, blk_num, false, fc::microseconds::maximum() );
          cancel_wait();
 
          pending_message_buffer.advance_read_ptr( message_length );

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -57,9 +57,20 @@ try:
     cluster.setWalletMgr(walletMgr)
 
     Print("Stand up cluster")
-    if cluster.launch(prodCount=prodCount, activateIF=activateIF, onlyBios=False, pnodes=pnodes, totalNodes=totalNodes, totalProducers=pnodes*prodCount,
-                      unstartedNodes=catchupCount, loadSystemContract=True,
-                      maximumP2pPerHost=totalNodes+trxGeneratorCnt) is False:
+    specificExtraNodeosArgs = {}
+    specificExtraNodeosArgs[pnodes+1] = f' --sync-fetch-span 1 '
+    specificExtraNodeosArgs[pnodes+2] = f' --sync-fetch-span 5 '
+    specificExtraNodeosArgs[pnodes+3] = f' --sync-fetch-span 21 '
+    specificExtraNodeosArgs[pnodes+4] = f' --sync-fetch-span 89 '
+    specificExtraNodeosArgs[pnodes+5] = f' --sync-fetch-span 377 '
+    specificExtraNodeosArgs[pnodes+6] = f' --sync-fetch-span 1597 '
+    specificExtraNodeosArgs[pnodes+7] = f' --sync-fetch-span 1597 '
+    specificExtraNodeosArgs[pnodes+8] = f' --sync-fetch-span 6765 '
+    specificExtraNodeosArgs[pnodes+9] = f' --sync-fetch-span 28657 '
+    specificExtraNodeosArgs[pnodes+10] = f' --sync-fetch-span 89 '
+    if cluster.launch(prodCount=prodCount, specificExtraNodeosArgs=specificExtraNodeosArgs, activateIF=activateIF, onlyBios=False,
+                      pnodes=pnodes, totalNodes=totalNodes, totalProducers=pnodes*prodCount, unstartedNodes=catchupCount,
+                      loadSystemContract=True, maximumP2pPerHost=totalNodes+trxGeneratorCnt) is False:
         Utils.errorExit("Failed to stand up eos cluster.")
 
     Print("Create test wallet")


### PR DESCRIPTION
When syncing do not mark a block as applied until it is actually applied to the chain state. 
Reverting this commit: https://github.com/AntelopeIO/leap/commit/fdeb7fcb0f464b48d190e678104fd6042d6e10a1 with the comment "GH-2125 If we have the block in our dispatcher list then it is applied". The comment is wrong. A block that is in the dispatcher list is not necessarily applied. We can not assume that a block is applied just because we have added it to our received block list. We distinguish from received blocks and applied blocks in `sync_manager` to know the current state of syncing. The indication that the block is already applied confused `sync_manager` so that it doesn't request the correct blocks.

Introduced in https://github.com/AntelopeIO/leap/pull/2290

Merges `release/1.0-beta1` into `main` including #146 & #147

Resolves #141 