### PR TITLE
use `boost::unordered_flat_map` for iterator cache's `_object_to_iterator`

### DIFF
--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <boost/unordered/unordered_flat_map.hpp>
 #include <eosio/chain/controller.hpp>
 #include <eosio/chain/transaction.hpp>
 #include <eosio/chain/transaction_context.hpp>
@@ -92,7 +93,7 @@ class apply_context {
             map<table_id_object::id_type, pair<const table_id_object*, int>> _table_cache;
             vector<const table_id_object*>                  _end_iterator_to_table;
             vector<const T*>                                _iterator_to_object;
-            map<const T*,int>                               _object_to_iterator;
+            boost::unordered_flat_map<const T*,int>         _object_to_iterator;
 
             /// Precondition: std::numeric_limits<int>::min() < ei < -1
             /// Iterator of -1 is reserved for invalid iterators (i.e. when the appropriate table has not yet been created).


### PR DESCRIPTION
I've noticed for some time that,
https://github.com/AntelopeIO/spring/blob/d361a93bb548c8d79996b37e447569e95f9b1159/libraries/chain/include/eosio/chain/apply_context.hpp#L80-L89
shows up as taking 1.5%+ of main thread time on EOS. This function isn't doing much, and the iterator cache doesn't get large in practice. I'm not sure what is going on, but the overhead seems limited to libc++ builds (our pinned reproducible builds).

Switch the `_object_to_iterator` map to `boost::unordered_flat_map`. There is no ordering requirement for this map (either in consensus or as part of the implementation). For a replay over blocks 381452700 through 381632370, the pinned build improves by a consistent ~2%. There is no performance difference for a stdlibc++ build.

fwiw I tried a `boost::container::map` and it was even slower (a bit).