### PR TITLE
rename debian package to 'antelope-spring' to avoid conflict

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,12 +101,12 @@ jobs:
           zstdcat build.tar.zst | tar x
           cd build
           cpack
-          ../tools/tweak-deb.sh spring_*.deb
+          ../tools/tweak-deb.sh antelope-spring_*.deb
       - name: Install dev package
         if: matrix.platform != 'reproducible'
         run: |
           apt-get update && apt-get upgrade -y
-          apt-get install -y ./build/spring_*.deb ./build/spring-dev*.deb
+          apt-get install -y ./build/antelope-spring_*.deb ./build/antelope-spring-dev*.deb
       - name: Test using TestHarness
         if: matrix.platform != 'reproducible'
         run: |
@@ -115,15 +115,15 @@ jobs:
         uses: actions/upload-artifact@v4
         if: matrix.platform != 'reproducible'
         with:
-          name: spring-dev-${{matrix.platform}}-amd64
-          path: build/spring-dev*.deb
+          name: antelope-spring-dev-${{matrix.platform}}-amd64
+          path: build/antelope-spring-dev*.deb
           compression-level: 0
       - name: Upload spring package
         uses: actions/upload-artifact@v4
         if: matrix.platform == 'reproducible'
         with:
-          name: spring-deb-amd64
-          path: build/spring_*.deb
+          name: antelope-spring-deb-amd64
+          path: build/antelope-spring_*.deb
           compression-level: 0
 
   tests:
@@ -298,12 +298,12 @@ jobs:
         run: |
           rm -r *
       - if: ${{ matrix.test == 'deb-install' }}
-        name: Download spring-dev
+        name: Download antelope-spring-dev
         uses: actions/download-artifact@v4
         with:
-          name: spring-dev-${{matrix.platform}}-amd64
+          name: antelope-spring-dev-${{matrix.platform}}-amd64
       - if: ${{ matrix.test == 'deb-install' }}
-        name: Install spring-dev Package
+        name: Install antelope-spring-dev Package
         run: |
           apt-get install -y ./*.deb
           rm ./*.deb

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,23 +13,23 @@ jobs:
       packages: write
       actions: read
     steps:
-      - name: Get ubuntu20 spring-dev.deb
+      - name: Get ubuntu20 antelope-spring-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: 'spring-dev.*amd64.deb'
+          file: 'antelope-spring-dev.*amd64.deb'
           target: ${{github.sha}}
-          artifact-name: spring-dev-ubuntu20-amd64
+          artifact-name: antelope-spring-dev-ubuntu20-amd64
           wait-for-exact-target: true
-      - name: Get ubuntu22 spring-dev.deb
+      - name: Get ubuntu22 antelope-spring-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: 'spring-dev.*amd64.deb'
+          file: 'antelope-spring-dev.*amd64.deb'
           target: ${{github.sha}}
-          artifact-name: spring-dev-ubuntu22-amd64
+          artifact-name: antelope-spring-dev-ubuntu22-amd64
           wait-for-exact-target: true
       - name: Create Dockerfile
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.16 )
 
-project( spring )
+project( antelope-spring )
 include(CTest) # suppresses DartConfiguration.tcl error
 enable_testing()
 

--- a/package.cmake
+++ b/package.cmake
@@ -55,7 +55,7 @@ if(ENABLE_SPRING_DEV_DEB)
    list(APPEND CPACK_COMPONENTS_ALL "dev")
 endif()
 
-#enable per component packages for .deb; ensure main package is just "spring", not "spring-base", and make the dev package have "spring-dev" at the front not the back
+#enable per component packages for .deb; ensure main package is just "antelope-spring", not "antelope-spring-base", and make the dev package have "antelope-spring-dev" at the front not the back
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_BASE_PACKAGE_NAME "${CMAKE_PROJECT_NAME}")
 set(CPACK_DEBIAN_BASE_FILE_NAME "${CPACK_DEBIAN_FILE_NAME}.deb")


### PR DESCRIPTION
Renames the Debian package from `spring` to `antelope-spring` to avoid clashing with an already named `spring` package in Debian & Ubuntu standard package repo. Resolves #213

Unfortunately, will need to change both cdt & reference-contracts after merging this to update the expected package name.