### PR TITLE
don't access used item in vector to avoid a `nodiscard` warning

### DIFF
--- a/unittests/svnn_ibc_tests.cpp
+++ b/unittests/svnn_ibc_tests.cpp
@@ -755,7 +755,7 @@ BOOST_AUTO_TEST_SUITE(svnn_ibc)
 
       // since heavy_proof_4 requires finalizer policy generation #2, we cannot prove it yet.
       try {
-         cluster.node0.push_action("ibc"_n, "checkproof"_n, "ibc"_n, heavy_proof_4)->action_traces[0];
+         cluster.node0.push_action("ibc"_n, "checkproof"_n, "ibc"_n, heavy_proof_4);
       }
       catch(const eosio_assert_message_exception& e){
          last_action_failed = true;


### PR DESCRIPTION
Calling `operator[]` on this vector and then doing nothing with the result gives a
```
warning: ignoring return value of function declared with 'nodiscard' attribute
```