### PR TITLE
Improve fork database logging

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1698,7 +1698,9 @@ struct controller_impl {
 
          auto pending_head = forkdb.pending_head();
          if( pending_head && blog_head && start_block_num <= blog_head->block_num() ) {
-            ilog( "fork database head ${h}, root ${r}", ("h", pending_head->block_num())( "r", forkdb.root()->block_num() ) );
+            ilog("fork database head ${hn}:${h}, root ${rn}:${r}",
+                 ("hn", pending_head->block_num())("h", pending_head->id())
+                 ("rn", forkdb.root()->block_num())("r", forkdb.root()->id()));
             if( pending_head->block_num() < chain_head.block_num() || chain_head.block_num() < forkdb.root()->block_num() ) {
                ilog( "resetting fork database with new last irreversible block as the new root: ${id}", ("id", chain_head.id()) );
                fork_db_reset_root_to_chain_head();

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -722,7 +722,7 @@ namespace eosio::chain {
       auto in_use_value = in_use.load();
       // check that fork_dbs are in a consistent state
       if (!legacy_valid && !savanna_valid) {
-         ilog("No fork_database to persist, not writing out: ${f}", ("f", fork_db_file));
+         ilog("No fork_database to persist");
          return;
       } else if (legacy_valid && savanna_valid && in_use_value == in_use_t::savanna) {
          legacy_valid = false; // don't write legacy if not needed, we delay 'clear' of legacy until close


### PR DESCRIPTION
- Change a `warn` level log to `info` since it does not necessarily indicate any issue.
- Add block ids to fork database log output.
- Add additional fork database log output at shutdown.