### PR TITLE
[1.0-beta2] P2P: Fix multiple range requests while syncing

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2240,7 +2240,8 @@ namespace eosio {
          set_state( lib_catchup );
          sync_next_expected_num = chain_info.lib_num + 1;
       } else {
-         sync_next_expected_num = std::max( chain_info.lib_num + 1, sync_next_expected_num );
+         peer_dlog(c, "already syncing, start sync ignored");
+         return;
       }
 
       request_next_chunk( c );

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2148,13 +2148,6 @@ namespace eosio {
       fc_dlog( logger, "sync_last_requested_num: ${r}, sync_next_expected_num: ${e}, sync_known_lib_num: ${k}, sync_req_span: ${s}, fhead: ${h}, lib: ${lib}",
                ("r", sync_last_requested_num)("e", sync_next_expected_num)("k", sync_known_lib_num)("s", sync_req_span)("h", chain_info.fork_head_num)("lib", chain_info.lib_num) );
 
-      if( chain_info.fork_head_num + sync_req_span < sync_last_requested_num && sync_source && sync_source->current() ) {
-         fc_dlog( logger, "ignoring request, fhead is ${h} last req = ${r}, sync_next_expected_num: ${e}, sync_known_lib_num: ${k}, sync_req_span: ${s}, source connection ${c}",
-                  ("h", chain_info.fork_head_num)("r", sync_last_requested_num)("e", sync_next_expected_num)
-                  ("k", sync_known_lib_num)("s", sync_req_span)("c", sync_source->connection_id) );
-         return;
-      }
-
       if (conn) {
          // p2p_high_latency_test.py test depends on this exact log statement.
          peer_ilog(conn, "Catching up with chain, our last req is ${cc}, theirs is ${t}, next expected ${n}, fhead ${h}",

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2556,23 +2556,13 @@ namespace eosio {
                }
             }
 
-            // use chain head instead of fork head so we do not get too far ahead of applied blocks
-            uint32_t head = my_impl->get_chain_head_num();
-            if (head + sync_req_span > sync_last_requested_num) { // don't allow to get too far head (one sync_req_span)
-               if (sync_next_expected_num > sync_last_requested_num && sync_last_requested_num < sync_known_lib_num) {
-                  fc_dlog(logger, "Requesting range ahead, head: ${h} blk_num: ${bn} sync_next_expected_num ${nen} sync_last_requested_num: ${lrn}",
-                          ("h", head)("bn", blk_num)("nen", sync_next_expected_num)("lrn", sync_last_requested_num));
-                  request_next_chunk();
-                  return;
-               }
-            }
-
             if (!blk_applied && blk_num >= c->sync_last_requested_block) {
                // block was not applied, possibly because we already have the block
                // We didn't request the next chunk of blocks, request them anyway because we might need them to resolve a fork
-               fc_dlog(logger, "Requesting blocks, head: ${h} blk_num: ${bn} sync_next_expected_num ${nen} "
+               fc_dlog(logger, "Requesting blocks, head: ${h} fhead ${fh} blk_num: ${bn} sync_next_expected_num ${nen} "
                                "sync_last_requested_num: ${lrn}, sync_last_requested_block: ${lrb}",
-                       ("h", head)("bn", blk_num)("nen", sync_next_expected_num)
+                       ("h", my_impl->get_chain_head_num())("fh", my_impl->get_fork_head_num())
+                       ("bn", blk_num)("nen", sync_next_expected_num)
                        ("lrn", sync_last_requested_num)("lrb", c->sync_last_requested_block));
                request_next_chunk();
             }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2199,6 +2199,7 @@ namespace eosio {
       if( !request_sent ) {
          sync_source.reset();
          fc_wlog(logger, "Unable to request range, sending handshakes to everyone");
+         set_state( in_sync ); // need to be out of lib_catchup so start_sync will work
          send_handshakes();
       }
    }


### PR DESCRIPTION
Since blocks are processed immediately into the fork database when received, there is no longer any reason to request ahead of the existing range. Under normal circumstances a node will receive blocks from its peer and process them into the fork database. While those blocks are being applied additional blocks can be requested from the network. Care is taken to make sure that the fork database does not out run the chain head by more than `sync-fetch-span`.

Resolves #281 