### PR TITLE
[1.0-beta1.1] Store proposed producers and proposed finalizers in building block

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -106,7 +106,7 @@ void finish_next(const block_header_state& prev,
    if (if_ext.new_proposer_policy) {
       // called when assembling the block
       next_header_state.proposer_policies[if_ext.new_proposer_policy->active_time] =
-         std::move(if_ext.new_proposer_policy);
+         std::make_shared<proposer_policy>(std::move(*if_ext.new_proposer_policy));
    }
 
    // finality_core

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -170,8 +170,6 @@ R apply_l(const block_handle& bh, F&& f) {
 struct completed_block {
    block_handle bsp;
 
-   bool is_legacy() const { return std::holds_alternative<block_state_legacy_ptr>(bsp.internal()); }
-
    deque<transaction_metadata_ptr> extract_trx_metas() {
       return apply<deque<transaction_metadata_ptr>>(bsp, [](auto& bsp) { return bsp->extract_trxs_metas(); });
    }
@@ -257,8 +255,6 @@ struct assembled_block {
    };
 
    std::variant<assembled_block_legacy, assembled_block_if> v;
-
-   bool is_legacy() const { return std::holds_alternative<assembled_block_legacy>(v); }
 
    template <class R, class F>
    R apply_legacy(F&& f) {
@@ -398,6 +394,7 @@ struct building_block {
       deque<transaction_receipt>          pending_trx_receipts;
       checksum_or_digests                 trx_mroot_or_receipt_digests {digests_t{}};
       action_digests_t                    action_receipt_digests;
+      trx_block_context                   trx_blk_context;
 
       building_block_common(const vector<digest_type>& new_protocol_feature_activations,
                             action_digests_t::store_which_t store_which) :
@@ -492,7 +489,7 @@ struct building_block {
 
       // returns the next proposer schedule version if producers should be proposed in block
       // if producers is not different then returns empty optional
-      std::optional<uint32_t> get_next_proposer_schedule_version(const shared_vector<shared_producer_authority>& producers) const {
+      std::optional<uint32_t> get_next_proposer_schedule_version(const std::vector<producer_authority>& producers) const {
          assert(active_proposer_policy);
 
          auto get_next_sched = [&]() -> const producer_authority_schedule& {
@@ -506,7 +503,7 @@ struct building_block {
 
          const producer_authority_schedule& lhs = get_next_sched();
          auto v = lhs.version;
-         if (!std::equal(lhs.producers.begin(), lhs.producers.end(), producers.begin(), producers.end())) {
+         if (lhs.producers != producers) {
             ++v;
             return std::optional<uint32_t>{v};
          }
@@ -529,8 +526,6 @@ struct building_block {
       v(building_block_if(prev, input, action_digests_t::store_which_t::savanna))
    {}
 
-   bool is_legacy() const { return std::holds_alternative<building_block_legacy>(v); }
-
    // apply legacy, building_block_legacy
    template <class R, class F>
    R apply_l(F&& f) {
@@ -550,6 +545,16 @@ struct building_block {
       else
          return std::visit(overloaded{[&](building_block_legacy& bb) -> R { return std::forward<F>(f)(bb); },
                                       [&](building_block_if& bb)     -> R { return std::forward<F>(f)(bb); }}, v);
+   }
+
+   template <class R, class F, class S>
+   R apply(F&& f, S&& s) {
+      if constexpr (std::is_same_v<void, R>)
+         std::visit(overloaded{[&](building_block_legacy& bb) { std::forward<F>(f)(bb); },
+                               [&](building_block_if& bb)     { std::forward<S>(s)(bb); }}, v);
+      else
+         return std::visit(overloaded{[&](building_block_legacy& bb) -> R { return std::forward<F>(f)(bb); },
+                                      [&](building_block_if& bb)     -> R { return std::forward<S>(s)(bb); }}, v);
    }
 
    deque<transaction_metadata_ptr> extract_trx_metas() {
@@ -596,7 +601,7 @@ struct building_block {
                         v);
    }
 
-   std::optional<uint32_t> get_next_proposer_schedule_version(const shared_vector<shared_producer_authority>& producers) const {
+   std::optional<uint32_t> get_next_proposer_schedule_version(const std::vector<producer_authority>& producers) const {
       return std::visit(
          overloaded{[](const building_block_legacy&) -> std::optional<uint32_t> { return std::nullopt; },
                     [&](const building_block_if& bb) -> std::optional<uint32_t> {
@@ -663,18 +668,6 @@ struct building_block {
                         v);
    }
 
-   void update_finalizer_policy_generation(finalizer_policy& new_finalizer_policy) {
-      apply<void>(
-         overloaded{
-            [&](building_block::building_block_legacy& bb_legacy) -> void {
-               new_finalizer_policy.generation = 1;
-            },
-            [&](building_block::building_block_if& bb_savanna) -> void {
-               new_finalizer_policy.generation = bb_savanna.parent.finalizer_policy_generation + 1;
-            }
-         });
-   }
-
    qc_data_t get_qc_data(fork_database& fork_db, const block_state& parent) {
       // find most recent ancestor block that has a QC by traversing fork db
       // branch from parent
@@ -706,7 +699,7 @@ struct building_block {
    assembled_block assemble_block(boost::asio::io_context& ioc,
                                   const protocol_feature_set& pfs,
                                   fork_database& fork_db,
-                                  std::unique_ptr<proposer_policy> new_proposer_policy,
+                                  std::optional<proposer_policy> new_proposer_policy,
                                   std::optional<finalizer_policy> new_finalizer_policy,
                                   bool validating,
                                   std::optional<qc_data_t> validating_qc_data,
@@ -881,8 +874,6 @@ struct pending_state {
       _db_session.push();
    }
 
-   bool is_legacy() const { return std::visit([](const auto& stage) { return stage.is_legacy(); }, _block_stage); }
-   
    const block_signing_authority& pending_block_signing_authority() const {
       return std::visit(
          [](const auto& stage) -> const block_signing_authority& { return stage.pending_block_signing_authority(); },
@@ -907,7 +898,7 @@ struct pending_state {
          _block_stage);
    }
 
-   std::optional<uint32_t> get_next_proposer_schedule_version(const shared_vector<shared_producer_authority>& producers) const {
+   std::optional<uint32_t> get_next_proposer_schedule_version(const std::vector<producer_authority>& producers) const {
       return std::visit(overloaded{
                            [&](const building_block& stage) -> std::optional<uint32_t> {
                               return stage.get_next_proposer_schedule_version(producers);
@@ -994,7 +985,6 @@ struct controller_impl {
                                       });
                                    }};
 
-   int64_t set_proposed_producers( vector<producer_authority> producers );
    int64_t set_proposed_producers_legacy( vector<producer_authority> producers );
 
    protocol_feature_activation_set_ptr head_activated_protocol_features() const {
@@ -3157,55 +3147,36 @@ struct controller_impl {
             );
          resource_limits.process_block_usage(bb.block_num());
 
-         // Any proposer policy?
-         auto process_new_proposer_policy = [&](auto&) -> std::unique_ptr<proposer_policy> {
-            std::unique_ptr<proposer_policy> new_proposer_policy;
-            const auto& gpo = db.get<global_property_object>();
-            if (gpo.proposed_schedule_block_num) {
-               std::optional<uint32_t> version = pending->get_next_proposer_schedule_version(gpo.proposed_schedule.producers);
-               if (version) {
-                  new_proposer_policy                    = std::make_unique<proposer_policy>();
-                  new_proposer_policy->active_time       = detail::get_next_next_round_block_time(bb.timestamp());
-                  new_proposer_policy->proposer_schedule = producer_authority_schedule::from_shared(gpo.proposed_schedule);
-                  new_proposer_policy->proposer_schedule.version = *version;
-                  ilog("Scheduling proposer schedule change at ${t}: ${s}",
-                       ("t", new_proposer_policy->active_time)("s", new_proposer_policy->proposer_schedule));
+         // Any proposer policy or finalizer policy?
+         std::optional<finalizer_policy> new_finalizer_policy;
+         std::optional<proposer_policy> new_proposer_policy;
+         bb.apply<void>(
+            overloaded{
+               [&](building_block::building_block_legacy& bb) -> void {
+                  // Make sure new_finalizer_policy is set only once in Legacy
+                  if (bb.trx_blk_context.proposed_fin_pol_block_num && !bb.pending_block_header_state.is_if_transition_block()) {
+                     new_finalizer_policy = std::move(bb.trx_blk_context.proposed_fin_pol);
+                     new_finalizer_policy->generation = 1;
+                  }
+               },
+               [&](building_block::building_block_if& bb) -> void {
+                  if (bb.trx_blk_context.proposed_fin_pol_block_num) {
+                     new_finalizer_policy = std::move(bb.trx_blk_context.proposed_fin_pol);
+                     new_finalizer_policy->generation = bb.parent.finalizer_policy_generation + 1;
+                  }
+                  if (bb.trx_blk_context.proposed_schedule_block_num) {
+                     std::optional<uint32_t> version = pending->get_next_proposer_schedule_version(bb.trx_blk_context.proposed_schedule.producers);
+                     if (version) {
+                        new_proposer_policy.emplace();
+                        new_proposer_policy->active_time       = detail::get_next_next_round_block_time(bb.timestamp);
+                        new_proposer_policy->proposer_schedule = std::move(bb.trx_blk_context.proposed_schedule);
+                        new_proposer_policy->proposer_schedule.version = *version;
+                        ilog("Scheduling proposer schedule change at ${t}: ${s}",
+                             ("t", new_proposer_policy->active_time)("s", new_proposer_policy->proposer_schedule));
+                     }
+                  }
                }
-
-               db.modify( gpo, [&]( auto& gp ) {
-                  gp.proposed_schedule_block_num = std::optional<block_num_type>();
-                  gp.proposed_schedule.version = 0;
-                  gp.proposed_schedule.producers.clear();
-               });
-            }
-            return new_proposer_policy;
-         };
-         auto new_proposer_policy = apply_s<std::unique_ptr<proposer_policy>>(chain_head, process_new_proposer_policy);
-
-         // Any finalizer policy?
-         std::optional<finalizer_policy> new_finalizer_policy = std::nullopt;
-         const auto& gpo = db.get<global_property_object>();
-         if (gpo.proposed_fin_pol_block_num.has_value()) {
-            new_finalizer_policy = gpo.proposed_fin_pol;
-
-            db.modify( gpo, [&]( auto& gp ) {
-               gp.proposed_fin_pol_block_num = std::nullopt;
-               gp.proposed_fin_pol.generation = 0;
-               gp.proposed_fin_pol.finalizers.clear();
             });
-         }
-
-         // Make sure new_finalizer_policy is set only once in Legacy
-         bb.apply_l<void>([&](building_block::building_block_legacy& bl) {
-            if (bl.pending_block_header_state.is_if_transition_block()) {
-               new_finalizer_policy = std::nullopt;
-            }
-         });
-
-         // Update generation
-         if (new_finalizer_policy.has_value()) {
-            bb.update_finalizer_policy_generation(*new_finalizer_policy);
-         }
 
          auto assembled_block =
             bb.assemble_block(thread_pool.get_executor(),
@@ -3328,32 +3299,30 @@ struct controller_impl {
       pending->push();
    }
 
-   void set_proposed_finalizers(finalizer_policy&& fin_pol) {
+   void apply_trx_block_context(trx_block_context& trx_blk_context) {
       assert(pending); // has to exist and be building_block since called from host function
       assert(std::holds_alternative<building_block>(pending->_block_stage));
       auto& bb = std::get<building_block>(pending->_block_stage);
 
-      // Use global_property_object instead of building_block so that if the
-      // transaction fails it will be rolledback.
-      auto cur_block_num = chain_head.block_num() + 1;
-      auto& gpo = db.get<global_property_object>();
-      db.modify( gpo, [&]( auto& gp ) {
-         gp.proposed_fin_pol_block_num = cur_block_num;
-         gp.proposed_fin_pol = std::move(fin_pol);
-      });
+      // Savanna uses new algorithm for proposer schedule change
+      // Prevent any in-flight legacy proposer schedule changes when finalizers are first proposed
+      if (trx_blk_context.proposed_fin_pol_block_num) {
+         bb.apply_l<void>([&](building_block::building_block_legacy& bl) {
+            const auto& gpo = db.get<global_property_object>();
+            if (gpo.proposed_schedule_block_num) {
+               db.modify(gpo, [&](auto& gp) {
+                  gp.proposed_schedule_block_num = std::optional<block_num_type>();
+                  gp.proposed_schedule.version   = 0;
+                  gp.proposed_schedule.producers.clear();
+               });
+            }
+            bl.new_pending_producer_schedule = {};
+            bl.pending_block_header_state.prev_pending_schedule.schedule.producers.clear();
+         });
+      }
 
-      bb.apply_l<void>([&](building_block::building_block_legacy& bl) {
-         // Savanna uses new algorithm for proposer schedule change, prevent any in-flight legacy proposer schedule changes
-         const auto& gpo = db.get<global_property_object>();
-         if (gpo.proposed_schedule_block_num) {
-            db.modify(gpo, [&](auto& gp) {
-               gp.proposed_schedule_block_num = std::optional<block_num_type>();
-               gp.proposed_schedule.version   = 0;
-               gp.proposed_schedule.producers.clear();
-            });
-         }
-         bl.new_pending_producer_schedule = {};
-         bl.pending_block_header_state.prev_pending_schedule.schedule.producers.clear();
+      bb.apply<void>([&](auto& b) {
+         b.trx_blk_context.apply(std::move(trx_blk_context));
       });
    }
 
@@ -5262,37 +5231,16 @@ bool controller::is_writing_snapshot() const {
    return my->writing_snapshot.load(std::memory_order_acquire);
 }
 
-int64_t controller::set_proposed_producers( vector<producer_authority> producers ) {
+int64_t controller::set_proposed_producers( transaction_context& trx_context, vector<producer_authority> producers ) {
    assert(my->pending);
-   if (my->pending->is_legacy()) {
-      return my->set_proposed_producers_legacy(std::move(producers));
-   } else {
-      return my->set_proposed_producers(std::move(producers));
-   }
-}
-
-int64_t controller_impl::set_proposed_producers( vector<producer_authority> producers ) {
-   // Savanna sets the global_property_object.proposed_schedule similar to legacy, but it is only set during the building of the block.
-   // global_property_object is used instead of building_block so that if the transaction fails it is rolledback.
-
-   if (producers.empty())
-      return -1; // INSTANT_FINALITY depends on DISALLOW_EMPTY_PRODUCER_SCHEDULE
-
-   assert(pending);
-
-   producer_authority_schedule sch;
-   // sch.version is set in assemble_block
-   sch.producers = std::move(producers);
-
-   // store schedule in gpo so it will be rolledback if transaction fails
-   auto cur_block_num = chain_head.block_num() + 1;
-   auto& gpo = db.get<global_property_object>();
-   db.modify( gpo, [&]( auto& gp ) {
-      gp.proposed_schedule_block_num = cur_block_num;
-      gp.proposed_schedule = sch;
-   });
-
-   return std::numeric_limits<uint32_t>::max();
+   assert(std::holds_alternative<building_block>(my->pending->_block_stage));
+   auto& bb = std::get<building_block>(my->pending->_block_stage);
+   return bb.apply<int64_t>([&](building_block::building_block_legacy&) {
+                               return my->set_proposed_producers_legacy(std::move(producers));
+                            },
+                            [&](building_block::building_block_if&) {
+                               return trx_context.set_proposed_producers(std::move(producers));
+                            });
 }
 
 int64_t controller_impl::set_proposed_producers_legacy( vector<producer_authority> producers ) {
@@ -5341,7 +5289,7 @@ int64_t controller_impl::set_proposed_producers_legacy( vector<producer_authorit
       // The check for if there is a finalizer policy set is required because
       // is_if_transition_block() is set in assemble_block so it is not set
       // for the if genesis block.
-      return bl.pending_block_header_state.is_if_transition_block() || gpo.proposed_fin_pol_block_num.has_value();
+      return bl.pending_block_header_state.is_if_transition_block() || bl.trx_blk_context.proposed_fin_pol_block_num.has_value();
    });
    if (transition_block)
       return -1;
@@ -5359,8 +5307,8 @@ int64_t controller_impl::set_proposed_producers_legacy( vector<producer_authorit
    return version;
 }
 
-void controller::set_proposed_finalizers( finalizer_policy&& fin_pol ) {
-   my->set_proposed_finalizers(std::move(fin_pol));
+void controller::apply_trx_block_context(trx_block_context& trx_blk_context) {
+   my->apply_trx_block_context(trx_blk_context);
 }
 
 // called from net threads

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -61,7 +61,7 @@ struct building_block_input {
 // this struct can be extracted from a building block
 struct block_header_state_input : public building_block_input {
    digest_type                       transaction_mroot;    // Comes from std::get<checksum256_type>(building_block::trx_mroot_or_receipt_digests)
-   std::shared_ptr<proposer_policy>  new_proposer_policy;  // Comes from building_block::new_proposer_policy
+   std::optional<proposer_policy>    new_proposer_policy;  // Comes from building_block::new_proposer_policy
    std::optional<finalizer_policy>   new_finalizer_policy; // Comes from building_block::new_finalizer_policy
    qc_claim_t                        most_recent_ancestor_with_qc; // Comes from traversing branch from parent and calling get_best_qc()
    digest_type                       finality_mroot_claim;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -40,6 +40,8 @@ namespace eosio::chain {
    using chainbase::pinnable_mapped_file;
    using boost::signals2::signal;
 
+   class transaction_context;
+   struct trx_block_context;
    class dynamic_global_property_object;
    class global_property_object;
    class permission_object;
@@ -327,10 +329,11 @@ namespace eosio::chain {
 
          bool is_known_unexpired_transaction( const transaction_id_type& id) const;
 
-         int64_t set_proposed_producers( vector<producer_authority> producers );
+         // called by host function
+         int64_t set_proposed_producers( transaction_context& trx_context, vector<producer_authority> producers );
 
-         // called by host function set_finalizers
-         void set_proposed_finalizers( finalizer_policy&& fin_pol );
+         void apply_trx_block_context( trx_block_context& trx_blk_context );
+
          // called from net threads
          void process_vote_message( uint32_t connection_id, const vote_message_ptr& msg );
          // thread safe, for testing

--- a/libraries/chain/include/eosio/chain/finality/instant_finality_extension.hpp
+++ b/libraries/chain/include/eosio/chain/finality/instant_finality_extension.hpp
@@ -13,7 +13,7 @@ struct instant_finality_extension : fc::reflect_init {
    instant_finality_extension() = default;
    instant_finality_extension(qc_claim_t qc_claim,
                               std::optional<finalizer_policy> new_finalizer_policy,
-                              std::shared_ptr<proposer_policy> new_proposer_policy) :
+                              std::optional<proposer_policy> new_proposer_policy) :
       qc_claim(qc_claim),
       new_finalizer_policy(std::move(new_finalizer_policy)),
       new_proposer_policy(std::move(new_proposer_policy))
@@ -27,7 +27,7 @@ struct instant_finality_extension : fc::reflect_init {
 
    qc_claim_t                         qc_claim;
    std::optional<finalizer_policy>    new_finalizer_policy;
-   std::shared_ptr<proposer_policy>   new_proposer_policy;
+   std::optional<proposer_policy>     new_proposer_policy;
 };
 
 } /// eosio::chain

--- a/libraries/chain/include/eosio/chain/global_property_object.hpp
+++ b/libraries/chain/include/eosio/chain/global_property_object.hpp
@@ -90,10 +90,6 @@ namespace eosio::chain {
       chain_config                        configuration;
       chain_id_type                       chain_id;
       wasm_config                         wasm_configuration;
-      // Note: proposed_fin_pol_block_num and proposed_fin_pol are used per block
-      //       and reset after uses. They do not need to be stored in snapshots.
-      std::optional<block_num_type>       proposed_fin_pol_block_num;
-      finalizer_policy                    proposed_fin_pol;
 
       // For snapshot_global_property_object_v2 and initialize_from( const T& legacy )
       template<typename T>
@@ -115,10 +111,6 @@ namespace eosio::chain {
          } else {
             wasm_configuration = legacy.wasm_configuration;
          }
-
-         // proposed_fin_pol_block_num and proposed_fin_pol are set to default values.
-         proposed_fin_pol_block_num = std::nullopt;
-         proposed_fin_pol = finalizer_policy{};
       }
 
       // For snapshot_global_property_object v3, v4, and v5
@@ -162,10 +154,6 @@ namespace eosio::chain {
             value.configuration = row.configuration;
             value.chain_id = row.chain_id;
             value.wasm_configuration = row.wasm_configuration;
-            // Snapshot does not contain proposed_fin_pol_block_num and proposed_fin_pol.
-            // Return their default values
-            value.proposed_fin_pol_block_num = std::nullopt;
-            value.proposed_fin_pol = finalizer_policy{};
          }
       };
    }

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -835,7 +835,7 @@ namespace eosio::chain {
       if (producers.empty())
          return -1; // INSTANT_FINALITY depends on DISALLOW_EMPTY_PRODUCER_SCHEDULE
 
-      EOS_ASSERT(producers.size() <= config::max_proposers, wasm_execution_error,
+      EOS_ASSERT(producers.size() <= config::max_producers, wasm_execution_error,
                  "Producer schedule exceeds the maximum proposer count for this chain");
 
       trx_blk_context.proposed_schedule_block_num = control.head_block_num() + 1;

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -86,7 +86,7 @@ namespace eosio { namespace chain { namespace webassembly {
       }
       EOS_ASSERT( producers.size() == unique_producers.size(), wasm_execution_error, "duplicate producer name in producer schedule" );
 
-      return context.control.set_proposed_producers( std::move(producers) );
+      return context.control.set_proposed_producers( context.trx_context, std::move(producers) );
    }
 
    uint32_t interface::get_wasm_parameters_packed( span<char> packed_parameters, uint32_t max_version ) const {
@@ -206,7 +206,7 @@ namespace eosio { namespace chain { namespace webassembly {
                   "and less than or equal to the sum of the weights",
                   ("t", finpol.threshold)("w", weight_sum) );
 
-      context.control.set_proposed_finalizers( std::move(finpol) );
+      context.trx_context.set_proposed_finalizers( std::move(finpol) );
    }
 
    uint32_t interface::get_blockchain_parameters_packed( legacy_span<char> packed_blockchain_parameters ) const {

--- a/unittests/block_header_tests.cpp
+++ b/unittests/block_header_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_with_empty_values_test)
       header.header_extensions,
       instant_finality_extension::extension_id(),
       fc::raw::pack( instant_finality_extension{qc_claim_t{last_qc_block_num, is_last_strong_qc},
-                                                std::optional<finalizer_policy>{}, std::shared_ptr<proposer_policy>{}} )
+                                                std::optional<finalizer_policy>{}, std::optional<proposer_policy>{}} )
    );
 
    std::optional<block_header_extension> ext = header.extract_header_extension(instant_finality_extension::extension_id());
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_uniqueness_test)
       header.header_extensions,
       instant_finality_extension::extension_id(),
       fc::raw::pack( instant_finality_extension{qc_claim_t{0, false}, {std::nullopt},
-                                                std::shared_ptr<proposer_policy>{}} )
+                                                std::optional<proposer_policy>{}} )
    );
 
    std::vector<finalizer_authority> finalizers { {"test description", 50, fc::crypto::blslib::bls_public_key{"PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q" }} };
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_uniqueness_test)
    emplace_extension(
       header.header_extensions,
       instant_finality_extension::extension_id(),
-      fc::raw::pack( instant_finality_extension{qc_claim_t{100, true}, new_finalizer_policy, new_proposer_policy} )
+      fc::raw::pack( instant_finality_extension{qc_claim_t{100, true}, new_finalizer_policy, *new_proposer_policy} )
    );
    
    BOOST_CHECK_THROW(header.validate_and_extract_header_extensions(), invalid_block_header_extension);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(instant_finality_extension_with_values_test)
    emplace_extension(
       header.header_extensions,
       instant_finality_extension::extension_id(),
-      fc::raw::pack( instant_finality_extension{qc_claim_t{last_qc_block_num, is_strong_qc}, new_finalizer_policy, new_proposer_policy} )
+      fc::raw::pack( instant_finality_extension{qc_claim_t{last_qc_block_num, is_strong_qc}, new_finalizer_policy, *new_proposer_policy} )
    );
 
    std::optional<block_header_extension> ext = header.extract_header_extension(instant_finality_extension::extension_id());


### PR DESCRIPTION
The chainbase `global_property_object` was used to store `finalizer_policy` during block construction as a means to provide automatic rollback if the transaction/block failed. See https://github.com/AntelopeIO/spring/pull/99. However, `finalizer_policy` contains non-shared types of `std::vector` and `fc::crypto::blslib::bls_public_key`. 

This PR solves the problem of avoiding side-effects of proposed finalizer policy made in an aborted transaction in a different way than committing the speculative changes into the `global_property_object` in `chainbase`. Now we store the speculative changes in the transaction context. Then if we commit the transaction, it copies them over (assuming they are not nullopt) from the transaction context to the building block. This avoids having to add a shared version of the `finalizer_policy` and `bls_public_key`. 

For symmetry, the proposer schedule in Savanna was modified to also be managed the same way as `finalier_policy` in `transaction_context`.

This PR removes  `proposed_fin_pol_block_num` and `proposed_fin_pol` from `global_property_object` and therefore is not state compatible with previous versions. The proposed schedule `proposed_schedule_block_num` & `proposed_schedule` were not removed from `global_property_object` because they are still needed pre-Savanna.

Note PR #188 targets `main`. `main` includes producer and finalizer diffs. This is a cherry-pick of #188 with additional changes to fix merge conflicts.

Resolves #182 