### PR TITLE
[1.0-beta1] P2P: Fix stuck in peer syncing state

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4018,7 +4018,7 @@ namespace eosio {
       });
    }
 
-   void net_plugin_impl::on_accepted_block( const signed_block_ptr& block, const block_id_type& id ) {
+   void net_plugin_impl::on_accepted_block( const signed_block_ptr& block, const block_id_type&) {
       sync_master->send_handshakes_if_synced(fc::time_point::now() - block->timestamp);
       if (const auto* next_producers = chain_plug->chain().next_producers()) {
          on_pending_schedule(*next_producers);


### PR DESCRIPTION
Test failure: https://github.com/AntelopeIO/spring/actions/runs/9114438126/job/25059003107?pr=149

The producing node (Node03) was stuck in LIB catchup. Since blocks can be processed inside controller during a fork and not call `sync_master->sync_recv_block` with `blk_applied==true`. 

This is similar to the issue addressed in #27. In the #27, a handshake with the wrong information was sent. In this case no handshake was sent at all as it become synced up during a fork switch. I believe this issue was masked by #147 because it was incorrectly reporting blocks as applied. Without this improper reporting of applied blocks a fork switch that applies up to synced would not call  `sync_master->sync_recv_block` with `blk_applied==true` and not move node out of LIB catchup.

Now also send out handshakes if we determine we are synced and there is a pending handshake to send.

Related to #27 
Related to #147 

Resolves #150