### PR TITLE
[1.0-beta2 -> main] Fix fork_database add with mark_valid

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1323,15 +1323,17 @@ struct controller_impl {
          return fork_db.apply_l<bool>([&](const auto& forkdb_l) {
             block_state_legacy_ptr legacy = forkdb_l.get_block(bsp->id());
             fork_db.switch_to(fork_database::in_use_t::legacy); // apply block uses to know what types to create
+            block_state_ptr prev = forkdb.get_block(legacy->previous(), include_root_t::yes);
+            assert(prev);
             if( apply_block(br, legacy, controller::block_status::complete, trx_meta_cache_lookup{}) ) {
                fc::scoped_exit<std::function<void()>> e([&]{fork_db.switch_to(fork_database::in_use_t::both);});
                // irreversible apply was just done, calculate new_valid here instead of in transition_to_savanna()
                assert(legacy->action_mroot_savanna);
-               block_state_ptr prev = forkdb.get_block(legacy->previous(), include_root_t::yes);
-               assert(prev);
                transition_add_to_savanna_fork_db(forkdb, legacy, bsp, prev);
                return true;
             }
+            // add to forkdb as it expects root != head
+            transition_add_to_savanna_fork_db(forkdb, legacy, bsp, prev);
             fork_db.switch_to(fork_database::in_use_t::legacy);
             return false;
          });

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -46,7 +46,7 @@ namespace eosio::chain {
       explicit fork_database_t();
       ~fork_database_t();
 
-      void open( const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator );
+      void open( const char* desc, const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator );
       void close( std::ofstream& out );
 
       bsp_t get_block( const block_id_type& id, include_root_t include_root = include_root_t::no ) const;

--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -40,6 +40,10 @@ struct block_state_accessor {
       bsp->core = prev->core.next(parent_block, prev->core.latest_qc_claim());
       return bsp;
    }
+
+   static void reset_valid(block_state_ptr& bsp) {
+      bsp->validated.store(false);
+   }
 };
 
 } // namespace eosio::chain
@@ -72,21 +76,24 @@ BOOST_AUTO_TEST_CASE(add_remove_test) try {
    // keep track of all those added for easy verification
    std::vector<block_state_ptr> all { bsp11a, bsp12a, bsp13a, bsp11b, bsp12b, bsp12bb, bsp12bbb, bsp13b, bsp13bb, bsp13bbb, bsp14b, bsp11c, bsp12c, bsp13c };
 
-   forkdb.reset_root(root);
-   forkdb.add(bsp11a, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp11b, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp11c, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12a, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13a, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12b, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12bb, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12bbb, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp12c, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13b, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13bb, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13bbb, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp14b, mark_valid_t::no, ignore_duplicate_t::no);
-   forkdb.add(bsp13c, mark_valid_t::no, ignore_duplicate_t::no);
+   auto reset = [&]() {
+      forkdb.reset_root(root);
+      forkdb.add(bsp11a, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp11b, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp11c, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12a, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13a, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12b, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12bb, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12bbb, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp12c, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13b, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13bb, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13bbb, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp14b, mark_valid_t::no, ignore_duplicate_t::no);
+      forkdb.add(bsp13c, mark_valid_t::no, ignore_duplicate_t::no);
+   };
+   reset();
 
    // test get_block
    for (auto& i : all) {
@@ -127,6 +134,13 @@ BOOST_AUTO_TEST_CASE(add_remove_test) try {
    BOOST_REQUIRE(branch.size() == 2);
    BOOST_TEST(branch[0] == bsp12a);
    BOOST_TEST(branch[1] == bsp11a);
+
+   // test mark valid via add
+   block_state_accessor::reset_valid(bsp13a);
+   reset();
+   BOOST_TEST(forkdb.head()->id() == root->id());
+   forkdb.add(bsp13a, mark_valid_t::yes, ignore_duplicate_t::yes);
+   BOOST_TEST(forkdb.head()->id() == bsp13a->id());
 
 } FC_LOG_AND_RETHROW();
 


### PR DESCRIPTION
Fork database `add` with `mark_valid` would not mark the `block_state` validated if the fork database already contained the `block_state`. This PR fixes that which also fixes `terminate-at-block` unable to remove error `removing the block and its descendants would remove the current head block` during a transition.

Merges `release/1.0-beta2` into `main` including #252 

Resolves #216 