### PR TITLE
[1.0-beta2] Test: Allow time for blocks to reach snapshot node

### DIFF
--- a/tests/nodeos_chainbase_allocation_test.py
+++ b/tests/nodeos_chainbase_allocation_test.py
@@ -80,7 +80,7 @@ try:
     producerNode.kill(signal.SIGTERM)
 
     # wait for all blocks to arrive and be processed by irrNode
-    time.sleep(1)
+    time.sleep(3)
 
     # Create the snapshot and rename it to avoid name conflict later on
     res = irrNode.createSnapshot()

--- a/tests/nodeos_chainbase_allocation_test.py
+++ b/tests/nodeos_chainbase_allocation_test.py
@@ -79,6 +79,9 @@ try:
 
     producerNode.kill(signal.SIGTERM)
 
+    # wait for all blocks to arrive and be processed by irrNode
+    time.sleep(1)
+
     # Create the snapshot and rename it to avoid name conflict later on
     res = irrNode.createSnapshot()
     beforeShutdownSnapshotPath = res["payload"]["snapshot_name"]


### PR DESCRIPTION
Update test to allow time for blocks to reach and be processed by the irreversible node before creating snapshot.

Resolves #246 