### PR TITLE
Store proposed producers and proposed finalizers in building block

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -40,6 +40,8 @@ namespace eosio::chain {
    using chainbase::pinnable_mapped_file;
    using boost::signals2::signal;
 
+   class transaction_context;
+   struct trx_block_context;
    class dynamic_global_property_object;
    class global_property_object;
    class permission_object;
@@ -329,10 +331,11 @@ namespace eosio::chain {
 
          bool is_known_unexpired_transaction( const transaction_id_type& id) const;
 
-         int64_t set_proposed_producers( vector<producer_authority> producers );
+         // called by host function
+         int64_t set_proposed_producers( transaction_context& trx_context, vector<producer_authority> producers );
 
-         // called by host function set_finalizers
-         void set_proposed_finalizers( finalizer_policy&& fin_pol );
+         void apply_trx_block_context( trx_block_context& trx_blk_context );
+
          // called from net threads
          void process_vote_message( uint32_t connection_id, const vote_message_ptr& msg );
          // thread safe, for testing

--- a/libraries/chain/include/eosio/chain/global_property_object.hpp
+++ b/libraries/chain/include/eosio/chain/global_property_object.hpp
@@ -90,10 +90,6 @@ namespace eosio::chain {
       chain_config                        configuration;
       chain_id_type                       chain_id;
       wasm_config                         wasm_configuration;
-      // Note: proposed_fin_pol_block_num and proposed_fin_pol are used per block
-      //       and reset after uses. They do not need to be stored in snapshots.
-      std::optional<block_num_type>       proposed_fin_pol_block_num;
-      finalizer_policy                    proposed_fin_pol;
 
       // For snapshot_global_property_object_v2 and initialize_from( const T& legacy )
       template<typename T>
@@ -115,10 +111,6 @@ namespace eosio::chain {
          } else {
             wasm_configuration = legacy.wasm_configuration;
          }
-
-         // proposed_fin_pol_block_num and proposed_fin_pol are set to default values.
-         proposed_fin_pol_block_num = std::nullopt;
-         proposed_fin_pol = finalizer_policy{};
       }
 
       // For snapshot_global_property_object v3, v4, and v5
@@ -162,10 +154,6 @@ namespace eosio::chain {
             value.configuration = row.configuration;
             value.chain_id = row.chain_id;
             value.wasm_configuration = row.wasm_configuration;
-            // Snapshot does not contain proposed_fin_pol_block_num and proposed_fin_pol.
-            // Return their default values
-            value.proposed_fin_pol_block_num = std::nullopt;
-            value.proposed_fin_pol = finalizer_policy{};
          }
       };
    }

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -85,7 +85,7 @@ namespace eosio { namespace chain { namespace webassembly {
       }
       EOS_ASSERT( producers.size() == unique_producers.size(), wasm_execution_error, "duplicate producer name in producer schedule" );
 
-      return context.control.set_proposed_producers( std::move(producers) );
+      return context.control.set_proposed_producers( context.trx_context, std::move(producers) );
    }
 
    uint32_t interface::get_wasm_parameters_packed( span<char> packed_parameters, uint32_t max_version ) const {
@@ -205,7 +205,7 @@ namespace eosio { namespace chain { namespace webassembly {
                   "and less than or equal to the sum of the weights",
                   ("t", finpol.threshold)("w", weight_sum) );
 
-      context.control.set_proposed_finalizers( std::move(finpol) );
+      context.trx_context.set_proposed_finalizers( std::move(finpol) );
    }
 
    uint32_t interface::get_blockchain_parameters_packed( legacy_span<char> packed_blockchain_parameters ) const {


### PR DESCRIPTION
The chainbase `global_property_object` was used to store `finalizer_policy` during block construction as a means to provide automatic rollback if the transaction/block failed. See https://github.com/AntelopeIO/spring/pull/99. However, `finalizer_policy` contains non-shared types of `std::vector` and `fc::crypto::blslib::bls_public_key`. 

This PR solves the problem of avoiding side-effects of proposed finalizer policy made in an aborted transaction in a different way than committing the speculative changes into the `global_property_object` in `chainbase`. Now we store the speculative changes in the transaction context. Then if we commit the transaction, it copies them over (assuming they are not nullopt) from the transaction context to the building block. This avoids having to add a shared version of the `finalizer_policy` and `bls_public_key`. 

For symmetry, the proposer schedule in Savanna was modified to also be managed the same way as `finalier_policy` in `transaction_context`.

This PR removes  `proposed_fin_pol_block_num` and `proposed_fin_pol` from `global_property_object` and therefore is not state compatible with previous versions. The proposed schedule `proposed_schedule_block_num` & `proposed_schedule` were not removed from `global_property_object` because they are still needed pre-Savanna.

Resolves #182 