### PR TITLE
Make unit tests run in both Legacy and Savanna (Part 4,  block_tests, chain_tests, database_tests, restart_chain_tests)

### DIFF
--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
    BOOST_REQUIRE(old_version == pending_version);
    BOOST_REQUIRE(pending_version == old_pending_version);
 
-   const auto& gpo = tester.control->db().get<global_property_object>();
+   const auto& gpo = tester.control->db().template get<global_property_object>();
    BOOST_REQUIRE(!gpo.proposed_schedule_block_num);
    BOOST_REQUIRE(gpo.proposed_schedule.version == 0);
    BOOST_REQUIRE(gpo.proposed_schedule.producers.empty());
@@ -57,12 +57,12 @@ BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
    }
 } FC_LOG_AND_RETHROW()
 
-BOOST_AUTO_TEST_CASE( replace_account_keys ) try {
-   validating_tester tester;
+BOOST_AUTO_TEST_CASE_TEMPLATE( replace_account_keys, T, validating_testers ) try {
+   T tester;
    const name usr = config::system_account_name;
    const name active_permission = config::active_name;
    const auto& rlm = tester.control->get_resource_limits_manager();
-   const auto* perm = tester.control->db().find<permission_object, by_owner>(boost::make_tuple(usr, active_permission));
+   const auto* perm = tester.control->db().template find<permission_object, by_owner>(boost::make_tuple(usr, active_permission));
    BOOST_REQUIRE(perm != NULL);
 
    const int64_t old_size = (int64_t)(chain::config::billable_size_v<permission_object> + perm->auth.get_billable_size());
@@ -81,8 +81,8 @@ BOOST_AUTO_TEST_CASE( replace_account_keys ) try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_AUTO_TEST_CASE( decompressed_size_over_limit ) try {
-   tester chain;
+BOOST_AUTO_TEST_CASE_TEMPLATE( decompressed_size_over_limit, T, testers ) try {
+   T chain;
 
    // build a transaction, add cf data, sign
    cf_action                        cfa;
@@ -116,8 +116,8 @@ BOOST_AUTO_TEST_CASE( decompressed_size_over_limit ) try {
                            });
 } FC_LOG_AND_RETHROW()
 
-BOOST_AUTO_TEST_CASE( decompressed_size_under_limit ) try {
-   tester chain;
+BOOST_AUTO_TEST_CASE_TEMPLATE( decompressed_size_under_limit, T, testers ) try {
+   T chain;
 
    // build a transaction, add cf data, sign
    cf_action                        cfa;
@@ -150,9 +150,9 @@ BOOST_AUTO_TEST_CASE( decompressed_size_under_limit ) try {
 } FC_LOG_AND_RETHROW()
 
 // verify accepted_block signals validated blocks
-BOOST_AUTO_TEST_CASE( signal_validated_blocks ) try {
-   tester chain;
-   tester validator;
+BOOST_AUTO_TEST_CASE_TEMPLATE( signal_validated_blocks, T, testers ) try {
+   T chain;
+   T validator;
 
    signed_block_ptr accepted_block;
    block_id_type accepted_id;

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -11,9 +11,9 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_SUITE(database_tests)
 
    // Simple tests of undo infrastructure
-   BOOST_AUTO_TEST_CASE(undo_test) {
+   BOOST_AUTO_TEST_CASE_TEMPLATE( undo_test, T, validating_testers ) {
       try {
-         validating_tester test;
+         T test;
 
          // Bypass read-only restriction on state DB access for this unit test which really needs to mutate the DB to properly conduct its test.
          eosio::chain::database& db = const_cast<eosio::chain::database&>( test.control->db() );
@@ -39,9 +39,9 @@ BOOST_AUTO_TEST_SUITE(database_tests)
    }
 
    // Test the block fetching methods on database, fetch_bock_by_id, and fetch_block_by_number
-   BOOST_AUTO_TEST_CASE(get_blocks) {
+   BOOST_AUTO_TEST_CASE_TEMPLATE( get_blocks, T, validating_testers ) {
       try {
-         validating_tester test;
+         T test;
          vector<block_id_type> block_ids;
 
          const uint32_t num_of_blocks_to_prod = 200;


### PR DESCRIPTION
Update `block_tests`, `chain_tests`, `database_tests`, and `restart_chain_tests` to run in both Legacy and Savanna.

Partially resolves https://github.com/AntelopeIO/spring/issues/11