### PR TITLE
Provide finalizer policy in SHiP finality_data only when it gets promoted to pending

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -153,7 +153,6 @@ void evaluate_finalizer_policies_for_promotion(const block_header_state& prev,
    if (target != prev_proposed.end()) {
       if (pending_slot_open) {
          // promote the target to pending
-         // https://github.com/AntelopeIO/spring/issues/306 will update generation properly
          auto block_num = next_header_state.block_num();
          next_pending.emplace(block_num, target->second);
       } else {

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -341,18 +341,16 @@ finality_data_t block_state::get_finality_data() {
       base_digest = compute_base_digest(); // cache it
    }
 
-   // Check if there is any proposed finalizer policy in the block
-   std::optional<finalizer_policy> proposed_finalizer_policy;
+   // Check if there is a finalizer policy promoted to pending in the block
+   std::optional<finalizer_policy> pending_fin_pol;
    if (is_savanna_genesis_block()) {
-      // For Genesis Block, use the active finalizer policy which was proposed in the block.
-      proposed_finalizer_policy = *active_finalizer_policy;
-   } else {
-      for (const auto& p: proposed_finalizer_policies) {
-         if (p.first == block_num()) {
-            proposed_finalizer_policy = *p.second;
-            break;
-         }
-      }
+      // For Genesis Block, use the active finalizer policy which went through
+      // proposed to pending to actived in the single block.
+      pending_fin_pol = *active_finalizer_policy;
+   } else if (pending_finalizer_policy.has_value() && pending_finalizer_policy->first == block_num()) {
+      // The `first` element of `pending_finalizer_policy` pair is the block number
+      // when the policy becomes pending
+      pending_fin_pol = *pending_finalizer_policy->second;
    }
 
    return {
@@ -361,7 +359,7 @@ finality_data_t block_state::get_finality_data() {
       .final_on_strong_qc_block_num       = core.final_on_strong_qc_block_num,
       .action_mroot                       = action_mroot,
       .base_digest                        = *base_digest,
-      .proposed_finalizer_policy          = std::move(proposed_finalizer_policy)
+      .pending_finalizer_policy           = std::move(pending_fin_pol)
    };
 }
 

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -345,7 +345,7 @@ finality_data_t block_state::get_finality_data() {
    std::optional<finalizer_policy> pending_fin_pol;
    if (is_savanna_genesis_block()) {
       // For Genesis Block, use the active finalizer policy which went through
-      // proposed to pending to actived in the single block.
+      // proposed to pending to active in the single block.
       pending_fin_pol = *active_finalizer_policy;
    } else if (pending_finalizer_policy.has_value() && pending_finalizer_policy->first == block_num()) {
       // The `first` element of `pending_finalizer_policy` pair is the block number

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -65,7 +65,7 @@ struct finality_data_t {
    uint32_t     final_on_strong_qc_block_num{0};
    digest_type  action_mroot{};
    digest_type  base_digest{};
-   std::optional<finalizer_policy> pending_finalizer_policy; // the finalizer policy, which is promoted from proposed in the block
+   std::optional<finalizer_policy> pending_finalizer_policy; // finalizer policy if one is promoted to pending in the block
 };
 
 struct block_state : public block_header_state {     // block_header_state provides parent link

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -65,7 +65,7 @@ struct finality_data_t {
    uint32_t     final_on_strong_qc_block_num{0};
    digest_type  action_mroot{};
    digest_type  base_digest{};
-   std::optional<finalizer_policy> proposed_finalizer_policy; // finalizer policy, if proposed in the block
+   std::optional<finalizer_policy> pending_finalizer_policy; // the finalizer policy, which is promoted from proposed in the block
 };
 
 struct block_state : public block_header_state {     // block_header_state provides parent link
@@ -183,5 +183,5 @@ using block_state_pair      = std::pair<std::shared_ptr<block_state_legacy>, blo
 // not exporting pending_qc or valid_qc
 FC_REFLECT( eosio::chain::valid_t::finality_leaf_node_t, (major_version)(minor_version)(block_num)(finality_digest)(action_mroot) )
 FC_REFLECT( eosio::chain::valid_t, (validation_tree)(validation_mroots))
-FC_REFLECT( eosio::chain::finality_data_t, (major_version)(minor_version)(active_finalizer_policy_generation)(final_on_strong_qc_block_num)(action_mroot)(base_digest)(proposed_finalizer_policy) )
+FC_REFLECT( eosio::chain::finality_data_t, (major_version)(minor_version)(active_finalizer_policy_generation)(final_on_strong_qc_block_num)(action_mroot)(base_digest)(pending_finalizer_policy) )
 FC_REFLECT_DERIVED( eosio::chain::block_state, (eosio::chain::block_header_state), (block)(strong_digest)(weak_digest)(pending_qc)(valid)(validated) )

--- a/libraries/state_history/abi.cpp
+++ b/libraries/state_history/abi.cpp
@@ -610,7 +610,7 @@ extern const char* const state_history_plugin_abi = R"({
                 { "name": "final_on_strong_qc_block_num", "type": "uint32" },
                 { "name": "action_mroot", "type": "checksum256" },
                 { "name": "base_digest", "type": "checksum256" },
-                { "name": "proposed_finalizer_policy", "type": "finalizer_policy?" }
+                { "name": "pending_finalizer_policy", "type": "finalizer_policy?" }
             ]
         }
     ],

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries( unit_test eosio_chain_wrap state_history chainbase eosio_
 
 target_compile_options(unit_test PUBLIC -DDISABLE_EOSLIB_SERIALIZE)
 target_include_directories( unit_test PUBLIC
+                            ${CMAKE_CURRENT_SOURCE_DIR}
                             ${CMAKE_SOURCE_DIR}/libraries/testing/include
                             ${CMAKE_SOURCE_DIR}/test-contracts
                             ${CMAKE_BINARY_DIR}/contracts

--- a/unittests/block_state_tests.cpp
+++ b/unittests/block_state_tests.cpp
@@ -1,4 +1,4 @@
-#include "finality_test_cluster.hpp"
+#include <finality_test_cluster.hpp>
 
 #include <eosio/chain/block_state.hpp>
 #include <eosio/testing/tester.hpp>

--- a/unittests/block_state_tests.cpp
+++ b/unittests/block_state_tests.cpp
@@ -394,7 +394,7 @@ BOOST_FIXTURE_TEST_CASE(get_finality_data_test, finality_test_cluster<4>) try {
    // It takes one 3-chain for LIB to advance and 1 LIB proposed finalizer to be promoted to pending.
    for (size_t i=0; i<3; ++i) {
       produce_and_push_block();
-      process_votes(1, num_nodes - 1); // all non-producing nodes (staring from node1) vote
+      process_votes(1, num_nodes - 1); // all non-producing nodes (starting from node1) vote
 
       // We should not see pending_finalizer_policy in finality_data
       finality_data = *node0.control->head_finality_data();

--- a/unittests/block_state_tests.cpp
+++ b/unittests/block_state_tests.cpp
@@ -404,14 +404,14 @@ BOOST_FIXTURE_TEST_CASE(get_finality_data_test, finality_test_cluster<4>) try {
    // Produce one more block. The proposed finalizer policy is promoted to pending in this block.
    // We should see pending_finalizer_policy in finality_data
    produce_and_push_block();
-   process_votes(1, num_nodes - 1); // all non-producing nodes (staring from node1) vote
+   process_votes(1, num_nodes - 1); // all non-producing nodes (starting from node1) vote
    finality_data = *node0.control->head_finality_data();
    BOOST_REQUIRE(finality_data.pending_finalizer_policy.has_value());
 
    // Produce another block. We should not see pending_finalizer_policy as
    // no proposed finalizer policy is promoted to pending in this block
    produce_and_push_block();
-   process_votes(1, num_nodes - 1); // all non-producing nodes (staring from node1) vote
+   process_votes(1, num_nodes - 1); // all non-producing nodes (starting from node1) vote
    finality_data = *node0.control->head_finality_data();
    BOOST_REQUIRE(!finality_data.pending_finalizer_policy.has_value());
 } FC_LOG_AND_RETHROW();


### PR DESCRIPTION
SHiP `finality_data` should only include the finalizer policy when it goes from proposed to pending. This PR renames the existing field `finality_data_t::proposed_finalizer_policy` to `finality_data_t::pending_finalizer_policy` (but keeping the same type std::optional<finalizer_policy>) to capture the semantic change, and changes the logic to include the finalizer policy only when it goes from proposed to pending

Adds a test to check pending_finalizer_policy in finality_data.

https://github.com/AntelopeIO/abieos/pull/32 is created in abieos repo for corresponding SHiP protocol changes.

Resolves https://github.com/AntelopeIO/spring/issues/320