### PR TITLE
[1.0-beta2] Fix fork_database add with mark_valid

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1460,8 +1460,10 @@ struct controller_impl {
             auto it = v.begin();
 
             for( auto bitr = branch.rbegin(); bitr != branch.rend() && should_process(*bitr); ++bitr ) {
-               if (!apply_irreversible_block(forkdb, *bitr))
+               if (!apply_irreversible_block(forkdb, *bitr)) {
+                  root_id = forkdb.root()->id();
                   break;
+               }
 
                emit( irreversible_block, std::tie((*bitr)->block, (*bitr)->id()), __FILE__, __LINE__ );
 

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -355,9 +355,8 @@ namespace eosio::chain {
       }
 
       auto inserted = index.insert(n);
-      if( !inserted.second && ignore_duplicate != ignore_duplicate_t::yes ) {
-         EOS_THROW(fork_database_exception, "duplicate block added: ${id}", ("id", n->id()));
-      }
+      EOS_ASSERT(ignore_duplicate == ignore_duplicate_t::yes || inserted.second, fork_database_exception,
+                 "duplicate block added: ${id}", ("id", n->id()));
 
       if (mark_valid == mark_valid_t::yes) {
          // if just inserted and was inserted already valid then no update needed

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -121,7 +121,7 @@ namespace eosio::chain {
 
       explicit fork_database_impl() = default;
 
-      void             open_impl( const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator );
+      void             open_impl( const char* desc, const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator );
       void             close_impl( std::ofstream& out );
       void             add_impl( const bsp_t& n, mark_valid_t mark_valid, ignore_duplicate_t ignore_duplicate, bool validate, validator_t& validator );
       bool             is_valid() const;
@@ -153,13 +153,13 @@ namespace eosio::chain {
    fork_database_t<BSP>::~fork_database_t() = default; // close is performed in fork_database::~fork_database()
 
    template<class BSP>
-   void fork_database_t<BSP>::open( const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator ) {
+   void fork_database_t<BSP>::open( const char* desc, const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator ) {
       std::lock_guard g( my->mtx );
-      my->open_impl( fork_db_file, ds, validator );
+      my->open_impl( desc, fork_db_file, ds, validator );
    }
 
    template<class BSP>
-   void fork_database_impl<BSP>::open_impl( const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator ) {
+   void fork_database_impl<BSP>::open_impl( const char* desc, const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator ) {
       bsp_t _root = std::make_shared<bs_t>();
       fc::raw::unpack( ds, *_root );
       reset_root_impl( _root );
@@ -182,20 +182,20 @@ namespace eosio::chain {
          if (!head)
             std::filesystem::remove( fork_db_file );
          EOS_ASSERT( head, fork_database_exception,
-                     "could not find head while reconstructing fork database from file; "
+                     "could not find head while reconstructing fork database from file; ${d} "
                      "'${filename}' is likely corrupted and has been removed",
-                     ("filename", fork_db_file) );
+                     ("d", desc)("filename", fork_db_file) );
       }
 
       auto candidate = index.template get<by_best_branch>().begin();
       if( candidate == index.template get<by_best_branch>().end() || !bs_accessor_t::is_valid(**candidate) ) {
          EOS_ASSERT( head->id() == root->id(), fork_database_exception,
-                     "head not set to root despite no better option available; '${filename}' is likely corrupted",
-                     ("filename", fork_db_file) );
+                     "head not set to root despite no better option available; ${d} '${filename}' is likely corrupted",
+                     ("d", desc)("filename", fork_db_file) );
       } else {
          EOS_ASSERT( !first_preferred( **candidate, *head ), fork_database_exception,
-                     "head not set to best available option available; '${filename}' is likely corrupted",
-                     ("filename", fork_db_file) );
+                     "head not set to the best available option available; ${d} '${filename}' is likely corrupted",
+                     ("d", desc)("filename", fork_db_file) );
       }
    }
 
@@ -786,7 +786,7 @@ namespace eosio::chain {
             {
                // ---------- pre-Savanna format. Just a single fork_database_l ----------------
                in_use = in_use_t::legacy;
-               fork_db_l.open(fork_db_file, ds, validator);
+               fork_db_l.open("legacy", fork_db_file, ds, validator);
                break;
             }
 
@@ -800,13 +800,13 @@ namespace eosio::chain {
                bool legacy_valid { false };
                fc::raw::unpack( ds, legacy_valid );
                if (legacy_valid) {
-                  fork_db_l.open(fork_db_file, ds, validator);
+                  fork_db_l.open("legacy", fork_db_file, ds, validator);
                }
 
                bool savanna_valid { false };
                fc::raw::unpack( ds, savanna_valid );
                if (savanna_valid) {
-                  fork_db_s.open(fork_db_file, ds, validator);
+                  fork_db_s.open("savanna", fork_db_file, ds, validator);
                }
                break;
             }

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -46,7 +46,7 @@ namespace eosio::chain {
       explicit fork_database_t();
       ~fork_database_t();
 
-      void open( const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator );
+      void open( const char* desc, const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator );
       void close( std::ofstream& out );
 
       bsp_t get_block( const block_id_type& id, include_root_t include_root = include_root_t::no ) const;

--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -40,6 +40,10 @@ struct block_state_accessor {
       bsp->core = prev->core.next(parent_block, prev->core.latest_qc_claim());
       return bsp;
    }
+
+   static void reset_valid(block_state_ptr& bsp) {
+      bsp->validated.store(false);
+   }
 };
 
 } // namespace eosio::chain
@@ -72,21 +76,24 @@ BOOST_AUTO_TEST_CASE(add_remove_test) try {
    // keep track of all those added for easy verification
    std::vector<block_state_ptr> all { bsp11a, bsp12a, bsp13a, bsp11b, bsp12b, bsp12bb, bsp12bbb, bsp13b, bsp13bb, bsp13bbb, bsp14b, bsp11c, bsp12c, bsp13c };
 
-   forkdb.reset_root(root);
-   forkdb.add(bsp11a, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp11b, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp11c, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12a, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13a, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12b, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12bb, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12bbb, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12c, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13b, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13bb, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13bbb, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp14b, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13c, mark_valid_t::no, ignore_duplicate_t::no);
+   auto reset = [&]() {
+      forkdb.reset_root(root);
+      forkdb.add(bsp11a, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp11b, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp11c, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12a, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13a, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12b, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12bb, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12bbb, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12c, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13b, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13bb, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13bbb, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp14b, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13c, mark_valid_t::no, ignore_duplicate_t::no);
+   };
+   reset();
 
    // test get_block
    for (auto& i : all) {
@@ -127,6 +134,13 @@ BOOST_AUTO_TEST_CASE(add_remove_test) try {
    BOOST_REQUIRE(branch.size() == 2);
    BOOST_TEST(branch[0] == bsp12a);
    BOOST_TEST(branch[1] == bsp11a);
+
+   // test mark valid via add
+   block_state_accessor::reset_valid(bsp13a);
+   reset();
+   BOOST_TEST(forkdb.head()->id() == root->id());
+   forkdb.add(bsp13a, mark_valid_t::yes, ignore_duplicate_t::yes);
+   BOOST_TEST(forkdb.head()->id() == bsp13a->id());
 
 } FC_LOG_AND_RETHROW();
 


### PR DESCRIPTION
Fork database `add` with `mark_valid` would not mark the `block_state` validated if the fork database already contained the `block_state`. This PR fixes that which also fixes `terminate-at-block` unable to remove error `removing the block and its descendants would remove the current head block` during a transition.

Resolves #216 