### PR TITLE
check root block num before returning it when `include_root_t::yes`

### DIFF
--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -511,7 +511,7 @@ namespace eosio::chain {
 
    template<class BSP>
    BSP fork_database_impl<BSP>::search_on_branch_impl( const block_id_type& h, uint32_t block_num, include_root_t include_root ) const {
-      if( include_root == include_root_t::yes && root->id() == h ) {
+      if( include_root == include_root_t::yes && root->id() == h && root->block_num() == block_num ) {
          return root;
       }
 


### PR DESCRIPTION
Without this change it's possible for forkdb to return a block that does not match the block number requested which is causing a ship test malfunction.

Consider a forkdb that is rooted at block 300, has a head that is 300, and no block log exists, something calls `get_block_id_for_num(299)`
https://github.com/AntelopeIO/spring/blob/2b1228eba2bc87c34be6269b21e7085e94d466a5/libraries/chain/controller.cpp#L5201-L5208
so,
https://github.com/AntelopeIO/spring/blob/2b1228eba2bc87c34be6269b21e7085e94d466a5/libraries/chain/controller.cpp#L1140-L1142
ultimately,
https://github.com/AntelopeIO/spring/blob/2b1228eba2bc87c34be6269b21e7085e94d466a5/libraries/chain/fork_database.cpp#L532-L534
notice above that the first parameter will be the block id for block 300. then,
https://github.com/AntelopeIO/spring/blob/2b1228eba2bc87c34be6269b21e7085e94d466a5/libraries/chain/fork_database.cpp#L513-L516
since `root == head && include_root_t` the block id for block 300 will be returned. But we asked for block 299!