### PR TITLE
change `experimental-binaries` to `antelope-spring-experimental-binaries` to avoid version overlap with leap packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
           password: ${{github.token}}
       - run: echo "REPOSITORY_OWNER_LOWER=${GITHUB_REPOSITORY_OWNER,,}" >> "${GITHUB_ENV}"
       - name: Build and push antelope-spring-experimental-binaries
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ghcr.io/${{env.REPOSITORY_OWNER_LOWER}}/antelope-spring-experimental-binaries:${{github.ref_name}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,9 +45,9 @@ jobs:
           username: ${{github.repository_owner}}
           password: ${{github.token}}
       - run: echo "REPOSITORY_OWNER_LOWER=${GITHUB_REPOSITORY_OWNER,,}" >> "${GITHUB_ENV}"
-      - name: Build and push experimental-binaries
+      - name: Build and push antelope-spring-experimental-binaries
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ghcr.io/${{env.REPOSITORY_OWNER_LOWER}}/spring-experimental-binaries:${{github.ref_name}}
+          tags: ghcr.io/${{env.REPOSITORY_OWNER_LOWER}}/antelope-spring-experimental-binaries:${{github.ref_name}}
           context: .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           cat <<EOF > Dockerfile
           FROM scratch
-          LABEL org.opencontainers.image.description="A collection of experimental Leap and Spring binary packages"
+          LABEL org.opencontainers.image.description="A collection of experimental Spring binary packages"
           COPY *.deb /
           EOF
       - name: Login to ghcr
@@ -49,5 +49,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ghcr.io/${{env.REPOSITORY_OWNER_LOWER}}/experimental-binaries:${{github.ref_name}}
+          tags: ghcr.io/${{env.REPOSITORY_OWNER_LOWER}}/spring-experimental-binaries:${{github.ref_name}}
           context: .


### PR DESCRIPTION
Since we're going to have to change downstream users of the dev package anyways due to #287, might as well make this change now too so we can resolve #50