### PR TITLE
Fix compilation warning due to missing `base_tester` destructor.

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -165,6 +165,9 @@ namespace eosio::testing {
          static const fc::microseconds abi_serializer_max_time;
          static constexpr fc::microseconds default_skip_time = fc::milliseconds(config::block_interval_ms);
 
+         virtual ~base_tester() {}
+         base_tester() = default;
+         base_tester(base_tester&&) = default;
 
          void              init(const setup_policy policy = setup_policy::full, db_read_mode read_mode = db_read_mode::HEAD, std::optional<uint32_t> genesis_max_inline_action_size = std::optional<uint32_t>{});
          void              init(controller::config config, const snapshot_reader_ptr& snapshot);


### PR DESCRIPTION
`base_tester` used to have an empty virtual destructor: `virtual ~base_tester() {}`. Having a destructor disables the implicit move constructor.

My `savanna_cluster` has `tester` as a base class of its node. It is convenient because we can call all the `tester` methods directly.

However, in a recent change as a PR review request, I updated  the nodes from the `savanna_cluster` to be stored in a `std::vector` instead of a `std::array`. `std::vector` requires its elements to have a  default and a move constructor.

To address this issue, in the recently merged PR, I removed `virtual ~base_tester() {}`, which has the side effect of re-enabling the default move constructor, so `savanna_cluster` compiled fine. However it created compilation warnings in other tests such as:

```
In file included from /home/greg/github/enf/spring/plugins/producer_plugin/test/test_trx_full.cpp:5:
/home/greg/github/enf/spring/libraries/testing/include/eosio/testing/tester.hpp:564:7: error: constructor for 'eosio::testing::tester' must explicitly initialize the base class 'base_tester' which does not have a default constructor
  564 |       tester(setup_policy policy = setup_policy::full, db_read_mode read_mode = db_read_mode::HEAD, std::optional<uint32_t> genesis_max_inline_action_size = std::optional<uint32_t>{}) {
      |       ^
```

This PR adds back the explicit empty destructor in `base_tester`, as well as the two required defaulted constructors. Everything now compiles without tester-related warnings.

