### PR TITLE
P2P: Reduce log spam of close on shutdown

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1453,6 +1453,10 @@ namespace eosio {
 
    // called from connection strand
    void connection::_close( bool reconnect, bool shutdown ) {
+      if (socket_open)
+         peer_ilog(this, "closing");
+      else
+         peer_dlog(this, "close called on already closed socket");
       socket_open = false;
       boost::system::error_code ec;
       socket->shutdown( tcp::socket::shutdown_both, ec );
@@ -1478,7 +1482,6 @@ namespace eosio {
       peer_requested.reset();
       sent_handshake_count = 0;
       if( !shutdown) my_impl->sync_master->sync_reset_lib_num( shared_from_this(), true );
-      peer_ilog( this, "closing" );
       cancel_wait();
       sync_last_requested_block = 0;
       org = std::chrono::nanoseconds{0};


### PR DESCRIPTION
Shutting down a node that is synching can result in many log messages like:
```
info  2024-07-11T13:06:43.744 net-2     net_plugin.cpp:1457           _close               ] ["eos.p2p.eosusa.io:9882 - 1bd8339" - 3 35.131.184.46:9882] closing
info  2024-07-11T13:06:43.744 net-2     net_plugin.cpp:1457           _close               ] ["eos.p2p.eosusa.io:9882 - 1bd8339" - 3 35.131.184.46:9882] closing
info  2024-07-11T13:06:43.744 net-2     net_plugin.cpp:1457           _close               ] ["eos.p2p.eosusa.io:9882 - 1bd8339" - 3 35.131.184.46:9882] closing
info  2024-07-11T13:06:43.744 net-2     net_plugin.cpp:1457           _close               ] ["eos.p2p.eosusa.io:9882 - 1bd8339" - 3 35.131.184.46:9882] closing
info  2024-07-11T13:06:43.744 net-2     net_plugin.cpp:1457           _close               ] ["eos.p2p.eosusa.io:9882 - 1bd8339" - 3 35.131.184.46:9882] closing
```

Change to only `info` log close if socket is open.