### PR TITLE
Add performance logs to captured CI/CD log tar

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -192,7 +192,7 @@ jobs:
         uses: ./.github/actions/parallel-ctest-containers
         with:
           container: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.cfg.base].image}}
-          error-log-paths: '["build/etc", "build/var", "build/spring-ignition-wd", "build/TestLogs"]'
+          error-log-paths: '["build/etc", "build/var", "build/spring-ignition-wd", "build/TestLogs", "build/PerformanceHarnessScenarioRunnerLogs"]'
           log-tarball-prefix: ${{matrix.cfg.name}}
           tests-label: nonparallelizable_tests
           test-timeout: 420
@@ -233,7 +233,7 @@ jobs:
         uses: ./.github/actions/parallel-ctest-containers
         with:
           container: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.cfg.base].image}}
-          error-log-paths: '["build/etc", "build/var", "build/spring-ignition-wd", "build/TestLogs"]'
+          error-log-paths: '["build/etc", "build/var", "build/spring-ignition-wd", "build/TestLogs", "build/PerformanceHarnessScenarioRunnerLogs"]'
           log-tarball-prefix: ${{matrix.cfg.name}}
           tests-label: long_running_tests
           test-timeout: 2700


### PR DESCRIPTION
Add `build/PerformanceHarnessScenarioRunnerLogs` to log paths captured by CI/CD for performance run logs. Performance runs copy their output to `PerformanceHarnessScenarioRunnerLogs` after the run. If they fail that directory needs to be captured otherwise there are no logs. See for example: https://github.com/AntelopeIO/spring/actions/runs/9896737400/job/27340099533#step:4:2208