### PR TITLE
Test: Remove production of unneeded blocks

### DIFF
--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -42,7 +42,7 @@ BOOST_FIXTURE_TEST_CASE(newaccount_test, validating_tester) { try {
         aq_db.commit_block( block );
    });
 
-   produce_blocks(10);
+   produce_block();
 
    account_name tester_account = "tester"_n;
    const auto trace_ptr =  create_account(tester_account);
@@ -68,7 +68,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, validating_tester) { try {
         aq_db.commit_block( block );
     });
 
-    produce_blocks(10);
+    produce_block();
 
    const auto& tester_account = "tester"_n;
    const string role = "first";
@@ -103,7 +103,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test_multi_threaded, validating_tester) { try
       aq_db.commit_block( block );
    });
 
-   produce_blocks(10);
+   produce_block();
 
    const auto tester_account = "tester"_n;
    const string role = "first";

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -36,7 +36,7 @@ static auto get_account_full = [](chain_apis::read_only& plugin,
 BOOST_AUTO_TEST_SUITE(chain_plugin_tests)
 
 BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
-   produce_blocks(2);
+   produce_block();
 
    create_accounts( {"asserter"_n} );
    produce_block();
@@ -44,7 +44,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
    // setup contract and abi
    set_code( "asserter"_n, test_contracts::asserter_wasm() );
    set_abi( "asserter"_n, test_contracts::asserter_abi() );
-   produce_blocks(1);
+   produce_block();
 
    auto resolver = [&,this]( const account_name& name ) -> std::optional<abi_serializer> {
       try {
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
 } FC_LOG_AND_RETHROW() //get_consensus_parameters
 
 BOOST_FIXTURE_TEST_CASE( get_account, validating_tester ) try {
-   produce_blocks(2);
+   produce_block();
 
    std::vector<account_name> accs{{ "alice"_n, "bob"_n, "cindy"_n}};
    create_accounts(accs, false, false);

--- a/tests/get_producers_tests.cpp
+++ b/tests/get_producers_tests.cpp
@@ -29,12 +29,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, T, testers ) { try {
       BOOST_REQUIRE(row.contains("producer_authority"));
 
 
-      chain.produce_blocks(2);
+      chain.produce_block();
 
       chain.create_accounts( {"dan"_n,"sam"_n,"pam"_n} );
       chain.produce_block();
       chain.set_producers( {"dan"_n,"sam"_n,"pam"_n} );
-      chain.produce_blocks(30);
+      chain.produce_block();
+      chain.produce_block(fc::seconds(1000));
+      chain.produce_block();
 
       results = plugin.get_producers(params, fc::time_point::maximum());
       BOOST_REQUIRE_EQUAL(results.rows.size(), 3u);

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -64,7 +64,7 @@ issue_tokens( validating_tester& t, account_name issuer, account_name to, const 
 }
 
 BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
-   produce_blocks(2);
+   produce_block();
 
    create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
       "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n });
@@ -75,7 +75,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
 
    set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
    set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
-   produce_blocks(1);
+   produce_block();
 
    // create currency
    auto act = mutable_variant_object()
@@ -87,7 +87,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("999.0000 SYS") );
    }
-   produce_blocks(1);
+   produce_block();
 
    // iterate over scope
    eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
@@ -136,7 +136,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
 } FC_LOG_AND_RETHROW() /// get_scope_test
 
 BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
-   produce_blocks(2);
+   produce_block();
 
    create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
       "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n });
@@ -147,7 +147,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
 
    set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
    set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
-   produce_blocks(1);
+   produce_block();
 
    // create currency
    auto act = mutable_variant_object()
@@ -159,7 +159,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("10000.0000 SYS") );
    }
-   produce_blocks(1);
+   produce_block();
 
    // create currency 2
    act = mutable_variant_object()
@@ -170,7 +170,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("9999.0000 AAA") );
    }
-   produce_blocks(1);
+   produce_block();
 
    // create currency 3
    act = mutable_variant_object()
@@ -181,7 +181,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("7777.0000 CCC") );
    }
-   produce_blocks(1);
+   produce_block();
 
    // create currency 3
    act = mutable_variant_object()
@@ -192,7 +192,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("8888.0000 BBB") );
    }
-   produce_blocks(1);
+   produce_block();
 
    // get table: normal case
    eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
@@ -316,7 +316,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
-   produce_blocks(2);
+   produce_block();
 
    create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
       "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n, "eosio.rex"_n });
@@ -327,7 +327,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
 
    set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
    set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
-   produce_blocks(1);
+   produce_block();
 
    // create currency
    auto act = mutable_variant_object()
@@ -339,7 +339,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("10000.0000 SYS") );
    }
-   produce_blocks(1);
+   produce_block();
 
    set_code( config::system_account_name, test_contracts::eosio_system_wasm() );
    set_abi( config::system_account_name, test_contracts::eosio_system_abi() );
@@ -362,7 +362,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
    bidname("initb"_n, "org"_n, eosio::chain::asset::from_string("11.0000 SYS"));
    bidname("initc"_n, "io"_n, eosio::chain::asset::from_string("12.0000 SYS"));
    bidname("initd"_n, "html"_n, eosio::chain::asset::from_string("14.0000 SYS"));
-   produce_blocks(1);
+   produce_block();
 
    // get table: normal case
    eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -316,7 +316,9 @@ public:
                 BOOST_CHECK_EQUAL( success(), regproducer(p) );
             }
         }
-        produce_blocks( 250);
+        produce_block();
+        produce_block(fc::seconds(1000));
+        produce_block();
 
         auto trace_auth = validating_tester::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
                 ("account", name(config::system_account_name).to_string())
@@ -342,7 +344,9 @@ public:
             )
             );
         }
-        produce_blocks( 250 );
+        produce_block();
+        produce_block(fc::seconds(1000));
+        produce_block();
 
         auto producer_keys = control->active_producers().producers;
         BOOST_CHECK_EQUAL( 21u, producer_keys.size() );
@@ -366,9 +370,9 @@ BOOST_AUTO_TEST_SUITE(test_chain_plugin_tests)
 
 BOOST_FIXTURE_TEST_CASE(account_results_total_resources_test, chain_plugin_tester) { try {
 
-    produce_blocks(10);
+    produce_block();
     setup_system_accounts();
-    produce_blocks();
+    produce_block();
     create_account_with_resources("alice1111111"_n, config::system_account_name);
     //stake more than 15% of total EOS supply to activate chain
     transfer( name("eosio"), name("alice1111111"), core_from_string("650000000.0000"), name("eosio") );
@@ -383,9 +387,9 @@ BOOST_FIXTURE_TEST_CASE(account_results_total_resources_test, chain_plugin_teste
 
 BOOST_FIXTURE_TEST_CASE(account_results_self_delegated_bandwidth_test, chain_plugin_tester) { try {
 
-    produce_blocks(10);
+    produce_block();
     setup_system_accounts();
-    produce_blocks();
+    produce_block();
     const asset nstake = core_from_string("1.0000");
     const asset cstake = core_from_string("2.0000");
     create_account_with_resources("alice1111111"_n, config::system_account_name, core_from_string("1.0000"), false);
@@ -413,9 +417,9 @@ BOOST_FIXTURE_TEST_CASE(account_results_self_delegated_bandwidth_test, chain_plu
 
 BOOST_FIXTURE_TEST_CASE(account_results_refund_request_test, chain_plugin_tester) { try {
 
-    produce_blocks(10);
+    produce_block();
     setup_system_accounts();
-    produce_blocks();
+    produce_block();
 
     setup_producer_accounts({"producer1111"_n});
     regproducer("producer1111"_n);
@@ -469,7 +473,7 @@ BOOST_FIXTURE_TEST_CASE(account_results_refund_request_test, chain_plugin_tester
 
 BOOST_FIXTURE_TEST_CASE(account_results_voter_info_test, chain_plugin_tester) { try {
 
-    produce_blocks(10);
+    produce_block();
     setup_system_accounts();
 
     create_account_with_resources("alice1111111"_n, config::system_account_name, core_from_string("1.0000"), false);
@@ -484,7 +488,7 @@ BOOST_FIXTURE_TEST_CASE(account_results_voter_info_test, chain_plugin_tester) { 
 
 BOOST_FIXTURE_TEST_CASE(account_results_rex_info_test, chain_plugin_tester) { try {
 
-    produce_blocks(10);
+    produce_block();
     setup_system_accounts();
 
     create_account_with_resources("alice1111111"_n, config::system_account_name, core_from_string("1.0000"), false);

--- a/tests/test_snapshot_information.cpp
+++ b/tests/test_snapshot_information.cpp
@@ -26,10 +26,10 @@ void test_snapshot_information() {
    const std::filesystem::path parent_path = chain.get_config().blocks_dir.parent_path();
 
    chain.create_account("snapshot"_n);
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
    chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    auto block = chain.produce_block();
    const uint32_t base_block_num = block->block_num();

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -301,10 +301,10 @@ uint32_t last_fnc_err = 0;
 BOOST_AUTO_TEST_CASE_TEMPLATE(action_receipt_tests, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_account( "test"_n );
    chain.set_code( "test"_n, test_contracts::payloadless_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    auto call_doit_and_check = [&]( account_name contract, account_name signer, auto&& checker ) {
       signed_transaction trx;
@@ -367,7 +367,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_receipt_tests, T, validating_testers) { try
       BOOST_CHECK_EQUAL( m.begin()->second, base_test_auth_seq_num + 3 );
    } );
 
-   chain.produce_blocks(1); // Added to avoid the last doit transaction from being considered a duplicate.
+   chain.produce_block(); // Added to avoid the last doit transaction from being considered a duplicate.
    // Adding a block also retires an onblock action which increments both the global sequence number
    // and the recv and auth sequences numbers for the system account.
 
@@ -409,18 +409,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_receipt_tests, T, validating_testers) { try
 BOOST_AUTO_TEST_CASE_TEMPLATE(action_tests, T, validating_testers) { try {
    T chain;
 
-	chain.produce_blocks(2);
-	chain.create_account( "testapi"_n );
-	chain.create_account( "acc1"_n );
-	chain.create_account( "acc2"_n );
-	chain.create_account( "acc3"_n );
-	chain.create_account( "acc4"_n );
-	chain.produce_blocks(10);
-	chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-	chain.produce_blocks(1);
+   chain.produce_block();
+   chain.create_account("testapi"_n);
+   chain.create_account("acc1"_n);
+   chain.create_account("acc2"_n);
+   chain.create_account("acc3"_n);
+   chain.create_account("acc4"_n);
+   chain.produce_block();
+   chain.set_code("testapi"_n, test_contracts::test_api_wasm());
+   chain.produce_block();
 
    // test assert_true
-	CALL_TEST_FUNCTION( chain, "test_action", "assert_true", {});
+   CALL_TEST_FUNCTION(chain, "test_action", "assert_true", {});
 
    //test assert_false
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( chain, "test_action", "assert_false", {} ),
@@ -564,13 +564,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_tests, T, validating_testers) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(require_notice_tests, T, validating_testers) { try {
       T chain;
 
-      chain.produce_blocks(2);
+      chain.produce_block();
       chain.create_account( "testapi"_n );
       chain.create_account( "acc5"_n );
-      chain.produce_blocks(1);
+      chain.produce_block();
       chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
       chain.set_code( "acc5"_n, test_contracts::test_api_wasm() );
-      chain.produce_blocks(1);
+      chain.produce_block();
 
       // test require_notice
       signed_transaction trx;
@@ -593,14 +593,14 @@ BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
    chain.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::action_return_value} );
    chain.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_account( "testapi"_n );
    chain.create_account( "testapi2"_n );
-   chain.produce_blocks(10);
+   chain.produce_block();
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code( "testapi2"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify",
                                               fc::raw::pack( ((unsigned __int128)"testapi2"_n.to_uint64_t() << 64) | "testapi"_n.to_uint64_t() ) ),
@@ -622,12 +622,12 @@ BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(cf_action_tests, T, validating_testers) { try {
       T chain;
 
-      chain.produce_blocks(2);
+      chain.produce_block();
       chain.create_account( "testapi"_n );
       chain.create_account( "dummy"_n );
-      chain.produce_blocks(10);
+      chain.produce_block();
       chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-      chain.produce_blocks(1);
+      chain.produce_block();
       cf_action cfa;
       signed_transaction trx;
       chain.set_transaction_headers(trx);
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(cfa_stateful_api, T, validating_testers)  try {
    T chain;
 
    chain.create_account( "testapi"_n );
-	chain.produce_blocks(1);
+	chain.produce_block();
 	chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
 
    account_name a = "testapi2"_n;
@@ -782,7 +782,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(cfa_stateful_api, T, validating_testers)  try {
 BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, validating_tester_no_disable_deferred_trx)  try {
 
    create_account( "testapi"_n );
-	produce_blocks(1);
+	produce_block();
 	set_code( "testapi"_n, test_contracts::test_api_wasm() );
 
    account_name a = "testapi2"_n;
@@ -807,7 +807,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, validating_tester_no_disable_deferr
          return expect_assert_message(e, "only context free api's can be used in this context");
       });
 
-   produce_blocks(10);
+   produce_block();
 
    // CFA failed, testapi2 not created
    create_account( "testapi2"_n );
@@ -818,7 +818,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, validating_tester_no_disable_deferr
 BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, validating_tester_no_disable_deferred_trx)  try {
 
    create_account( "testapi"_n );
-	produce_blocks(1);
+	produce_block();
 	set_code( "testapi"_n, test_contracts::test_api_wasm() );
 
    account_name a = "testapi2"_n;
@@ -833,7 +833,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, validating_tester_no_disable_defer
                                  });
    action act({}, test_api_action<TEST_METHOD("test_transaction", "context_free_api")>{});
    trx.context_free_actions.push_back(act);
-   set_transaction_headers(trx, 10, 2);
+   set_transaction_headers(trx, 10, 1);
    trx.sign( get_private_key( creator, "active" ), control->get_chain_id()  );
    auto trace = push_transaction( trx );
    BOOST_REQUIRE(trace != nullptr);
@@ -841,7 +841,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, validating_tester_no_disable_defer
       BOOST_REQUIRE_EQUAL(transaction_receipt_header::status_enum::delayed, trace->receipt->status);
       BOOST_REQUIRE_EQUAL(1, trace->action_traces.size());
    }
-   produce_blocks(10);
+   produce_blocks(3);
 
    // CFA success, testapi2 created
    BOOST_CHECK_EXCEPTION(create_account( "testapi2"_n ), fc::exception,
@@ -941,11 +941,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(light_validation_skip_cfa, T, testers)  try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_pass_tests, T, validating_testers)  { try {
    T chain;
 
-	chain.produce_blocks(2);
+	chain.produce_block();
 	chain.create_account( "testapi"_n );
-	chain.produce_blocks(10);
+	chain.produce_block();
 	chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-	chain.produce_blocks(1);
+	chain.produce_block();
 
    // test checktime_pass
    CALL_TEST_FUNCTION( chain, "test_checktime", "checktime_pass", {});
@@ -998,14 +998,14 @@ void call_test(Tester& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cp
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( checktime_fail_tests, T, validating_testers ) { try {
    T t;
-   t.produce_blocks(2);
+   t.produce_block();
 
    ilog( "create account" );
    t.create_account( "testapi"_n );
    ilog( "set code" );
    t.set_code( "testapi"_n, test_contracts::test_api_wasm() );
    ilog( "produce block" );
-   t.produce_blocks(1);
+   t.produce_block();
 
    int64_t x; int64_t net; int64_t cpu;
    t.control->get_resource_limits_manager().get_account_limits( "testapi"_n, x, net, cpu );
@@ -1054,10 +1054,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( checktime_pause_max_trx_cpu_extended_test, T, tes
       return;
    }
    t.execute_setup_policy( setup_policy::full );
-   t.produce_blocks(2);
+   t.produce_block();
    t.create_account( "pause"_n );
    t.set_code( "pause"_n, test_contracts::test_api_wasm() );
-   t.produce_blocks(1);
+   t.produce_block();
 
    int64_t ram_bytes; int64_t net; int64_t cpu;
    auto& rl = t.control->get_resource_limits_manager();
@@ -1120,10 +1120,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( checktime_pause_max_trx_extended_test, T, testers
       return;
    }
    t.execute_setup_policy( setup_policy::full );
-   t.produce_blocks(2);
+   t.produce_block();
    t.create_account( "pause"_n );
    t.set_code( "pause"_n, test_contracts::test_api_wasm() );
-   t.produce_blocks(1);
+   t.produce_block();
 
    // Test deadline is extended when max_transaction_time is the limiting factor
 
@@ -1168,10 +1168,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( checktime_pause_block_deadline_not_extended_test,
       return;
    }
    t.execute_setup_policy( setup_policy::full );
-   t.produce_blocks(2);
+   t.produce_block();
    t.create_account( "pause"_n );
    t.set_code( "pause"_n, test_contracts::test_api_wasm() );
-   t.produce_blocks(1);
+   t.produce_block();
 
    // Test block deadline is not extended when it is the limiting factor
    // Specify large enough time so that WASM is completely loaded.
@@ -1215,10 +1215,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( checktime_pause_block_deadline_not_extended_while
       return;
    }
    t.execute_setup_policy( setup_policy::full );
-   t.produce_blocks(2);
+   t.produce_block();
    t.create_account( "pause"_n );
    t.set_code( "pause"_n, test_contracts::test_api_wasm() );
-   t.produce_blocks(1);
+   t.produce_block();
 
    // Test block deadline is not extended when it is the limiting factor
    // This test is different from the previous in that not enough time is provided to load the WASM.
@@ -1253,12 +1253,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( checktime_pause_block_deadline_not_extended_while
 BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_intrinsic, T, validating_testers) { try {
    T chain;
 
-	chain.produce_blocks(2);
-	chain.create_account( "testapi"_n );
-	chain.produce_blocks(10);
+   chain.produce_block();
+   chain.create_account("testapi"_n);
+   chain.produce_block();
 
-        std::stringstream ss;
-        ss << R"CONTRACT(
+   std::stringstream ss;
+   ss << R"CONTRACT(
 (module
   (type $FUNCSIG$vij (func (param i32 i64)))
   (type $FUNCSIG$j (func  (result i64)))
@@ -1296,7 +1296,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_intrinsic, T, validating_testers) { try 
         }
         ss<< "))";
 	chain.set_code( "testapi"_n, ss.str().c_str() );
-	chain.produce_blocks(1);
+	chain.produce_block();
 
         BOOST_TEST( !chain.is_code_cached("testapi"_n) );
 
@@ -1316,12 +1316,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_intrinsic, T, validating_testers) { try 
 BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_grow_memory, T, validating_testers) { try {
    T chain;
 
-	chain.produce_blocks(2);
-	chain.create_account( "testapi"_n );
-	chain.produce_blocks(10);
+   chain.produce_block();
+   chain.create_account("testapi"_n);
+   chain.produce_block();
 
-        std::stringstream ss;
-        ss << R"CONTRACT(
+   std::stringstream ss;
+   ss << R"CONTRACT(
 (module
   (memory 1)
 
@@ -1337,7 +1337,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_grow_memory, T, validating_testers) { tr
         }
         ss<< "))";
 	chain.set_code( "testapi"_n, ss.str().c_str() );
-	chain.produce_blocks(1);
+	chain.produce_block();
 
         BOOST_TEST( !chain.is_code_cached("testapi"_n) );
 
@@ -1357,11 +1357,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_grow_memory, T, validating_testers) { tr
 BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_hashing_fail, T, validating_testers) { try {
    T chain;
 
-	chain.produce_blocks(2);
+	chain.produce_block();
 	chain.create_account( "testapi"_n );
-	chain.produce_blocks(10);
+	chain.produce_block();
 	chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-	chain.produce_blocks(1);
+	chain.produce_block();
 
         BOOST_TEST( !chain.is_code_cached("testapi"_n) );
 
@@ -1419,11 +1419,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_start, T, validating_testers) try {
  (start $start)
 )
 )=====";
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_account( "testapi"_n );
-   chain.produce_blocks(10);
+   chain.produce_block();
    chain.set_code( "testapi"_n, checktime_start_wast );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_EXCEPTION( call_test( chain, test_api_action<TEST_METHOD("doesn't matter", "doesn't matter")>{},
                                      5000, 3, 3 ),
@@ -1435,11 +1435,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_start, T, validating_testers) try {
  *************************************************************************************/
 template<typename T>
 void transaction_tests(T& chain) {
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_account( "testapi"_n );
-   chain.produce_blocks(100);
+   chain.produce_block();
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // test for zero auth
    {
@@ -1492,7 +1492,7 @@ void transaction_tests(T& chain) {
          );
 
       {
-         chain.produce_blocks(10);
+         chain.produce_block();
          transaction_trace_ptr trace;
          auto c = chain.control->applied_transaction().connect([&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> x) {
             auto& t = std::get<0>(x);
@@ -1644,9 +1644,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( inline_action_with_over_4k_limit, T, testers ) { 
 BOOST_AUTO_TEST_CASE_TEMPLATE( inline_action_objective_limit, T, testers ) { try {
    const uint32_t _4k = 4 * 1024;
    T chain(setup_policy::full, db_read_mode::HEAD, {_4k});
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_account( "testapi"_n );
-   chain.produce_blocks(100);
+   chain.produce_block();
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
    chain.produce_block();
 
@@ -1709,11 +1709,11 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(api_part3_tests)
 
 BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester_no_disable_deferred_trx) { try {
-   produce_blocks(2);
+   produce_block();
    create_accounts( {"testapi"_n, "testapi2"_n, "alice"_n} );
    set_code( "testapi"_n, test_contracts::test_api_wasm() );
    set_code( "testapi2"_n, test_contracts::test_api_wasm() );
-   produce_blocks(1);
+   produce_block();
 
    //schedule
    {
@@ -1735,7 +1735,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester_no_disable
       c.disconnect();
    }
 
-   produce_blocks(10);
+   produce_block();
 
    //schedule twice without replace_existing flag (second deferred transaction should replace first one)
    {
@@ -1761,7 +1761,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester_no_disable
       c.disconnect();
    }
 
-   produce_blocks(10);
+   produce_block();
 
    //schedule twice with replace_existing flag (second deferred transaction should replace first one)
    {
@@ -1788,7 +1788,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester_no_disable
       c.disconnect();
    }
 
-   produce_blocks(10);
+   produce_block();
 
    //schedule and cancel
    {
@@ -1804,14 +1804,14 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester_no_disable
       c.disconnect();
    }
 
-   produce_blocks(10);
+   produce_block();
 
    //cancel_deferred() return zero if no scheduled transaction found
    {
       CALL_TEST_FUNCTION(*this, "test_transaction", "cancel_deferred_transaction_not_found", {});
    }
 
-   produce_blocks(10);
+   produce_block();
 
    //repeated deferred transactions
    {
@@ -1832,7 +1832,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester_no_disable
       BOOST_CHECK_EQUAL( traces.size(), 5 );
    }
 
-   produce_blocks(10);
+   produce_block();
 
    {
       // Trigger a tx which in turn sends a deferred tx with payer != receiver
@@ -1979,7 +1979,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
    BOOST_REQUIRE_EQUAL(1, index.size());
    print_deferred();
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.push_action( contract_account, "delayedcall"_n, test_account, fc::mutable_variant_object()
       ("payer",     test_account)
@@ -2080,7 +2080,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(chain_tests, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_account( "testapi"_n );
 
@@ -2111,7 +2111,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(chain_tests, T, validating_testers) { try {
    chain.set_producers (producers );
 
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(100);
+   chain.produce_block();
+   chain.produce_block(fc::seconds(1000));
+   chain.produce_block();
 
    vector<account_name> prods( chain.control->active_producers().producers.size() );
    for ( uint32_t i = 0; i < prods.size(); i++ ) {
@@ -2129,15 +2131,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(chain_tests, T, validating_testers) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(db_tests, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_account( "testapi"_n );
    chain.create_account( "testapi2"_n );
-   chain.produce_blocks(10);
+   chain.produce_block();
    chain.set_code( "testapi"_n, test_contracts::test_api_db_wasm() );
    chain.set_abi(  "testapi"_n, test_contracts::test_api_db_abi() );
    chain.set_code( "testapi2"_n, test_contracts::test_api_db_wasm() );
    chain.set_abi(  "testapi2"_n, test_contracts::test_api_db_abi() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.push_action( "testapi"_n, "pg"_n,  "testapi"_n, mutable_variant_object() ); // primary_i64_general
    chain.push_action( "testapi"_n, "pl"_n,  "testapi"_n, mutable_variant_object() ); // primary_i64_lowerbound
@@ -2294,12 +2296,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(db_notify_tests, T, validating_testers) {
 BOOST_AUTO_TEST_CASE_TEMPLATE(multi_index_tests, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account( "testapi"_n );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code( "testapi"_n, test_contracts::test_api_multi_index_wasm() );
    chain.set_abi( "testapi"_n, test_contracts::test_api_multi_index_abi() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    auto check_failure = [&chain]( action_name a, const char* expected_error_msg ) {
       BOOST_CHECK_EXCEPTION(  chain.push_action( "testapi"_n, a, "testapi"_n, {} ),
@@ -2629,13 +2631,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(cstr_tests, T, validating_testers) {
 BOOST_AUTO_TEST_CASE_TEMPLATE(print_tests, T, validating_testers) { try {
    T chain;
 
-	chain.produce_blocks(2);
-	chain.create_account("testapi"_n );
-	chain.produce_blocks(1000);
+   chain.produce_block();
+   chain.create_account("testapi"_n);
+   chain.produce_block();
 
-	chain.set_code("testapi"_n, test_contracts::test_api_wasm() );
-	chain.produce_blocks(1000);
-	string captured = "";
+   chain.set_code("testapi"_n, test_contracts::test_api_wasm());
+   chain.produce_block();
+   string captured = "";
 
 	// test prints
    auto tx1_trace = CALL_TEST_FUNCTION( chain, "test_print", "test_prints", {} );
@@ -2757,16 +2759,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(print_tests, T, validating_testers) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(types_tests, T, validating_testers) { try {
    T chain;
 
-	chain.produce_blocks(1000);
-	chain.create_account( "testapi"_n );
+   chain.produce_block();
+   chain.create_account("testapi"_n);
 
-	chain.produce_blocks(1000);
-	chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-	chain.produce_blocks(1000);
+   chain.produce_block();
+   chain.set_code("testapi"_n, test_contracts::test_api_wasm());
+   chain.produce_block();
 
-	CALL_TEST_FUNCTION( chain, "test_types", "types_size", {});
-	CALL_TEST_FUNCTION( chain, "test_types", "char_to_symbol", {});
-	CALL_TEST_FUNCTION( chain, "test_types", "string_to_name", {});
+   CALL_TEST_FUNCTION(chain, "test_types", "types_size", {});
+   CALL_TEST_FUNCTION(chain, "test_types", "char_to_symbol", {});
+   CALL_TEST_FUNCTION(chain, "test_types", "string_to_name", {});
 
    BOOST_REQUIRE_EQUAL( chain.validate(), true );
 } FC_LOG_AND_RETHROW() }
@@ -2777,12 +2779,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(types_tests, T, validating_testers) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(permission_tests, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account( "testapi"_n );
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    auto get_result_int64 = [&]() -> int64_t {
       const auto& db = chain.control->db();
@@ -3009,11 +3011,11 @@ BOOST_AUTO_TEST_CASE( set_producers_legacy ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(datastream_tests, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(1000);
+   chain.produce_block();
    chain.create_account("testapi"_n );
-   chain.produce_blocks(1000);
+   chain.produce_block();
    chain.set_code("testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1000);
+   chain.produce_block();
 
    CALL_TEST_FUNCTION( chain, "test_datastream", "test_basic", {} );
 
@@ -3049,7 +3051,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(permission_usage_tests, T, validating_testers) { t
                                      })
    ), eosio_assert_message_exception );
 
-   chain.produce_blocks(5);
+   chain.produce_block();
 
    chain.set_authority( "bob"_n, "perm1"_n, authority( chain.get_private_key("bob"_n, "perm1").get_public_key() ) );
 
@@ -3062,7 +3064,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(permission_usage_tests, T, validating_testers) { t
 
    auto permission_creation_time = chain.control->pending_block_time();
 
-   chain.produce_blocks(5);
+   chain.produce_block();
 
    CALL_TEST_FUNCTION( chain, "test_permission", "test_permission_last_used",
                        fc::raw::pack(test_permission_last_used_action{
@@ -3071,7 +3073,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(permission_usage_tests, T, validating_testers) { t
                                      })
    );
 
-   chain.produce_blocks(5);
+   chain.produce_block();
 
    chain.push_reqauth( "bob"_n, {{"bob"_n, "perm1"_n}}, {chain.get_private_key("bob"_n, "perm1")} );
 
@@ -3118,7 +3120,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(account_creation_time_tests, T, validating_testers
    chain.create_account( "alice"_n );
    auto alice_creation_time = chain.control->pending_block_time();
 
-   chain.produce_blocks(10);
+   chain.produce_block();
 
    CALL_TEST_FUNCTION( chain, "test_permission", "test_account_creation_time",
                        fc::raw::pack(test_permission_last_used_action{
@@ -3201,7 +3203,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(eosio_assert_code_tests, T, validating_testers) { 
    auto var = fc::json::from_string(abi_string);
    abi_serializer abis(var.as<abi_def>(), abi_serializer::create_yield_function( chain.abi_serializer_max_time ));
 
-   chain.produce_blocks(10);
+   chain.produce_block();
 
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( chain, "test_action", "test_assert_code", fc::raw::pack((uint64_t)42) ),
                           eosio_assert_code_exception, eosio_assert_code_is(42)                                        );
@@ -3256,22 +3258,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(eosio_assert_code_tests, T, validating_testers) { 
 BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_test, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("testapi"_n );
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("bob"_n );
    chain.set_code( "bob"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("charlie"_n );
    chain.set_code( "charlie"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("david"_n );
    chain.set_code( "david"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("erin"_n );
    chain.set_code( "erin"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // prove act digest
    auto pad = [](const digest_type& expected_act_digest, const action& act, const vector<char>& act_output)
@@ -3440,25 +3442,25 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_test, T, validating_testers) { try 
 BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_failtest1, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("testapi"_n );
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("bob"_n );
    chain.set_code( "bob"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("charlie"_n );
    chain.set_code( "charlie"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("david"_n );
    chain.set_code( "david"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("erin"_n );
    chain.set_code( "erin"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.create_account("fail1"_n ); // <- make first action fails in the middle
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    transaction_trace_ptr txn_trace =
       CALL_TEST_FUNCTION_NO_THROW( chain, "test_action", "test_action_ordinal1", {});
@@ -3509,25 +3511,25 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_failtest1, T, validating_testers) {
 BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_failtest2, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("testapi"_n );
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("bob"_n );
    chain.set_code( "bob"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("charlie"_n );
    chain.set_code( "charlie"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("david"_n );
    chain.set_code( "david"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("erin"_n );
    chain.set_code( "erin"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.create_account("fail3"_n ); // <- make action 3 fails in the middle
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    transaction_trace_ptr txn_trace =
       CALL_TEST_FUNCTION_NO_THROW( chain, "test_action", "test_action_ordinal1", {});
@@ -3631,25 +3633,25 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_failtest2, T, validating_testers) {
 BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_failtest3, T, validating_testers) { try {
    T chain;
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("testapi"_n );
    chain.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("bob"_n );
    chain.set_code( "bob"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("charlie"_n );
    chain.set_code( "charlie"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("david"_n );
    chain.set_code( "david"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("erin"_n );
    chain.set_code( "erin"_n, test_contracts::test_api_wasm() );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.create_account("failnine"_n ); // <- make action 9 fails in the middle
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    transaction_trace_ptr txn_trace =
       CALL_TEST_FUNCTION_NO_THROW( chain, "test_action", "test_action_ordinal1", {});
@@ -3785,10 +3787,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_failtest3, T, validating_testers) {
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( action_results_tests, T, validating_testers ) { try {
    T t;
-   t.produce_blocks(2);
+   t.produce_block();
    t.create_account( "test"_n );
    t.set_code( "test"_n, test_contracts::action_results_wasm() );
-   t.produce_blocks(1);
+   t.produce_block();
 
    auto call_autoresret_and_check = [&]( account_name contract, account_name signer, action_name action, auto&& checker ) {
       signed_transaction trx;
@@ -3808,7 +3810,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( action_results_tests, T, validating_testers ) { t
       BOOST_REQUIRE_EQUAL( fc::raw::unpack<int>(atrace[0].return_value), 10 );
    } );
 
-   t.produce_blocks(1);
+   t.produce_block();
 
    call_autoresret_and_check( "test"_n, "test"_n, "retlim"_n, [&]( const transaction_trace_ptr& res ) {
       BOOST_CHECK_EQUAL( res->receipt->status, transaction_receipt::executed );
@@ -3825,15 +3827,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( action_results_tests, T, validating_testers ) { t
                                        expected_vec.end() );
    } );
 
-   t.produce_blocks(1);
+   t.produce_block();
    BOOST_REQUIRE_THROW(call_autoresret_and_check( "test"_n, "test"_n, "retoverlim"_n, [&]( auto res ) {}),
                        action_return_value_exception);
-   t.produce_blocks(1);
+   t.produce_block();
    BOOST_REQUIRE_THROW(call_autoresret_and_check( "test"_n, "test"_n, "ret1overlim"_n, [&]( auto res ) {}),
                        action_return_value_exception);
-   t.produce_blocks(1);
+   t.produce_block();
    t.set_code( config::system_account_name, test_contracts::action_results_wasm() );
-   t.produce_blocks(1);
+   t.produce_block();
    call_autoresret_and_check( config::system_account_name,
                               config::system_account_name,
                               "retmaxlim"_n,
@@ -3850,7 +3852,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( action_results_tests, T, validating_testers ) { t
                                                                   expected_vec.begin(),
                                                                   expected_vec.end() );
                               } );
-   t.produce_blocks(1);
+   t.produce_block();
    BOOST_REQUIRE_THROW(call_autoresret_and_check( config::system_account_name,
                                                   config::system_account_name,
                                                   "setliminv"_n,
@@ -3894,11 +3896,11 @@ static const char get_code_hash_wast[] = R"=====(
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( get_code_hash_tests, T, validating_testers ) { try {
    T t;
-   t.produce_blocks(2);
+   t.produce_block();
    t.create_account("gethash"_n);
    t.create_account("test"_n);
    t.set_code("gethash"_n, get_code_hash_wast);
-   t.produce_blocks(1);
+   t.produce_block();
 
    auto check = [&](account_name acc, uint64_t expected_seq) {
       fc::sha256 expected_code_hash;

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( broadcasted_block_test, T, testers )
  */
 BOOST_FIXTURE_TEST_CASE( abort_block_transactions, validating_tester) { try {
 
-      produce_blocks(2);
+      produce_block();
       signed_transaction trx;
 
       account_name a = "newco"_n;
@@ -300,7 +300,7 @@ BOOST_FIXTURE_TEST_CASE( abort_block_transactions, validating_tester) { try {
                                  return std::string( e.what() ).find( a.to_string() ) != std::string::npos;
                               }) ;
 
-      produce_blocks(1);
+      produce_block();
 
    } FC_LOG_AND_RETHROW() }
 
@@ -309,7 +309,7 @@ BOOST_FIXTURE_TEST_CASE( abort_block_transactions, validating_tester) { try {
  */
 BOOST_FIXTURE_TEST_CASE( abort_block_transactions_tester, validating_tester) { try {
 
-      produce_blocks(2);
+      produce_block();
       signed_transaction trx;
 
       account_name a = "newco"_n;

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( signal_validated_blocks, T, testers ) try {
       validated_id = id;
    });
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    validator.push_block(accepted_block);
 
    chain.create_account("hello"_n);

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -466,14 +466,14 @@ BOOST_FIXTURE_TEST_CASE( test_proxy_deferred, pre_disable_deferred_trx_currency_
 } FC_LOG_AND_RETHROW() /// test_proxy_deferred
 
 BOOST_FIXTURE_TEST_CASE( test_deferred_failure, pre_disable_deferred_trx_currency_tester ) try {
-   produce_blocks(2);
+   produce_block();
 
    create_accounts( {"alice"_n, "bob"_n, "proxy"_n} );
    produce_block();
 
    set_code("proxy"_n, test_contracts::proxy_wasm());
    set_code("bob"_n, test_contracts::proxy_wasm());
-   produce_blocks(1);
+   produce_block();
 
    abi_serializer proxy_abi_ser(json::from_string(test_contracts::proxy_abi()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ));
 
@@ -578,7 +578,7 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, pre_disable_deferred_trx_currenc
 BOOST_AUTO_TEST_CASE_TEMPLATE( test_input_quantity, T, currency_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"alice"_n, "bob"_n, "carl"_n} );
 

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_SUITE(database_tests)
          T test;
          vector<block_id_type> block_ids;
 
-         const uint32_t num_of_blocks_to_prod = 200;
-         // Produce 200 blocks and check their IDs should match the above
+         const uint32_t num_of_blocks_to_prod = 20;
+         // Produce 20 blocks and check their IDs should match the above
          test.produce_blocks(num_of_blocks_to_prod);
          for (uint32_t i = 0; i < num_of_blocks_to_prod; ++i) {
             block_ids.emplace_back(test.control->fetch_block_by_number(i + 1)->calculate_id());
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
          const auto nonexisting_future_block_num = test.control->head_block_num() + 1;
          BOOST_TEST(test.control->fetch_block_by_number(nonexisting_future_block_num) == nullptr);
 
-         const uint32_t next_num_of_blocks_to_prod = 100;
+         const uint32_t next_num_of_blocks_to_prod = 10;
          test.produce_blocks(next_num_of_blocks_to_prod);
 
          // Check the last irreversible block number is updated correctly

--- a/unittests/dry_run_trx_tests.cpp
+++ b/unittests/dry_run_trx_tests.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_SUITE(dry_run_trx_tests)
 BOOST_AUTO_TEST_CASE_TEMPLATE( require_authorization, T, dry_run_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    action act = {
       {}, // no authorization provided: vector<permission_level>{{config::system_account_name,config::active_name}},
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( require_authorization, T, dry_run_trx_testers ) {
 BOOST_AUTO_TEST_CASE_TEMPLATE( newaccount_test, T, dry_run_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    action act = {
       vector<permission_level>{{config::system_account_name,config::active_name}},
@@ -123,14 +123,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( newaccount_test, T, dry_run_trx_testers ) { try {
    chain.send_action(act, false); // should not throw
    chain.send_action(act, true); // should not throw
    BOOST_CHECK_THROW(chain.control->get_account("alice"_n), fc::exception); // not actually created
-   chain.produce_blocks( 1 );
+   chain.produce_block();
    BOOST_CHECK_THROW(chain.control->get_account("alice"_n), fc::exception); // not actually created
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( setcode_test, T, dry_run_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    chain.create_accounts( {"setcodetest"_n} );
 
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( setcode_test, T, dry_run_trx_testers ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( setabi_test, T, dry_run_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    chain.create_accounts( {"setabitest"_n} );
 
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( setabi_test, T, dry_run_trx_testers ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( updateauth_test, T, dry_run_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    chain.create_accounts( {"alice"_n} );
 
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( updateauth_test, T, dry_run_trx_testers ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( deleteauth_test, T, dry_run_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    chain.create_accounts( {"alice"_n} );
 
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( deleteauth_test, T, dry_run_trx_testers ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( linkauth_test, T, dry_run_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    chain.create_account("eosio.token"_n);
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( linkauth_test, T, dry_run_trx_testers ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( unlinkauth_test, T, dry_run_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    chain.create_account("eosio.token"_n);
    chain.set_code("eosio.token"_n, test_contracts::eosio_token_wasm());

--- a/unittests/eosio.token_tests.cpp
+++ b/unittests/eosio.token_tests.cpp
@@ -22,15 +22,15 @@ class eosio_token_tester : public T {
 public:
 
    eosio_token_tester() {
-      T::produce_blocks( 2 );
+      T::produce_block();
 
       T::create_accounts( { "alice"_n, "bob"_n, "carol"_n, "eosio.token"_n } );
-      T::produce_blocks( 2 );
+      T::produce_block();
 
       T::set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
       T::set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
 
-      T::produce_blocks();
+      T::produce_block();
 
       const auto& accnt = T::control->db().template get<account_object,by_name>( "eosio.token"_n );
       abi_def abi;
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( create_tests, T, eosio_token_testers ) try {
       ("max_supply", "1000.000 TKN")
       ("issuer", "alice")
    );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
 } FC_LOG_AND_RETHROW()
 
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( symbol_already_exists, T, eosio_token_testers ) t
       ("max_supply", "100 TKN")
       ("issuer", "alice")
    );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_REQUIRE_EQUAL( chain.wasm_assert_msg( "token with symbol already exists" ),
                         chain.create( "alice"_n, asset::from_string("100 TKN"))
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( create_max_supply, T, eosio_token_testers ) try {
       ("max_supply", "4611686018427387903 TKN")
       ("issuer", "alice")
    );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    asset max(10, symbol(SY(0, NKT)));
    share_type amount = 4611686018427387904;
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( create_max_decimals, T, eosio_token_testers ) try
       ("max_supply", "1.000000000000000000 TKN")
       ("issuer", "alice")
    );
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    asset max(10, symbol(SY(0, NKT)));
    //1.0000000000000000000 => 0x8ac7230489e80000L
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( issue_tests, T, eosio_token_testers ) try {
    T chain;
 
    auto token = chain.create( "alice"_n, asset::from_string("1000.000 TKN"));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.issue( "alice"_n, "alice"_n, asset::from_string("500.000 TKN"), "hola" );
 
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( transfer_tests, T, eosio_token_testers ) try {
    T chain;
 
    auto token = chain.create( "alice"_n, asset::from_string("1000 CERO"));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.issue( "alice"_n, "alice"_n, asset::from_string("1000 CERO"), "hola" );
 

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -27,12 +27,12 @@ public:
    eosio_system_tester(Lambda setup) {
       setup(*this);
 
-      T::produce_blocks( 2 );
+      T::produce_block();
 
       T::create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
                "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n, "eosio.rex"_n });
 
-      T::produce_blocks( 100 );
+      T::produce_block();
 
       T::set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
       T::set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
@@ -63,7 +63,7 @@ public:
          abi_ser.set_abi(std::move(abi), abi_serializer::create_yield_function( T::abi_serializer_max_time ));
       }
 
-      T::produce_blocks();
+      T::produce_block();
 
       create_account_with_resources( "alice1111111"_n, config::system_account_name, core_from_string("1.0000"), false );
       create_account_with_resources( "bob111111111"_n, config::system_account_name, core_from_string("0.4500"), false );
@@ -510,7 +510,7 @@ public:
          T::set_code( "eosio.msig"_n, test_contracts::eosio_msig_wasm() );
          T::set_abi( "eosio.msig"_n, test_contracts::eosio_msig_abi() );
 
-         T::produce_blocks();
+         T::produce_block();
          const auto& accnt = T::control->db().template get<account_object,by_name>( "eosio.msig"_n );
          abi_def msig_abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, msig_abi), true);
@@ -538,7 +538,8 @@ public:
             BOOST_REQUIRE_EQUAL( T::success(), regproducer(p) );
          }
       }
-      T::produce_blocks( 250);
+      T::produce_block();
+      T::produce_block(fc::seconds(1000));
 
       auto trace_auth = validating_tester::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
                                             ("account", name(config::system_account_name).to_string())
@@ -564,7 +565,8 @@ public:
                              )
          );
       }
-      T::produce_blocks( 250 );
+      T::produce_block();
+      T::produce_block(fc::seconds(1000));
 
       auto producer_keys = T::control->active_producers().producers;
       BOOST_REQUIRE_EQUAL( 21u, producer_keys.size() );

--- a/unittests/partitioned_block_log_tests.cpp
+++ b/unittests/partitioned_block_log_tests.cpp
@@ -40,14 +40,14 @@ struct restart_from_block_log_tester : T {
    restart_from_block_log_tester() {
       using namespace eosio::chain;
       chain.create_account("replay1"_n);
-      chain.produce_blocks(1);
+      chain.produce_block();
       chain.create_account("replay2"_n);
-      chain.produce_blocks(1);
+      chain.produce_block();
       chain.create_account("replay3"_n);
-      chain.produce_blocks(1);
+      chain.produce_block();
       auto cutoff_block = chain.produce_block();
       cutoff_block_num  = cutoff_block->block_num();
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay1"_n));
       BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay2"_n));

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(activate_and_restart, T, testers) try {
 
    // Activate PREACTIVATE_FEATURE.
    c.schedule_protocol_features_wo_preactivation({ *d });
-   c.produce_blocks(2);
+   c.produce_block();
 
    auto head_block_num = c.control->head_block_num();
 
@@ -699,10 +699,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fix_linkauth_restriction, T, testers) { try {
 
    const auto& tester_account = "tester"_n;
 
-   chain.produce_blocks();
+   chain.produce_block();
    chain.create_account("currency"_n);
    chain.create_account(tester_account);
-   chain.produce_blocks();
+   chain.produce_block();
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
            ("account", name(tester_account).to_string())
@@ -857,7 +857,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(only_bill_to_first_authorizer, T, testers) { try {
    const auto& tester_account = "tester"_n;
    const auto& tester_account2 = "tester2"_n;
 
-   chain.produce_blocks();
+   chain.produce_block();
    chain.create_account(tester_account);
    chain.create_account(tester_account2);
 
@@ -875,7 +875,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(only_bill_to_first_authorizer, T, testers) { try {
 
    const resource_limits_manager& mgr = chain.control->get_resource_limits_manager();
 
-   chain.produce_blocks();
+   chain.produce_block();
 
    {
       action act;
@@ -920,7 +920,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(only_bill_to_first_authorizer, T, testers) { try {
    BOOST_REQUIRE( d );
 
    chain.preactivate_protocol_features( {*d} );
-   chain.produce_blocks();
+   chain.produce_block();
 
    {
       action act;
@@ -1575,7 +1575,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(producer_schedule_change_extension_test, T, tester
    const auto& d = pfm.get_builtin_digest(builtin_protocol_feature_t::wtmsig_block_signatures);
    BOOST_REQUIRE(d);
 
-   c.produce_blocks(2);
+   c.produce_block();
 
    // sync a remote node into this chain
    T remote( setup_policy::none );
@@ -1684,7 +1684,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(wtmsig_block_signing_inflight_legacy_test, T, test
    const auto& d = pfm.get_builtin_digest(builtin_protocol_feature_t::wtmsig_block_signatures);
    BOOST_REQUIRE(d);
 
-   c.produce_blocks(2);
+   c.produce_block();
 
    // activate the feature, and start an in-flight producer schedule change with the legacy format
    c.preactivate_protocol_features( {*d} );
@@ -1715,7 +1715,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(wtmsig_block_signing_inflight_extension_test, T, t
    const auto& d = pfm.get_builtin_digest(builtin_protocol_feature_t::wtmsig_block_signatures);
    BOOST_REQUIRE(d);
 
-   c.produce_blocks(2);
+   c.produce_block();
 
    // activate the feature
    c.preactivate_protocol_features( {*d} );

--- a/unittests/ram_tests.cpp
+++ b/unittests/ram_tests.cpp
@@ -31,12 +31,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
    const auto table_allocation_bytes = 12000;
    BOOST_REQUIRE_MESSAGE(table_allocation_bytes > increment_contract_bytes, "increment_contract_bytes must be less than table_allocation_bytes for this test setup to work");
    chain.buyrambytes(config::system_account_name, config::system_account_name, 70000);
-   chain.produce_blocks(10);
+   chain.produce_block();
    chain.create_account_with_resources("testram11111"_n,config::system_account_name, init_request_bytes + 40);
    chain.create_account_with_resources("testram22222"_n,config::system_account_name, init_request_bytes + 1190);
-   chain.produce_blocks(10);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL( chain.success(), chain.stake( name("eosio.stake"), name("testram11111"), core_from_string("10.0000"), core_from_string("5.0000") ) );
-   chain.produce_blocks(10);
+   chain.produce_block();
 
    for (auto i = 0; i < 10; ++i) {
       try {
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
          chain.buyrambytes(config::system_account_name, "testram22222"_n, increment_contract_bytes);
       }
    }
-   chain.produce_blocks(10);
+   chain.produce_block();
 
    for (auto i = 0; i < 10; ++i) {
       try {
@@ -60,10 +60,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
          chain.buyrambytes(config::system_account_name, "testram22222"_n, increment_contract_bytes);
       }
    }
-   chain.produce_blocks(10);
+   chain.produce_block();
    chain.set_code( "testram22222"_n, test_contracts::test_ram_limit_wasm() );
    chain.set_abi( "testram22222"_n, test_contracts::test_ram_limit_abi() );
-   chain.produce_blocks(10);
+   chain.produce_block();
 
    auto total = chain.get_total_stake( "testram11111"_n );
    const auto init_bytes =  total["ram_bytes"].as_uint64();
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                         ("from", 1)
                         ("to", 10)
                         ("size", 1780 /*1910*/));
-   chain.produce_blocks(1);
+   chain.produce_block();
    auto ram_usage = rlm.get_account_ram_usage("testram11111"_n);
 
    total = chain.get_total_stake( "testram11111"_n );
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
    wlog("ram_tests 2    %%%%%%");
-   chain.produce_blocks(1);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL(ram_usage, rlm.get_account_ram_usage("testram11111"_n));
 
    // update the entries with smaller allocations so that we can verify space is freed and new allocations can be made
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                         ("from", 1)
                         ("to", 10)
                         ("size", 1680/*1810*/));
-   chain.produce_blocks(1);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage("testram11111"_n));
 
    // verify the added entry is beyond the allocation bytes limit
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                            ("size", 1680/*1810*/)),
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
-   chain.produce_blocks(1);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage("testram11111"_n));
 
    // verify the new entry's bytes minus the freed up bytes for existing entries still exceeds the allocation bytes limit
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                            ("size", 1760)),
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
-   chain.produce_blocks(1);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage("testram11111"_n));
 
    // verify the new entry's bytes minus the freed up bytes for existing entries are under the allocation bytes limit
@@ -145,12 +145,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                         ("from", 1)
                         ("to", 11)
                         ("size", 1600/*1720*/));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    tester->push_action( "testram11111"_n, "rmentry"_n, "testram11111"_n, mvo()
                         ("from", 3)
                         ("to", 3));
-   chain.produce_blocks(1);
+   chain.produce_block();
    
    // verify that the new entry will exceed the allocation bytes limit
    BOOST_REQUIRE_EXCEPTION(
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                            ("size", 1780)),
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // verify that the new entry is under the allocation bytes limit
    tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                         ("from", 12)
                         ("to", 12)
                         ("size", 1620/*1720*/));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // verify that anoth new entry will exceed the allocation bytes limit, to setup testing of new payer
    BOOST_REQUIRE_EXCEPTION(
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                            ("size", 1660)),
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // verify that the new entry is under the allocation bytes limit
    tester->push_action( "testram11111"_n, "setentry"_n, {"testram11111"_n,"testram22222"_n}, mvo()
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                         ("from", 12)
                         ("to", 12)
                         ("size", 1720));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // verify that another new entry that is too big will exceed the allocation bytes limit, to setup testing of new payer
    BOOST_REQUIRE_EXCEPTION(
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                            ("size", 1900)),
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    wlog("ram_tests 18    %%%%%%");
    // verify that the new entry is under the allocation bytes limit, because entry 12 is now charged to testram22222
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                         ("from", 13)
                         ("to", 13)
                         ("size", 1720));
-   chain.produce_blocks(1);
+   chain.produce_block();
    
    // verify that new entries for testram22222 exceed the allocation bytes limit
    BOOST_REQUIRE_EXCEPTION(
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                            ("size", 1930)),
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram22222 has insufficient ram"));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // verify that new entries for testram22222 are under the allocation bytes limit
    tester->push_action( "testram11111"_n, "setentry"_n, {"testram11111"_n,"testram22222"_n}, mvo()
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                         ("from", 12)
                         ("to", 21)
                         ("size", 1910));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // verify that new entry for testram22222 exceed the allocation bytes limit
    BOOST_REQUIRE_EXCEPTION(
@@ -238,12 +238,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                            ("size", 1910)),
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram22222 has insufficient ram"));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    tester->push_action( "testram11111"_n, "rmentry"_n, "testram11111"_n, mvo()
                         ("from", 20)
                         ("to", 20));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // verify that new entry for testram22222 are under the allocation bytes limit
    tester->push_action( "testram11111"_n, "setentry"_n, {"testram11111"_n,"testram22222"_n}, mvo()
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( ram_tests, T, eosio_system_testers ) { try {
                         ("from", 22)
                         ("to", 22)
                         ("size", 1910));
-   chain.produce_blocks(1);
+   chain.produce_block();
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/read_only_trx_tests.cpp
+++ b/unittests/read_only_trx_tests.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_SUITE(read_only_trx_tests)
 BOOST_AUTO_TEST_CASE_TEMPLATE( newaccount_test, T, read_only_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    action act = {
       {},
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( newaccount_test, T, read_only_trx_testers ) { try
 BOOST_AUTO_TEST_CASE_TEMPLATE( setcode_test, T, read_only_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    std::vector<uint8_t> code(10);
    action act = {
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( setcode_test, T, read_only_trx_testers ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( setabi_test, T, read_only_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    std::vector<uint8_t> abi(10);
    action act = {
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( setabi_test, T, read_only_trx_testers ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( updateauth_test, T, read_only_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    auto auth = authority( chain.get_public_key( "alice"_n, "test" ) );
    action act = {
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( updateauth_test, T, read_only_trx_testers ) { try
 BOOST_AUTO_TEST_CASE_TEMPLATE( deleteauth_test, T, read_only_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    name account = "alice"_n;
    name permission = "active"_n;
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( deleteauth_test, T, read_only_trx_testers ) { try
 BOOST_AUTO_TEST_CASE_TEMPLATE( linkauth_test, T, read_only_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    name account = "alice"_n;
    name code = "eosio_token"_n;
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( linkauth_test, T, read_only_trx_testers ) { try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( unlinkauth_test, T, read_only_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    name account = "alice"_n;
    name code = "eosio_token"_n;
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( unlinkauth_test, T, read_only_trx_testers ) { try
 BOOST_AUTO_TEST_CASE_TEMPLATE( canceldelay_test, T, read_only_trx_testers ) { try {
    T chain;
 
-   chain.produce_blocks( 1 );
+   chain.produce_block();
 
    permission_level canceling_auth { config::system_account_name,config::active_name };
    transaction_id_type trx_id { "0718886aa8a3895510218b523d3d694280d1dbc1f6d30e173a10b2039fc894f1" };

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -143,11 +143,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_restart_from_block_log, T, testers ) {
    T chain;
 
    chain.create_account("replay1"_n);
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("replay2"_n);
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.create_account("replay3"_n);
-   chain.produce_blocks(1); // replay3 will be in fork_db.dat
+   chain.produce_block(); // replay3 will be in fork_db.dat
 
    BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay1"_n));
    BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay2"_n));

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -195,25 +195,25 @@ void exhaustive_snapshot_test()
    chain.create_accounts({"snapshot"_n, "snapshot1"_n});
 
    // Set code and increment the first account
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
    chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.push_action("snapshot"_n, "increment"_n, "snapshot"_n, mutable_variant_object()
          ( "value", 1 )
    );
 
    // Set code and increment the second account
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code("snapshot1"_n, test_contracts::snapshot_test_wasm());
    chain.set_abi("snapshot1"_n, test_contracts::snapshot_test_abi());
-   chain.produce_blocks(1);
+   chain.produce_block();
    // increment the test contract
    chain.push_action("snapshot1"_n, "increment"_n, "snapshot1"_n, mutable_variant_object()
          ( "value", 1 )
    );
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.control->abort_block();
 
@@ -266,10 +266,10 @@ void replay_over_snapshot_test()
    const std::filesystem::path parent_path = chain.get_config().blocks_dir.parent_path();
 
    chain.create_account("snapshot"_n);
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
    chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.control->abort_block();
 
    static const int pre_snapshot_block_count = 12;
@@ -368,10 +368,10 @@ void chain_id_in_snapshot_test()
    const std::filesystem::path parent_path = chain.get_config().blocks_dir.parent_path();
 
    chain.create_account("snapshot"_n);
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
    chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.control->abort_block();
 
    // create a new snapshot child
@@ -421,16 +421,16 @@ void compatible_versions_test()
 
       TESTER chain(setup_policy::none, db_read_mode::HEAD, {legacy_default_max_inline_action_size});
       chain.create_account("snapshot"_n);
-      chain.produce_blocks(1);
+      chain.produce_block();
       chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
       chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
-      chain.produce_blocks(1);
+      chain.produce_block();
       chain.control->abort_block();
 
       // continue until all the above blocks are in the blocks.log
       auto head_block_num = chain.control->head_block_num();
       while (chain.control->last_irreversible_block_num() < head_block_num) {
-         chain.produce_blocks(1);
+         chain.produce_block();
       }
 
       auto source = chain.get_config().blocks_dir / "blocks.log";
@@ -567,10 +567,10 @@ void restart_with_existing_state_and_truncated_block_log_test()
    const std::filesystem::path parent_path = chain.get_config().blocks_dir.parent_path();
 
    chain.create_account("snapshot"_n);
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
    chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.control->abort_block();
 
    static const int pre_snapshot_block_count = 12;
@@ -658,10 +658,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( json_snapshot_validity_test, TESTER, testers )
 
    // prep the chain
    chain.create_account("snapshot"_n);
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code("snapshot"_n, test_contracts::snapshot_test_wasm());
    chain.set_abi("snapshot"_n, test_contracts::snapshot_test_abi());
-   chain.produce_blocks(10);
+   chain.produce_block();
    chain.control->abort_block();
 
    auto pid_string = std::to_string(getpid());
@@ -726,7 +726,7 @@ void jumbo_row_test()
 
    chain.create_accounts({"jumbo"_n});
    chain.set_code("jumbo"_n, set_jumbo_row_wast);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    signed_transaction trx;
    action act;
@@ -738,7 +738,7 @@ void jumbo_row_test()
    chain.set_transaction_headers(trx);
    trx.sign(tester::get_private_key("jumbo"_n, "active"), chain.control->get_chain_id());
    chain.push_transaction(trx);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.control->abort_block();
 

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
 
    chain.create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n, "eosio.rex"_n});
 
-   chain.produce_blocks( 100 );
+   chain.produce_block();
 
    chain.set_code( "eosio.token"_n, test_contracts::eosio_token_wasm() );
    chain.set_abi( "eosio.token"_n, test_contracts::eosio_token_abi() );
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
       ("memo", "for stuff")
    );
 
-   chain.produce_blocks(10);
+   chain.produce_block();
 
    chain.set_code( config::system_account_name, test_contracts::eosio_system_wasm() );
    chain.set_abi( config::system_account_name, test_contracts::eosio_system_abi() );
@@ -504,7 +504,7 @@ BOOST_AUTO_TEST_CASE(test_deltas_resources_history) {
       chain.set_code("tester"_n, test_contracts::get_table_test_wasm());
       chain.set_abi("tester"_n, test_contracts::get_table_test_abi());
 
-      chain.produce_blocks(2);
+      chain.produce_block();
 
       auto trace = chain.push_action("tester"_n, "addhashobj"_n, "tester"_n, mutable_variant_object()("hashinput", "hello"));
       BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);

--- a/unittests/wasm_config_tests.cpp
+++ b/unittests/wasm_config_tests.cpp
@@ -188,7 +188,7 @@ static const char one_data[] =  "(data (i32.const 0))";
 
 template<typename T>
 void test_max_section_elements(T& chain, int32_t n_elements, int32_t oversize, const char* wast, const char* one_element) {
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts({"section"_n});
    chain.produce_block();
 
@@ -238,7 +238,7 @@ BOOST_DATA_TEST_CASE_F(wasm_config_tester<savanna_validating_tester>, max_sectio
 // must be unique and apply must be one of the exports.
 template<typename T>
 void test_max_section_elements_export(T& chain, int32_t n_elements, int32_t oversize) {
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts({"section"_n});
    chain.produce_block();
 
@@ -298,7 +298,7 @@ static const char max_linear_memory_wast[] = R"=====(
 
 template<typename T>
 void test_max_linear_memory_init(T& chain, int32_t n_init, int32_t oversize) {
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts({"initdata"_n});
    chain.produce_block();
 
@@ -346,7 +346,7 @@ static const std::vector<std::tuple<int, int, bool, bool>> func_local_params = {
 
 template<typename T>
 void test_max_func_local_bytes(T& chain, int32_t n_params, int32_t n_locals, int32_t n_stack, int32_t set_high, int32_t expect_success) {
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts({"stackz"_n});
    chain.produce_block();
 
@@ -403,7 +403,7 @@ BOOST_DATA_TEST_CASE_F(wasm_config_tester<savanna_validating_tester>, max_func_l
 BOOST_AUTO_TEST_CASE_TEMPLATE( max_func_local_bytes_mixed, T, wasm_config_testers ) {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts({"stackz"_n});
    chain.produce_block();
 
@@ -447,7 +447,7 @@ static const std::vector<std::tuple<int, int, bool>> old_func_local_params = {
 };
 
 BOOST_DATA_TEST_CASE_F(old_wasm_tester, max_func_local_bytes_old, data::make({0, 8192, 16384}) * data::make(old_func_local_params), n_stack, n_params, n_locals, expect_success) {
-   produce_blocks(2);
+   produce_block();
    create_accounts({"stackz"_n});
    produce_block();
 
@@ -481,7 +481,7 @@ BOOST_DATA_TEST_CASE_F(old_wasm_tester, max_func_local_bytes_old, data::make({0,
 BOOST_AUTO_TEST_CASE_TEMPLATE( max_stack, T, wasm_config_testers ) {
    T chain;
 
-   chain.produce_blocks();
+   chain.produce_block();
    chain.create_accounts({"stackz"_n});
    chain.produce_block();
    std::string code;
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( max_stack, T, wasm_config_testers ) {
 }
 
 BOOST_FIXTURE_TEST_CASE(max_stack_old, old_wasm_tester) {
-   produce_blocks();
+   produce_block();
    create_accounts({"stackz"_n});
    produce_block();
    std::string code;
@@ -566,7 +566,7 @@ BOOST_FIXTURE_TEST_CASE(max_stack_old, old_wasm_tester) {
 }
 
 BOOST_FIXTURE_TEST_CASE(max_func_local_bytes_mixed_old, old_wasm_tester) {
-   produce_blocks(2);
+   produce_block();
    create_accounts({"stackz"_n});
    produce_block();
 
@@ -723,7 +723,7 @@ static const char max_symbol_table_wast[] = R"=====(
 
 template<typename T>
 void test_max_symbol_bytes_export(T& chain, int32_t n_symbol, int32_t oversize, const char* wast) {
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts({"bigname"_n});
 
@@ -771,7 +771,7 @@ static const char max_symbol_import_wast[] = R"=====(
 BOOST_AUTO_TEST_CASE_TEMPLATE( max_symbol_bytes_import, T, wasm_config_testers ) {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts({"bigname"_n});
 
    constexpr int n_symbol = 33;
@@ -816,7 +816,7 @@ static const std::vector<uint8_t> small_contract_wasm{
 BOOST_AUTO_TEST_CASE_TEMPLATE( max_module_bytes, T, wasm_config_testers ) {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts({"bigmodule"_n});
 
    const int n_module = small_contract_wasm.size();
@@ -839,7 +839,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( max_module_bytes, T, wasm_config_testers ) {
 BOOST_AUTO_TEST_CASE_TEMPLATE( max_code_bytes, T, wasm_config_testers ) {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts({"bigcode"_n});
 
    constexpr int n_code = 224;
@@ -883,7 +883,7 @@ static const char intrinsic_biggest_memory_wast[] = R"=====(
 BOOST_AUTO_TEST_CASE_TEMPLATE( max_pages, T, wasm_config_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( { "bigmem"_n, "accessmem"_n, "intrinsicmem"_n } );
    chain.set_code("accessmem"_n, access_biggest_memory_wast);
@@ -899,7 +899,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( max_pages, T, wasm_config_testers ) try {
                                                        "MAX_WASM_PAGES", params.max_pages - 1));
 
       chain.set_code("bigmem"_n, biggest_memory_wast_f.c_str());
-      chain.produce_blocks(1);
+      chain.produce_block();
 
       auto pushit = [&](uint64_t extra_pages) {
          action act;
@@ -947,7 +947,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( max_pages, T, wasm_config_testers ) try {
       pushit(1);
       checkaccess(max_pages - 1);
       pushintrinsic(max_pages);
-      chain.produce_blocks(1);
+      chain.produce_block();
 
       // Increase memory limit
       ++params.max_pages;

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -71,13 +71,13 @@ BOOST_AUTO_TEST_SUITE(wasm_part1_tests)
 BOOST_AUTO_TEST_CASE_TEMPLATE( basic_test, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"asserter"_n} );
    chain.produce_block();
 
    chain.set_code("asserter"_n, test_contracts::asserter_wasm());
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    transaction_id_type no_assert_id;
    {
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( basic_test, T, validating_testers ) try {
       no_assert_id = trx.id();
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(no_assert_id));
    const auto& receipt = chain.get_transaction_receipt(no_assert_id);
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( basic_test, T, validating_testers ) try {
       BOOST_CHECK_THROW(chain.push_transaction( trx ), eosio_assert_message_exception);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    auto has_tx = chain.chain_has_transaction(yes_assert_id);
    BOOST_REQUIRE_EQUAL(false, has_tx);
@@ -132,13 +132,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( basic_test, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( prove_mem_reset, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"asserter"_n} );
    chain.produce_block();
 
    chain.set_code("asserter"_n, test_contracts::asserter_wasm());
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    // repeat the action multiple times, each time the action handler checks for the expected
    // default value then modifies the value which should not survive until the next invoction
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( prove_mem_reset, T, validating_testers ) try {
       chain.set_transaction_headers(trx);
       trx.sign( chain.get_private_key( "asserter"_n, "active" ), chain.control->get_chain_id() );
       chain.push_transaction( trx );
-      chain.produce_blocks(1);
+      chain.produce_block();
       BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
       const auto& receipt = chain.get_transaction_receipt(trx.id());
       BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
@@ -164,14 +164,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( prove_mem_reset, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( abi_from_variant, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"asserter"_n} );
    chain.produce_block();
 
    chain.set_code("asserter"_n, test_contracts::asserter_wasm());
    chain.set_abi("asserter"_n, test_contracts::asserter_abi());
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    auto resolver = [&]( const account_name& name ) -> std::optional<abi_serializer> {
       try {
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( abi_from_variant, T, validating_testers ) try {
    chain.set_transaction_headers(trx);
    trx.sign( chain.get_private_key( "asserter"_n, "active" ), chain.control->get_chain_id() );
    chain.push_transaction( trx );
-   chain.produce_blocks(1);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
    const auto& receipt = chain.get_transaction_receipt(trx.id());
    BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
@@ -216,12 +216,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( abi_from_variant, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( f32_tests, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
    chain.produce_block();
    chain.create_accounts( {"f32.tests"_n} );
    {
       chain.set_code("f32.tests"_n, f32_test_wast);
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -233,7 +232,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_tests, T, validating_testers ) try {
       chain.set_transaction_headers(trx);
       trx.sign(chain.get_private_key( "f32.tests"_n, "active" ), chain.control->get_chain_id());
       chain.push_transaction(trx);
-      chain.produce_blocks(1);
+      chain.produce_block();
       BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
       chain.get_transaction_receipt(trx.id());
    }
@@ -241,12 +240,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_tests, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( f32_test_bitwise, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"f32.tests"_n} );
    chain.produce_block();
    {
       chain.set_code("f32.tests"_n, f32_bitwise_test_wast);
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -258,7 +257,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_test_bitwise, T, validating_testers ) try {
       chain.set_transaction_headers(trx);
       trx.sign(chain.get_private_key( "f32.tests"_n, "active" ), chain.control->get_chain_id());
       chain.push_transaction(trx);
-      chain.produce_blocks(1);
+      chain.produce_block();
       BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
       chain.get_transaction_receipt(trx.id());
    }
@@ -266,12 +265,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_test_bitwise, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( f32_test_cmp, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"f32.tests"_n} );
    chain.produce_block();
    {
       chain.set_code("f32.tests"_n, f32_cmp_test_wast);
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -283,7 +282,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_test_cmp, T, validating_testers ) try {
       chain.set_transaction_headers(trx);
       trx.sign(chain.get_private_key( "f32.tests"_n, "active" ), chain.control->get_chain_id());
       chain.push_transaction(trx);
-      chain.produce_blocks(1);
+      chain.produce_block();
       BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
       chain.get_transaction_receipt(trx.id());
    }
@@ -293,12 +292,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_test_cmp, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( f64_tests, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"f.tests"_n} );
    chain.produce_block();
    {
       chain.set_code("f.tests"_n, f64_test_wast);
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -310,7 +309,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_tests, T, validating_testers ) try {
       chain.set_transaction_headers(trx);
       trx.sign(chain.get_private_key( "f.tests"_n, "active" ), chain.control->get_chain_id());
       chain.push_transaction(trx);
-      chain.produce_blocks(1);
+      chain.produce_block();
       BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
       chain.get_transaction_receipt(trx.id());
    }
@@ -318,12 +317,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_tests, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( f64_test_bitwise, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"f.tests"_n} );
    chain.produce_block();
    {
       chain.set_code("f.tests"_n, f64_bitwise_test_wast);
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -335,7 +334,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_test_bitwise, T, validating_testers ) try {
       chain.set_transaction_headers(trx);
       trx.sign(chain.get_private_key( "f.tests"_n, "active" ), chain.control->get_chain_id());
       chain.push_transaction(trx);
-      chain.produce_blocks(1);
+      chain.produce_block();
       BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
       chain.get_transaction_receipt(trx.id());
    }
@@ -343,12 +342,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_test_bitwise, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( f64_test_cmp, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"f.tests"_n} );
    chain.produce_block();
    {
       chain.set_code("f.tests"_n, f64_cmp_test_wast);
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -360,7 +359,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_test_cmp, T, validating_testers ) try {
       chain.set_transaction_headers(trx);
       trx.sign(chain.get_private_key( "f.tests"_n, "active" ), chain.control->get_chain_id());
       chain.push_transaction(trx);
-      chain.produce_blocks(1);
+      chain.produce_block();
       BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
       chain.get_transaction_receipt(trx.id());
    }
@@ -370,13 +369,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_test_cmp, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( f32_f64_conversion_tests, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"ftests"_n} );
    chain.produce_block();
    {
       chain.set_code("ftests"_n, f32_f64_conv_wast);
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -388,7 +387,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_f64_conversion_tests, T, validating_testers )
       chain.set_transaction_headers(trx);
       trx.sign(chain.get_private_key( "ftests"_n, "active" ), chain.control->get_chain_id());
       chain.push_transaction(trx);
-      chain.produce_blocks(1);
+      chain.produce_block();
       BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
       chain.get_transaction_receipt(trx.id());
    }
@@ -402,12 +401,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_f64_overflow_tests, T, validating_testers ) t
    auto check = [&](const char *wast_template, const char *op, const char *param) -> bool {
       count+=16;
       chain.create_accounts( {name("ftests"_n.to_uint64_t()+count)} );
-      chain.produce_blocks(1);
+      chain.produce_block();
       std::vector<char> wast;
       wast.resize(strlen(wast_template) + 128);
       sprintf(&(wast[0]), wast_template, op, param);
       chain.set_code(name("ftests"_n.to_uint64_t()+count), &(wast[0]));
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -421,7 +420,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_f64_overflow_tests, T, validating_testers ) t
 
       try {
          chain.push_transaction(trx);
-         chain.produce_blocks(1);
+         chain.produce_block();
          BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
          chain.get_transaction_receipt(trx.id());
          return true;
@@ -501,13 +500,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_f64_overflow_tests, T, validating_testers ) t
 BOOST_AUTO_TEST_CASE_TEMPLATE( misaligned_tests, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"aligncheck"_n} );
    chain.produce_block();
 
    auto check_aligned = [&]( auto wast ) {
       chain.set_code("aligncheck"_n, wast);
-      chain.produce_blocks(10);
+      chain.produce_block();
 
       signed_transaction trx;
       action act;
@@ -536,12 +535,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( misaligned_tests, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( check_entry_behavior, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"entrycheck"_n} );
    chain.produce_block();
 
    chain.set_code("entrycheck"_n, entry_wast);
-   chain.produce_blocks(10);
+   chain.produce_block();
 
    signed_transaction trx;
    action act;
@@ -553,7 +552,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_entry_behavior, T, validating_testers ) try
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "entrycheck"_n, "active" ), chain.control->get_chain_id());
    chain.push_transaction(trx);
-   chain.produce_blocks(1);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
    const auto& receipt = chain.get_transaction_receipt(trx.id());
    BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
@@ -562,12 +561,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_entry_behavior, T, validating_testers ) try
 BOOST_AUTO_TEST_CASE_TEMPLATE( check_entry_behavior_2, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"entrycheck"_n} );
    chain.produce_block();
 
    chain.set_code("entrycheck"_n, entry_wast_2);
-   chain.produce_blocks(10);
+   chain.produce_block();
 
    signed_transaction trx;
    action act;
@@ -579,7 +578,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_entry_behavior_2, T, validating_testers ) t
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "entrycheck"_n, "active" ), chain.control->get_chain_id());
    chain.push_transaction(trx);
-   chain.produce_blocks(1);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
    const auto& receipt = chain.get_transaction_receipt(trx.id());
    BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
@@ -631,13 +630,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( entry_db, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( simple_no_memory_check, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"nomem"_n} );
    chain.produce_block();
 
    chain.set_code("nomem"_n, simple_no_memory_wast);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    //the apply func of simple_no_memory_wast tries to call a native func with linear memory pointer
    signed_transaction trx;
@@ -656,13 +655,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( simple_no_memory_check, T, validating_testers ) t
 BOOST_AUTO_TEST_CASE_TEMPLATE( check_global_reset, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"globalreset"_n} );
    chain.produce_block();
 
    chain.set_code("globalreset"_n, mutable_global_wast);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    signed_transaction trx;
    {
@@ -683,7 +682,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_global_reset, T, validating_testers ) try {
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "globalreset"_n, "active" ), chain.control->get_chain_id());
    chain.push_transaction(trx);
-   chain.produce_blocks(1);
+   chain.produce_block();
    BOOST_REQUIRE_EQUAL(true, chain.chain_has_transaction(trx.id()));
    const auto& receipt = chain.get_transaction_receipt(trx.id());
    BOOST_CHECK_EQUAL(transaction_receipt::executed, receipt.status);
@@ -696,7 +695,7 @@ void test_big_memory(setup_policy policy) {
    if(policy != setup_policy::full)
       t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
-   t.produce_blocks(2);
+   t.produce_block();
 
 
    t.create_accounts( {"bigmem"_n} );
@@ -706,7 +705,7 @@ void test_big_memory(setup_policy policy) {
                                           "MAX_WASM_PAGES", eosio::chain::wasm_constraints::maximum_linear_memory/(64*1024)));
 
    t.set_code("bigmem"_n, biggest_memory_wast_f.c_str());
-   t.produce_blocks(1);
+   t.produce_block();
 
    signed_transaction trx;
    action act;
@@ -720,7 +719,7 @@ void test_big_memory(setup_policy policy) {
    //but should not be able to grow beyond largest page
    t.push_transaction(trx);
 
-   t.produce_blocks(1);
+   t.produce_block();
 
    string too_big_memory_wast_f = fc::format_string(too_big_memory_wast, fc::mutable_variant_object(
                                           "MAX_WASM_PAGES_PLUS_ONE", eosio::chain::wasm_constraints::maximum_linear_memory/(64*1024)+1));
@@ -738,13 +737,13 @@ void test_table_init(setup_policy policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
       t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
-   t.produce_blocks(2);
+   t.produce_block();
 
    t.create_accounts( {"tableinit"_n} );
    t.produce_block();
 
    t.set_code("tableinit"_n, valid_sparse_table);
-   t.produce_blocks(1);
+   t.produce_block();
 
    BOOST_CHECK_THROW(t.set_code("tableinit"_n, too_big_table), eosio::chain::wasm_exception);
 
@@ -805,13 +804,13 @@ BOOST_AUTO_TEST_SUITE(wasm_part2_tests)
 BOOST_AUTO_TEST_CASE_TEMPLATE( memory_init_border, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"memoryborder"_n} );
    chain.produce_block();
 
    chain.set_code("memoryborder"_n, memory_init_borderline);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("memoryborder"_n, memory_init_toolong), eosio::chain::wasm_exception);
    BOOST_CHECK_THROW(chain.set_code("memoryborder"_n, memory_init_negative), eosio::chain::wasm_exception);
@@ -822,7 +821,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( imports, T, validating_testers ) try {
    T chain;
 
    try {
-      chain.produce_blocks(2);
+      chain.produce_block();
 
       chain.create_accounts( {"imports"_n} );
       chain.produce_block();
@@ -841,7 +840,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( imports, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( nested_limit_test, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"nested"_n} );
    chain.produce_block();
@@ -953,7 +952,7 @@ void test_lotso_globals(setup_policy policy) {
    if(policy != setup_policy::full)
       t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
-   t.produce_blocks(2);
+   t.produce_block();
 
    t.create_accounts( {"globals"_n} );
    t.produce_block();
@@ -982,7 +981,7 @@ BOOST_DATA_TEST_CASE( lotso_globals, bdata::make({setup_policy::preactivate_feat
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( offset_check_old, T, validating_testers ) try {
    T t(flat_set<account_name>{}, {}, setup_policy::old_wasm_parser);
-   t.produce_blocks(2);
+   t.produce_block();
 
    t.create_accounts( {"offsets"_n} );
    t.produce_block();
@@ -1047,7 +1046,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( offset_check_old, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( offset_check, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"offsets"_n} );
    chain.produce_block();
@@ -1094,7 +1093,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( offset_check, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( noop, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"noop"_n, "alice"_n} );
    chain.produce_block();
 
@@ -1107,7 +1106,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( noop, T, validating_testers ) try {
    abi_serializer abi_ser(std::move(abi), abi_serializer::create_yield_function( chain.abi_serializer_max_time ));
 
    {
-      chain.produce_blocks(5);
+      chain.produce_block();
       signed_transaction trx;
       action act;
       act.account = "noop"_n;
@@ -1132,7 +1131,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( noop, T, validating_testers ) try {
    }
 
    {
-      chain.produce_blocks(5);
+      chain.produce_block();
       signed_transaction trx;
       action act;
       act.account = "noop"_n;
@@ -1164,7 +1163,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( noop, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( eosio_abi, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    const auto& accnt  = chain.control->db().template get<account_object,by_name>(config::system_account_name);
    abi_def abi;
@@ -1200,7 +1199,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( eosio_abi, T, validating_testers ) try {
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( check_big_deserialization, T, validating_testers ) try {
    T t(flat_set<account_name>{}, {}, setup_policy::old_wasm_parser);
-   t.produce_blocks(2);
+   t.produce_block();
    t.create_accounts( {"cbd"_n} );
    t.produce_block();
 
@@ -1213,9 +1212,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_big_deserialization, T, validating_testers 
    ss << ")";
 
    t.set_code("cbd"_n, ss.str().c_str());
-   t.produce_blocks(1);
+   t.produce_block();
 
-   t.produce_blocks(1);
+   t.produce_block();
 
    ss.str("");
    ss << "(module ";
@@ -1226,7 +1225,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_big_deserialization, T, validating_testers 
    ss << ")";
 
    BOOST_CHECK_THROW(t.set_code("cbd"_n, ss.str().c_str()), wasm_serialization_error);
-   t.produce_blocks(1);
+   t.produce_block();
 
    ss.str("");
    ss << "(module ";
@@ -1238,7 +1237,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_big_deserialization, T, validating_testers 
    ss << "))";
 
    BOOST_CHECK_THROW(t.set_code("cbd"_n, ss.str().c_str()), fc::assert_exception); // this is caught first by MAX_SIZE_OF_ARRAYS check
-   t.produce_blocks(1);
+   t.produce_block();
 
    ss.str("");
    ss << "(module ";
@@ -1254,7 +1253,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_big_deserialization, T, validating_testers 
    ss << "))";
 
    t.set_code("cbd"_n, ss.str().c_str());
-   t.produce_blocks(1);
+   t.produce_block();
 
    ss.str("");
    ss << "(module ";
@@ -1270,19 +1269,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_big_deserialization, T, validating_testers 
    ss << "))";
 
    BOOST_CHECK_THROW(t.set_code("cbd"_n, ss.str().c_str()), wasm_serialization_error);
-   t.produce_blocks(1);
+   t.produce_block();
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"tbl"_n} );
    chain.produce_block();
 
    chain.set_code("tbl"_n, table_checker_wast);
-   chain.produce_blocks(1);
+   chain.produce_block();
    {
    signed_transaction trx;
    action act;
@@ -1295,7 +1294,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    chain.push_transaction(trx);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    {
    signed_transaction trx;
@@ -1309,7 +1308,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    chain.push_transaction(trx);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    {
    signed_transaction trx;
@@ -1323,7 +1322,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    chain.push_transaction(trx);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    {
    signed_transaction trx;
@@ -1339,7 +1338,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    BOOST_CHECK_THROW(chain.push_transaction(trx), eosio_assert_message_exception);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    {
    signed_transaction trx;
@@ -1355,7 +1354,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    BOOST_CHECK_THROW(chain.push_transaction(trx), eosio::chain::wasm_execution_error);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    {
    signed_transaction trx;
@@ -1371,11 +1370,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    BOOST_CHECK_THROW(chain.push_transaction(trx), eosio::chain::wasm_execution_error);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    //run a few tests with new, proper syntax, call_indirect
    chain.set_code("tbl"_n, table_checker_proper_syntax_wast);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    {
    signed_transaction trx;
@@ -1389,7 +1388,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    chain.push_transaction(trx);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    {
    signed_transaction trx;
    action act;
@@ -1402,7 +1401,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    chain.push_transaction(trx);
    }
    chain.set_code("tbl"_n, table_checker_small_wast);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    {
    signed_transaction trx;
@@ -1422,64 +1421,64 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
 BOOST_AUTO_TEST_CASE_TEMPLATE( protected_globals, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"gob"_n} );
    chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("gob"_n, global_protection_none_get_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("gob"_n, global_protection_some_get_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("gob"_n, global_protection_none_set_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("gob"_n, global_protection_some_set_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    //sanity to make sure I got general binary construction okay
    chain.set_code("gob"_n, global_protection_okay_get_wasm);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("gob"_n, global_protection_none_get_wasm), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("gob"_n, global_protection_some_get_wasm), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    chain.set_code("gob"_n, global_protection_okay_set_wasm);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("gob"_n, global_protection_some_set_wasm), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( apply_export_and_signature, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"bbb"_n} );
    chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("bbb"_n, no_apply_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("bbb"_n, no_apply_2_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("bbb"_n, no_apply_3_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("bbb"_n, apply_wrong_signature_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( trigger_serialization_errors, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    const vector<uint8_t> proper_wasm = { 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0d, 0x02, 0x60, 0x03, 0x7f, 0x7f, 0x7f,
                                          0x00, 0x60, 0x03, 0x7e, 0x7e, 0x7e, 0x00, 0x02, 0x0e, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x06, 0x73,
                                          0x68, 0x61, 0x32, 0x35, 0x36, 0x00, 0x00, 0x03, 0x02, 0x01, 0x01, 0x04, 0x04, 0x01, 0x70, 0x00,
@@ -1499,37 +1498,37 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( trigger_serialization_errors, T, validating_teste
 
    chain.set_code("bbb"_n, proper_wasm);
    BOOST_CHECK_THROW(chain.set_code("bbb"_n, malformed_wasm), wasm_serialization_error);
-   chain.produce_blocks(1);
+   chain.produce_block();
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( protect_injected, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"inj"_n} );
    chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("inj"_n, import_injected_wast), fc::exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( import_signature, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"imp"_n} );
    chain.produce_block();
 
    BOOST_CHECK_THROW(chain.set_code("imp"_n, import_wrong_signature_wast), wasm_exception);
-   chain.produce_blocks(1);
+   chain.produce_block();
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( mem_growth_memset, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"grower"_n} );
    chain.produce_block();
@@ -1548,7 +1547,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( mem_growth_memset, T, validating_testers ) try {
       chain.push_transaction(trx);
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
    chain.set_code("grower"_n, memory_growth_memset_test);
    {
       signed_transaction trx;
@@ -1598,7 +1597,7 @@ INCBIN(80k_deep_loop_with_void, "80k_deep_loop_with_void.wasm");
 BOOST_AUTO_TEST_CASE_TEMPLATE( fuzz, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"fuzzy"_n} );
    chain.produce_block();
@@ -1752,7 +1751,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( fuzz, T, validating_testers ) try {
       chain.set_code( "fuzzy"_n, wasm );
    }
 
-   chain.produce_blocks(1);
+   chain.produce_block();
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -1762,7 +1761,7 @@ BOOST_AUTO_TEST_SUITE(wasm_part3_tests)
 BOOST_AUTO_TEST_CASE_TEMPLATE( big_maligned_host_ptr, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"bigmaligned"_n} );
    chain.produce_block();
 
@@ -1771,7 +1770,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( big_maligned_host_ptr, T, validating_testers ) tr
                                               ("MAX_NAME_ARRAY", (eosio::chain::wasm_constraints::maximum_linear_memory-1)/sizeof(chain::account_name)));
 
    chain.set_code("bigmaligned"_n, large_maligned_host_ptr_wast_f.c_str());
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    signed_transaction trx;
    action act;
@@ -1782,7 +1781,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( big_maligned_host_ptr, T, validating_testers ) tr
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "bigmaligned"_n, "active" ), chain.control->get_chain_id());
    chain.push_transaction(trx);
-   chain.produce_blocks(1);
+   chain.produce_block();
 } FC_LOG_AND_RETHROW()
 
 template<typename T>
@@ -2182,7 +2181,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( billed_cpu_test, T, testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( zero_memory_pages, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
 
    chain.create_accounts( {"zero"_n} );
    chain.produce_block();
@@ -2229,12 +2228,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( zero_memory_pages, T, validating_testers ) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE( eosio_exit_in_start, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
+   chain.produce_block();
    chain.create_accounts( {"startexit"_n} );
    chain.produce_block();
 
    chain.set_code("startexit"_n, exit_in_start_wast);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    signed_transaction trx;
    action act;
@@ -2245,21 +2244,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( eosio_exit_in_start, T, validating_testers ) try 
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "startexit"_n, "active" ), chain.control->get_chain_id());
    chain.push_transaction(trx);
-   chain.produce_blocks(1);
+   chain.produce_block();
 } FC_LOG_AND_RETHROW()
 
 // memory.grow with a negative argument can shrink the available memory.
 BOOST_AUTO_TEST_CASE_TEMPLATE( negative_memory_grow, T, validating_testers ) try {
    T chain;
 
-   chain.produce_blocks(2);
-
+   chain.produce_block();
 
    chain.create_accounts( {"negmemgrow"_n} );
    chain.produce_block();
 
    chain.set_code("negmemgrow"_n, negative_memory_grow_wast);
-   chain.produce_blocks(1);
+   chain.produce_block();
 
    {
    signed_transaction trx;
@@ -2272,7 +2270,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( negative_memory_grow, T, validating_testers ) try
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "negmemgrow"_n, "active" ), chain.control->get_chain_id());
    chain.push_transaction(trx);
-   chain.produce_blocks(1);
+   chain.produce_block();
    }
 
    chain.set_code("negmemgrow"_n, negative_memory_grow_trap_wast);
@@ -2394,7 +2392,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( net_usage_tests, T, validating_testers ) try {
          code += "(call $test (call $i64_trunc_u_f64 (f64.const 1)))\n";
       }
       code += "))";
-      chain.produce_blocks(1);
+      chain.produce_block();
       signed_transaction trx;
       auto wasm = ::eosio::chain::wast_to_wasm(code);
       trx.actions.emplace_back( vector<permission_level>{{account,config::active_name}},
@@ -2410,7 +2408,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( net_usage_tests, T, validating_testers ) try {
       try {
          packed_transaction ptrx(trx);
          chain.push_transaction(ptrx);
-         chain.produce_blocks(1);
+         chain.produce_block();
          return true;
       } catch (tx_net_usage_exceeded &) {
          return false;
@@ -2449,7 +2447,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( weighted_net_usage_tests, T, validating_testers )
          code += ")))\n";
       }
       code += "))"; ver++;
-      chain.produce_blocks(1);
+      chain.produce_block();
       signed_transaction trx;
       auto wasm = ::eosio::chain::wast_to_wasm(code);
       trx.actions.emplace_back( vector<permission_level>{{account,config::active_name}},
@@ -2464,7 +2462,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( weighted_net_usage_tests, T, validating_testers )
       try {
          packed_transaction ptrx(trx);
          chain.push_transaction(ptrx );
-         chain.produce_blocks(1);
+         chain.produce_block();
          return true;
       } catch (tx_net_usage_exceeded &) {
          return false;

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -49,7 +49,7 @@ class whitelist_blacklist_tester {
               ( "quantity", "1000000.00 TOK" )
               ( "memo", "issue" )
          );
-         chain->produce_blocks();
+         chain->produce_block();
       }
 
       void shutdown() {
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( actor_whitelist, T, whitelist_blacklist_validatin
                           actor_whitelist_exception,
                           fc_exception_message_starts_with("authorizing actor(s) in transaction are not on the actor whitelist: [\"bob\"]")
                         );
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( actor_blacklist, T, whitelist_blacklist_validating_testers ) { try {
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( actor_blacklist, T, whitelist_blacklist_validatin
                           actor_blacklist_exception,
                           fc_exception_message_starts_with("authorizing actor(s) in transaction are on the actor blacklist: [\"bob\"]")
                         );
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( contract_whitelist, T, whitelist_blacklist_validating_testers ) { try {
@@ -184,17 +184,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( contract_whitelist, T, whitelist_blacklist_valida
 
    test.transfer( "charlie"_n, "alice"_n );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.chain->set_code("bob"_n, test_contracts::eosio_token_wasm() );
    test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi() );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.chain->set_code("charlie"_n, test_contracts::eosio_token_wasm() );
    test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi() );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.transfer( "alice"_n, "bob"_n );
 
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( contract_whitelist, T, whitelist_blacklist_valida
                           contract_whitelist_exception,
                           fc_exception_message_starts_with("account 'charlie' is not on the contract whitelist")
                         );
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( contract_blacklist, T, whitelist_blacklist_validating_testers ) { try {
@@ -233,17 +233,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( contract_blacklist, T, whitelist_blacklist_valida
 
    test.transfer( "charlie"_n, "alice"_n );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.chain->set_code("bob"_n, test_contracts::eosio_token_wasm() );
    test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi() );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.chain->set_code("charlie"_n, test_contracts::eosio_token_wasm() );
    test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi() );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.transfer( "alice"_n, "bob"_n );
 
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( contract_blacklist, T, whitelist_blacklist_valida
                           contract_blacklist_exception,
                           fc_exception_message_starts_with("account 'charlie' is on the contract blacklist")
                         );
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( action_blacklist, T, whitelist_blacklist_validating_testers ) { try {
@@ -276,17 +276,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( action_blacklist, T, whitelist_blacklist_validati
 
    test.transfer( "eosio.token"_n, "alice"_n, "1000.00 TOK" );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.chain->set_code("bob"_n, test_contracts::eosio_token_wasm() );
    test.chain->set_abi("bob"_n, test_contracts::eosio_token_abi() );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.chain->set_code("charlie"_n, test_contracts::eosio_token_wasm() );
    test.chain->set_abi("charlie"_n, test_contracts::eosio_token_abi() );
 
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 
    test.transfer( "alice"_n, "bob"_n );
 
@@ -304,15 +304,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( action_blacklist, T, whitelist_blacklist_validati
                           action_blacklist_exception,
                           fc_exception_message_starts_with("action 'charlie::create' is on the action blacklist")
                         );
-   test.chain->produce_blocks();
+   test.chain->produce_block();
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( blacklist_eosio, T, whitelist_blacklist_testers ) { try {
    T tester1;
    tester1.init();
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
    tester1.chain->set_code(config::system_account_name, test_contracts::eosio_token_wasm() );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
    tester1.shutdown();
    tester1.contract_blacklist = {config::system_account_name};
    tester1.init(false);
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( blacklist_eosio, T, whitelist_blacklist_testers )
       tester2.chain->push_block( b );
    }
 
-   tester1.chain->produce_blocks(2);
+   tester1.chain->produce_block();
 
    while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
       auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
@@ -338,12 +338,12 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "charlie"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi() );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
 
    tester1.chain->push_action( "bob"_n, "defercall"_n, "alice"_n, mvo()
       ( "payer", "alice" )
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
       ( "payload", 10 )
    );
 
-   tester1.chain->produce_blocks(2);
+   tester1.chain->produce_block();
 
    tester1.shutdown();
 
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
       ( "payload", 10 )
    );
 
-   BOOST_CHECK_EXCEPTION( tester1.chain->produce_blocks(), fc::exception,
+   BOOST_CHECK_EXCEPTION( tester1.chain->produce_block(), fc::exception,
                           fc_exception_message_is("account 'charlie' is on the contract blacklist")
                         );
    tester1.chain->produce_blocks(2, true); // Produce 2 empty blocks (other than onblock of course).
@@ -391,12 +391,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( blacklist_onerror, T, whitelist_blacklist_validat
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "charlie"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi() );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
 
    tester1.chain->push_action( "bob"_n, "defercall"_n, "alice"_n, mvo()
       ( "payer", "alice" )
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( blacklist_onerror, T, whitelist_blacklist_validat
       ( "payload", 13 )
    );
 
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
    tester1.shutdown();
 
    tester1.action_blacklist = {{config::system_account_name, "onerror"_n}};
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( blacklist_onerror, T, whitelist_blacklist_validat
       ( "payload", 13 )
    );
 
-   BOOST_CHECK_EXCEPTION( tester1.chain->produce_blocks(), fc::exception,
+   BOOST_CHECK_EXCEPTION( tester1.chain->produce_block(), fc::exception,
                           fc_exception_message_is("action 'eosio::onerror' is on the action blacklist")
                         );
 
@@ -429,14 +429,14 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
    tester1.chain->set_code( "alice"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "alice"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "charlie"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi() );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
 
    auto auth = authority(eosio::testing::base_tester::get_public_key(name("alice"), "active"));
    auth.accounts.push_back( permission_level_weight{{"alice"_n, config::eosio_code_name}, 1} );
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
       ( "auth", auth )
    );
 
-   tester1.chain->produce_blocks(2);
+   tester1.chain->produce_block();
 
    tester1.shutdown();
 
@@ -551,7 +551,7 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
    BOOST_REQUIRE_EQUAL(1u, num_deferred);
 
    // With charlie now in the actor blacklist, retiring the previously scheduled deferred transaction should now not be possible.
-   BOOST_CHECK_EXCEPTION( tester1.chain->produce_blocks(), fc::exception,
+   BOOST_CHECK_EXCEPTION( tester1.chain->produce_block(), fc::exception,
                           fc_exception_message_is("authorizing actor(s) in transaction are on the actor blacklist: [\"charlie\"]")
                         );
 
@@ -575,14 +575,14 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
    tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
    tester1.chain->set_code( "alice"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "alice"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
    tester1.chain->set_code( "charlie"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "charlie"_n,  test_contracts::deferred_test_abi() );
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
 
    auto auth = authority(eosio::testing::base_tester::get_public_key(name("alice"), "active"));
    auth.accounts.push_back( permission_level_weight{{"alice"_n, config::eosio_code_name}, 1} );
@@ -614,7 +614,7 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
       ( "auth", auth )
    );
 
-   tester1.chain->produce_blocks(2);
+   tester1.chain->produce_block();
 
    tester1.shutdown();
 
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
 
    // Retire the deferred transaction successfully despite charlie being on the actor blacklist.
    // This is allowed due to the fact that the sender of the deferred transaction (also charlie) is in the sender bypass list.
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
 
    num_deferred = tester1.chain->control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_REQUIRE_EQUAL(0u, num_deferred);
@@ -695,7 +695,7 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
 
    // Now retire the deferred transaction successfully despite charlie being on both the actor blacklist and bob being on the contract blacklist
    // This is allowed due to the fact that the sender of the deferred transaction (also charlie) is in the sender bypass list.
-   tester1.chain->produce_blocks();
+   tester1.chain->produce_block();
 
    num_deferred = tester1.chain->control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_REQUIRE_EQUAL(0u, num_deferred);
@@ -711,7 +711,7 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
    BOOST_REQUIRE_EQUAL(1u, num_deferred);
 
    // Ensure that if there if the sender is not on the sender bypass list, then the contract blacklist is enforced.
-   BOOST_CHECK_EXCEPTION( tester1.chain->produce_blocks(), fc::exception,
+   BOOST_CHECK_EXCEPTION( tester1.chain->produce_block(), fc::exception,
                           fc_exception_message_is("account 'bob' is on the contract blacklist") );
 
    whitelist_blacklist_tester<tester> tester2;


### PR DESCRIPTION
Remove extra block production not needed that only slow down test execution.

Partially #264