### PR TITLE
Change reference contracts target back to main

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -4,6 +4,6 @@
        "prerelease":true
     },
     "referencecontracts":{
-       "ref":"fix_failures_by_default_tester"
+       "ref":"main"
     }
  }


### PR DESCRIPTION
Reference contracts change for default libtester PR https://github.com/AntelopeIO/reference-contracts/pull/95 has been merged. Change reference contracts target back to `main`.