### PR TITLE
[1.0-beta3 -> main] clear state history's finality log if savanna transition is forked out

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -191,8 +191,10 @@ public:
          return;
 
       std::optional<finality_data_t> finality_data = chain_plug->chain().head_finality_data();
-      if(!finality_data.has_value())
+      if(!finality_data.has_value()) {
+         finality_data_log->clear();
          return;
+      }
 
       finality_data_log->pack_and_write_entry(id, previous_id, [finality_data](bio::filtering_ostreambuf& buf) {
          fc::datastream<boost::iostreams::filtering_ostreambuf&> ds{buf};


### PR DESCRIPTION
main merge of #301:

Avoid state history finality log failure and node shutdown if savanna transition is forked out. Resolves #289. This is a fairly simple change that erases all finality data log files and reopens a fresh head log when savanna finality data is removed (which can only happen upon the transition being forked out).

An even simpler alternative would be to always write the `std::optional<finality_data_t>` out, which we could do instead, but that puts a little more burden on consumers.