### PR TITLE
Fix terminate-at-block for transition blocks

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4127,6 +4127,7 @@ struct controller_impl {
             try {
                apply_block( br, new_head, s, trx_lookup );
             } catch ( const std::exception& e ) {
+               wlog("Exception during apply block: ${e}", ("e", e.what()));
                forkdb.remove( new_head->id() );
                throw;
             }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1456,7 +1456,7 @@ struct controller_impl {
 
             for( auto bitr = branch.rbegin(); bitr != branch.rend() && should_process(*bitr); ++bitr ) {
                if (!apply_irreversible_block(forkdb, *bitr))
-                  break;
+                  return;
 
                emit( irreversible_block, std::tie((*bitr)->block, (*bitr)->id()), __FILE__, __LINE__ );
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1481,9 +1481,15 @@ struct controller_impl {
                   break;
                }
             }
-         } catch( std::exception& ) {
-            if( root_id != forkdb.root()->id() ) {
-               forkdb.advance_root( root_id );
+         } catch( const std::exception& e ) {
+            try {
+               if (root_id != forkdb.root()->id()) {
+                  forkdb.advance_root(root_id);
+               }
+            } catch( const fc::exception& e2 ) {
+               elog("Caught exception ${e2}, while processing exception ${e}", ("e2", e2.to_detail_string())("e", e.what()));
+            } catch( const std::exception& e2 ) {
+               elog("Caught exception ${e2}, while processing exception ${e}", ("e2", e2.what())("e", e.what()));
             }
             throw;
          }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1456,7 +1456,7 @@ struct controller_impl {
 
             for( auto bitr = branch.rbegin(); bitr != branch.rend() && should_process(*bitr); ++bitr ) {
                if (!apply_irreversible_block(forkdb, *bitr))
-                  return;
+                  continue;
 
                emit( irreversible_block, std::tie((*bitr)->block, (*bitr)->id()), __FILE__, __LINE__ );
 


### PR DESCRIPTION
Fix `terminate-at-block` option to work for transition blocks.

Resolves #216 