### PR TITLE
[1.0-beta1] Vote processing fix

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3245,6 +3245,7 @@ struct controller_impl {
                if( s == controller::block_status::incomplete ) {
                   forkdb.add( bsp, mark_valid_t::yes, ignore_duplicate_t::no );
                   emit( accepted_block_header, std::tie(bsp->block, bsp->id()), __FILE__, __LINE__ );
+                  vote_processor.notify_new_block();
                } else {
                   assert(s != controller::block_status::irreversible);
                   forkdb.mark_valid( bsp );

--- a/libraries/chain/include/eosio/chain/vote_processor.hpp
+++ b/libraries/chain/include/eosio/chain/vote_processor.hpp
@@ -186,6 +186,8 @@ public:
 
    // called from net threads
    void notify_new_block() {
+      if (stopped)
+         return;
       // would require a mtx lock to check if index is empty, post check to thread_pool
       boost::asio::post(thread_pool.get_executor(), [this] {
          std::unique_lock g(mtx);

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -499,7 +499,7 @@ namespace eosio::testing {
          // wait for this node's vote to be processed
          size_t retrys = 200;
          while (!c.node_has_voted_if_finalizer(c.head_block_id()) && --retrys) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
          }
          FC_ASSERT(retrys, "Never saw this nodes vote processed before timeout");
       }

--- a/unittests/finality_test_cluster.cpp
+++ b/unittests/finality_test_cluster.cpp
@@ -70,7 +70,7 @@ eosio::chain::vote_status finality_test_cluster::wait_on_vote(uint32_t connectio
    // duplicates are not signaled
    size_t retrys = 200;
    while ( (last_connection_vote != connection_id) && --retrys) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
    }
    if (!duplicate && last_connection_vote != connection_id) {
       FC_ASSERT(false, "Never received vote");


### PR DESCRIPTION
- Do not post to vote thread pool if thread pool is not active.
  - This fixes a memory leak when there are no vote threads; which is why this PR is targeted to `1.0-beta1` instead of `main`
- A producer should notify vote processor that it has produced a block
  - I believe this resolves issue #139 
- Update the tester wait on votes to be consistent

Resolves #139