### PR TITLE
[1.0-beta2 -> main] P2P: Send handshake when in lib_catchup and verify catchup is called

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2393,8 +2393,10 @@ namespace eosio {
                      ("ne", sync_next_expected_num)("id", id.str().substr( 8, 16 )) );
          }
          auto chain_info = my_impl->get_chain_info();
-         if( sync_state == lib_catchup || num < chain_info.lib_num )
+         if( sync_state == lib_catchup || num < chain_info.lib_num ) {
+            c->send_handshake();
             return false;
+         }
          set_state( head_catchup );
          {
             fc::lock_guard g_conn( c->conn_mtx );


### PR DESCRIPTION
Instead of ignoring a verify catchup while in `lib_catchup`, send handshake to peer. Should avoid the peer thinking it is still syncing from it.

Merges `release/1.0-beta2` into `main` including #241 

Resolves #224 
