### PR TITLE
add test that leap3 and eosio state history log entries can be read

### DIFF
--- a/tests/ship_log.cpp
+++ b/tests/ship_log.cpp
@@ -1175,7 +1175,6 @@ BOOST_DATA_TEST_CASE(split_forks, bdata::xrange(1u, 6u), fork_size) try {
 
 //(manually) fabricate a leap 3.x ship log format and make sure it's readable
 BOOST_AUTO_TEST_CASE(old_log_format) try {
-   //just opens and closes an empty log a few times
    const temp_directory tmpdir;
 
    const unsigned begin_block = 2;


### PR DESCRIPTION
Manually craft a leap 3.x structured state history log and then read it back with current log reading code. Resolves #225. Both eosio and leap3 formats are treated identical in the code so don't see much of a need to craft an eosio formatted log.

A reminder on the differences,
https://github.com/AntelopeIO/spring/blob/3f78e0f134a819f5977c1d0747fbdb141392a83a/libraries/state_history/include/eosio/state_history/log.hpp#L194-L203