### PR TITLE
[1.0-beta2] Fix terminate-at-block for transition block

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1353,6 +1353,8 @@ struct controller_impl {
    void transition_to_savanna() {
       assert(chain_head.header().contains_header_extension(instant_finality_extension::extension_id()));
       // copy head branch from legacy forkdb legacy to savanna forkdb
+      if (check_shutdown())
+         return;
       fork_database_legacy_t::branch_t legacy_branch;
       block_state_legacy_ptr legacy_root;
       fork_db.apply_l<void>([&](const auto& forkdb) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1332,6 +1332,7 @@ struct controller_impl {
                transition_add_to_savanna_fork_db(forkdb, legacy, bsp, prev);
                return true;
             }
+            fork_db.switch_to(fork_database::in_use_t::legacy);
             return false;
          });
       }

--- a/tests/nodeos_read_terminate_at_block_test.py
+++ b/tests/nodeos_read_terminate_at_block_test.py
@@ -146,10 +146,13 @@ def getBlockNumInfo(testNode):
     head = None
     lib = None
 
+    retries = 20
     while True:
         info = testNode.getInfo()
 
-        if not info:
+        if not info and retries > 0:
+            time.sleep(0.5)
+            retries -= 1
             continue
 
         try:

--- a/tests/nodeos_read_terminate_at_block_test.py
+++ b/tests/nodeos_read_terminate_at_block_test.py
@@ -19,9 +19,9 @@ errorExit = Utils.errorExit
 cmdError = Utils.cmdError
 relaunchTimeout = 10
 numOfProducers = 1
-# One producing node, three regular terminate-at-block nodes, and three nodes
+# One producing node, four regular terminate-at-block nodes, and three nodes
 # where replay snapshot through block logs with terminate-at-block
-totalNodes = 7
+totalNodes = 8
 
 # Parse command line arguments
 args = TestHelper.parse_args({
@@ -226,12 +226,13 @@ try:
     regularNodeosArgs = {
         1 : "--read-mode irreversible --terminate-at-block 75",
         2 : "--read-mode head --terminate-at-block 100",
-        3 : "--read-mode speculative --terminate-at-block 125"
+        3 : "--read-mode speculative --terminate-at-block 125",
+        4 : "--read-mode irreversible --terminate-at-block 155"
     }
     replayNodeosArgs = {
-        4 : "--read-mode irreversible",
-        5 : "--read-mode head",
-        6 : "--read-mode speculative"
+        5 : "--read-mode irreversible",
+        6 : "--read-mode head",
+        7 : "--read-mode speculative"
     }
 
     # combine all together


### PR DESCRIPTION
- Do not switch fork database to savanna unless irreversible apply completes otherwise fork database is left in an inconsistent state.
- Add another test case to `tests/nodeos_read_terminate_at_block_test.py` for terminate after savanna transition in irreversible mode.

Resolves #216 