### PR TITLE
Update eosio.prods auth under savanna

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4253,44 +4253,38 @@ struct controller_impl {
    }
 
    void update_producers_authority() {
+      auto& bb = std::get<building_block>(pending->_block_stage);
+      const auto& producers = bb.active_producers().producers;
 
-      auto update_producers_auth = [&](const vector<producer_authority>& producers) {
-         auto update_permission = [&](auto& permission, auto threshold) {
-            auto auth = authority(threshold, {}, {});
-            for (auto& p : producers) {
-               auth.accounts.push_back({
-                  {p.producer_name, config::active_name},
-                  1
-               });
-            }
+      auto update_permission = [&](auto& permission, auto threshold) {
+         auto auth = authority(threshold, {}, {});
+         for (auto& p : producers) {
+            auth.accounts.push_back({
+               {p.producer_name, config::active_name},
+               1
+            });
+         }
 
-            if (permission.auth != auth) {
-               db.modify(permission, [&](auto& po) { po.auth = auth; });
-            }
-         };
-
-         uint32_t num_producers       = producers.size();
-         auto     calculate_threshold = [=](uint32_t numerator, uint32_t denominator) {
-            return ((num_producers * numerator) / denominator) + 1;
-         };
-
-         update_permission(authorization.get_permission({config::producers_account_name, config::active_name}),
-                           calculate_threshold(2, 3) /* more than two-thirds */);
-
-         update_permission(
-            authorization.get_permission({config::producers_account_name, config::majority_producers_permission_name}),
-            calculate_threshold(1, 2) /* more than one-half */);
-
-         update_permission(
-            authorization.get_permission({config::producers_account_name, config::minority_producers_permission_name}),
-            calculate_threshold(1, 3) /* more than one-third */);
-
-         // TODO: Add tests
+         if (permission.auth != auth) {
+            db.modify(permission, [&](auto& po) { po.auth = auth; });
+         }
       };
 
-      // this is not called when hotstuff is activated
-      auto& bb = std::get<building_block>(pending->_block_stage);
-      update_producers_auth(bb.active_producers().producers);
+      uint32_t num_producers       = producers.size();
+      auto     calculate_threshold = [=](uint32_t numerator, uint32_t denominator) {
+         return ((num_producers * numerator) / denominator) + 1;
+      };
+
+      update_permission(authorization.get_permission({config::producers_account_name, config::active_name}),
+                        calculate_threshold(2, 3) /* more than two-thirds */);
+
+      update_permission(
+         authorization.get_permission({config::producers_account_name, config::majority_producers_permission_name}),
+         calculate_threshold(1, 2) /* more than one-half */);
+
+      update_permission(
+         authorization.get_permission({config::producers_account_name, config::minority_producers_permission_name}),
+         calculate_threshold(1, 3) /* more than one-third */);
    }
 
    void create_block_summary(const block_id_type& id) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4253,12 +4253,8 @@ struct controller_impl {
    }
 
    void update_producers_authority() {
-      // this is not called when hotstuff is activated
-      auto& bb = std::get<building_block>(pending->_block_stage);
-      bb.apply_l<void>([this](building_block::building_block_legacy& legacy_header) {
-         pending_block_header_state_legacy& pbhs = legacy_header.pending_block_header_state;
-         const auto& producers = pbhs.active_schedule.producers;
 
+      auto update_producers_auth = [&](const vector<producer_authority>& producers) {
          auto update_permission = [&](auto& permission, auto threshold) {
             auto auth = authority(threshold, {}, {});
             for (auto& p : producers) {
@@ -4290,7 +4286,11 @@ struct controller_impl {
             calculate_threshold(1, 3) /* more than one-third */);
 
          // TODO: Add tests
-      });
+      };
+
+      // this is not called when hotstuff is activated
+      auto& bb = std::get<building_block>(pending->_block_stage);
+      update_producers_auth(bb.active_producers().producers);
    }
 
    void create_block_summary(const block_id_type& id) {

--- a/unittests/producer_schedule_if_tests.cpp
+++ b/unittests/producer_schedule_if_tests.cpp
@@ -1,4 +1,5 @@
 #include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/authorization_manager.hpp>
 #include <eosio/testing/tester.hpp>
 
 #include <boost/test/unit_test.hpp>
@@ -26,11 +27,24 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule_after_instant_finality_activat
       const uint32_t check_duration = 100; // number of blocks
       bool scheduled_changed_to_new = false;
       for (uint32_t i = 0; i < check_duration; ++i) {
-         const auto current_schedule = control->active_producers();
-         if (new_prod_schd == current_schedule.producers) {
+         const auto current_schedule = control->active_producers().producers;
+         if (new_prod_schd == current_schedule) {
             scheduled_changed_to_new = true;
             if (expected_block_num != 0)
                BOOST_TEST(control->head_block_num() == expected_block_num);
+
+            // verify eosio.prods updated
+            const name usr = config::producers_account_name;
+            const name active_permission = config::active_name;
+            const auto* perm = control->db().template find<permission_object, by_owner>(boost::make_tuple(usr, active_permission));
+            for (auto account : perm->auth.accounts) {
+               auto act = account.permission.actor;
+               auto itr = std::find_if( current_schedule.begin(), current_schedule.end(), [&](const auto& p) {
+                  return p.producer_name == act;
+               });
+               bool found = itr != current_schedule.end();
+               BOOST_TEST(found);
+            }
          }
 
          auto b = produce_block();
@@ -38,7 +52,7 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule_after_instant_finality_activat
 
          // Check if the producer is the same as what we expect
          const auto block_time = control->head_block_time();
-         const auto& expected_producer = get_expected_producer(current_schedule.producers, block_time);
+         const auto& expected_producer = get_expected_producer(current_schedule, block_time);
          BOOST_TEST(control->head_block_producer() == expected_producer);
 
          if (scheduled_changed_to_new)

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -1,4 +1,5 @@
 #include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/authorization_manager.hpp>
 #include <eosio/testing/tester.hpp>
 
 #include <boost/test/unit_test.hpp>
@@ -31,6 +32,18 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, validating_tester ) try {
          const auto current_schedule = control->active_producers().producers;
          if (new_prod_schd == current_schedule) {
             scheduled_changed_to_new = true;
+            // verify eosio.prods updated
+            const name usr = config::producers_account_name;
+            const name active_permission = config::active_name;
+            const auto* perm = control->db().template find<permission_object, by_owner>(boost::make_tuple(usr, active_permission));
+            for (auto account : perm->auth.accounts) {
+               auto act = account.permission.actor;
+               auto itr = std::find_if( current_schedule.begin(), current_schedule.end(), [&](const auto& p) {
+                  return p.producer_name == act;
+               });
+               bool found = itr != current_schedule.end();
+               BOOST_TEST(found);
+            }
          }
 
          // Produce block


### PR DESCRIPTION
Producer authority `eosio.prods` was not being updated under Savanna. 
Multisigs failed (see #169) because the producer authorities were not updated when the producer schedule changed.

Partly resolves #169 