### PR TITLE
Update wasm_tests to run both modes

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -569,7 +569,8 @@ namespace eosio::testing {
          init(std::move(config), std::move(pfs), genesis);
       }
 
-      tester(const fc::temp_directory& tempdir, bool use_genesis) {
+      tester(const fc::temp_directory& tempdir, bool use_genesis, bool is_savanna = false) {
+         this->is_savanna = is_savanna;
          auto def_conf = default_config(tempdir);
          cfg = def_conf.first;
 
@@ -625,6 +626,7 @@ namespace eosio::testing {
    public:
       savanna_tester(setup_policy policy = setup_policy::full, db_read_mode read_mode = db_read_mode::HEAD, std::optional<uint32_t> genesis_max_inline_action_size = std::optional<uint32_t>{});
       savanna_tester(controller::config config, const genesis_state& genesis);
+      savanna_tester(const fc::temp_directory& tempdir, bool use_genesis);
    };
 
    using legacy_tester = tester;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1408,6 +1408,10 @@ namespace eosio::testing {
    : tester(config, genesis, true) { // true for is_savanna
    }
 
+   savanna_tester::savanna_tester(const fc::temp_directory& tempdir, bool use_genesis)
+   : tester(tempdir, use_genesis, true) { // true for is_savanna
+   }
+
    unique_ptr<controller> validating_tester::create_validating_node(controller::config vcfg, const genesis_state& genesis, bool use_genesis, deep_mind_handler* dmlog) {
       unique_ptr<controller> validating_node = std::make_unique<controller>(vcfg, make_protocol_feature_set(), genesis.compute_chain_id());
       validating_node->add_indices();

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -111,7 +111,8 @@ set(ctest_tests "'${ctest_tests}' -j8") # surround test list string in apostroph
 # even on fresh first time test runs before ctest auto-detects costs
 foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
    set_tests_properties(api_unit_test_${RUNTIME} PROPERTIES COST 5000)
-   set_tests_properties(wasm_unit_test_${RUNTIME} PROPERTIES COST 4000)
+   set_tests_properties(wasm_part1_unit_test_${RUNTIME} PROPERTIES COST 4000)
+   set_tests_properties(wasm_part2_unit_test_${RUNTIME} PROPERTIES COST 4000)
    set_tests_properties(delay_unit_test_${RUNTIME} PROPERTIES COST 3000)
 endforeach()
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -62,7 +62,8 @@ struct provereset {
 
 FC_REFLECT_EMPTY(provereset);
 
-BOOST_AUTO_TEST_SUITE(wasm_tests)
+// Split the tests into two parts so that they can be finished within CICD time limit
+BOOST_AUTO_TEST_SUITE(wasm_part1_tests)
 
 /**
  * Prove that action reading and assertions are working
@@ -1269,6 +1270,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_big_deserialization, T, validating_testers 
 
 } FC_LOG_AND_RETHROW()
 
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(wasm_part2_tests)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try {
    T chain;


### PR DESCRIPTION
* Add a new constructor `savanna_tester(const fc::temp_directory&, bool)`
* Update `wasm_test`s to run in both Legacy and Savanna

Partially resolves https://github.com/AntelopeIO/spring/issues/11