### PR TITLE
don't `include_root_t` for `controller::fetch_block_id_on_head_branch_by_num()`

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1139,7 +1139,7 @@ struct controller_impl {
 
    std::optional<block_id_type> fetch_block_id_on_head_branch_by_num(uint32_t block_num) const {
       return fork_db.apply<std::optional<block_id_type>>([&](const auto& forkdb) -> std::optional<block_id_type> {
-         auto bsp = forkdb.search_on_head_branch(block_num, include_root_t::yes);
+         auto bsp = forkdb.search_on_head_branch(block_num);
          if (bsp) return bsp->id();
          return {};
       });


### PR DESCRIPTION
I'm suspicious that this call should not `include_root_t::yes` because doing so can cause the forkdb to return a block that does not match the block number requested, which is causing a ship test malfunction. Unfortunately it's not entirely clear to me what other side effects switching this will cause; though all tests do pass :innocent: 

Consider a forkdb that is rooted at block 300, has a head that is 300, and no block log exists, something calls `get_block_id_for_num(299)`
https://github.com/AntelopeIO/spring/blob/2b1228eba2bc87c34be6269b21e7085e94d466a5/libraries/chain/controller.cpp#L5201-L5208
so,
https://github.com/AntelopeIO/spring/blob/2b1228eba2bc87c34be6269b21e7085e94d466a5/libraries/chain/controller.cpp#L1140-L1142
ultimately,
https://github.com/AntelopeIO/spring/blob/2b1228eba2bc87c34be6269b21e7085e94d466a5/libraries/chain/fork_database.cpp#L532-L534
notice above that the first parameter will be the block id for block 300. then,
https://github.com/AntelopeIO/spring/blob/2b1228eba2bc87c34be6269b21e7085e94d466a5/libraries/chain/fork_database.cpp#L513-L516
since `root == head && include_root_t` the block id for block 300 will be returned. But we asked for block 299!