### PR TITLE
Fix a bug in libtester `produce_blocks` and make SHiP unit tests work in both Savanna and Legacy

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4970,6 +4970,10 @@ void controller::allow_voting(bool val) {
    my->allow_voting = val;
 }
 
+bool controller::get_allow_voting_flag() {
+   return my->allow_voting;
+}
+
 void controller::set_async_voting(async_t val) {
    my->async_voting = val;
 }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -183,6 +183,7 @@ namespace eosio::chain {
          void sign_block( const signer_callback_type& signer_callback );
          void commit_block(block_report& br);
          void allow_voting(bool val);
+         bool get_allow_voting_flag();
          void set_async_voting(async_t val);
          void set_async_aggregation(async_t val);
          void maybe_switch_forks(const forked_callback_t& cb, const trx_meta_cache_lookup& trx_lookup);

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -542,10 +542,15 @@ namespace eosio::testing {
 
    signed_block_ptr base_tester::produce_blocks( uint32_t n, bool empty ) {
       signed_block_ptr res;
+      bool allow_voting_originally = control->get_allow_voting_flag();
+
       for (uint32_t i = 0; i < n; ++i) {
-         // for performance, only vote on the last four to move finality
+         // For performance, only vote on the last four to move finality.
+         // Modify allow_voting only if it was set to true originally;
+         // otherwise the allow_voting would be set to true when `i >= 4` even though the user of
+         // `produce_blocks` wants it to be true.
          // This is 4 instead of 3 because the extra block has to be produced to log_irreversible
-         if (n > 4)
+         if (allow_voting_originally && n > 4)
             control->allow_voting(i >= n - 4);
          res = empty ? produce_empty_block() : produce_block();
       }

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -708,8 +708,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_splitted_log, T, state_history_testers) {
    BOOST_CHECK(std::filesystem::exists( archive_dir / "chain_state_history-21-40.log" ));
    BOOST_CHECK(std::filesystem::exists( archive_dir / "chain_state_history-21-40.index" ));
 
-   BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-41-60.log" ));
-   BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-41-60.index" ));
+   if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
+      // Under Savanna, logs are archived earlier because LIB advances faster.
+      BOOST_CHECK(std::filesystem::exists( archive_dir / "trace_history-41-60.log" ));
+      BOOST_CHECK(std::filesystem::exists( archive_dir / "trace_history-41-60.index" ));
+   } else {
+      BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-41-60.log" ));
+      BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-41-60.index" ));
+   }
+
    BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-61-80.log" ));
    BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-61-80.index" ));
    BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-81-100.log" ));
@@ -718,11 +725,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_splitted_log, T, state_history_testers) {
    BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-101-120.index" ));
    BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-121-140.log" ));
    BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-121-140.index" ));
+   if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
+      BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-141-160.log" ));
+      BOOST_CHECK(std::filesystem::exists( retained_dir / "trace_history-141-160.index" ));
+   }
 
-   BOOST_CHECK_EQUAL(chain.traces_log.block_range().first, 41u);
+   if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
+      BOOST_CHECK_EQUAL(chain.traces_log.block_range().first, 61u);
+   }
+   else {
+      BOOST_CHECK_EQUAL(chain.traces_log.block_range().first, 41u);
+   }
 
-   BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-41-60.log" ));
-   BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-41-60.index" ));
+   if constexpr (std::is_same_v<T, state_history_tester<legacy_tester>>) {
+      BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-41-60.log" ));
+      BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-41-60.index" ));
+   }
    BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-61-80.log" ));
    BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-61-80.index" ));
    BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-81-100.log" ));
@@ -731,20 +749,36 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_splitted_log, T, state_history_testers) {
    BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-101-120.index" ));
    BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-121-140.log" ));
    BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-121-140.index" ));
+   if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
+      BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-141-160.log" ));
+      BOOST_CHECK(std::filesystem::exists( retained_dir / "chain_state_history-141-160.index" ));
+   }
 
-   BOOST_CHECK_EQUAL(chain.chain_state_log.block_range().first, 41u);
+   if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
+     BOOST_CHECK_EQUAL(chain.chain_state_log.block_range().first, 61u);
+   } else {
+     BOOST_CHECK_EQUAL(chain.chain_state_log.block_range().first, 41u);
+   }
 
    BOOST_CHECK(get_traces(chain.traces_log, 10).empty());
    BOOST_CHECK(get_traces(chain.traces_log, 100).size());
    BOOST_CHECK(get_traces(chain.traces_log, 140).size());
    BOOST_CHECK(get_traces(chain.traces_log, 150).size());
-   BOOST_CHECK(get_traces(chain.traces_log, 160).empty());
+   if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
+      BOOST_CHECK(get_traces(chain.traces_log, 160).size());
+   } else {
+      BOOST_CHECK(get_traces(chain.traces_log, 160).empty());
+   }
 
    BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 10).empty());
    BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 100).size());
    BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 140).size());
    BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 150).size());
-   BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 160).empty());
+   if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
+      BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 160).size());
+   } else {
+      BOOST_CHECK(get_decompressed_entry(chain.chain_state_log, 160).empty());
+   }
 }
 
 void push_blocks( tester& from, tester& to ) {

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -792,7 +792,6 @@ void push_blocks( tester& from, tester& to ) {
 
 template<typename T>
 bool test_fork(uint32_t stride, uint32_t max_retained_files) {
-
    fc::temp_directory state_history_dir;
 
    eosio::state_history::partition_config config{
@@ -812,9 +811,9 @@ bool test_fork(uint32_t stride, uint32_t max_retained_files) {
    chain1.produce_blocks(30, true);
 
    if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
-      // Do not vote the last block such that it won't become final when
-      // the first block from chain2 is pushed to chain1. This way, LIBs on chain1
-      // and chain2 are kept the same, and further blocks from chain2 can be
+      // Produce one more block; do not vote it such that it won't become final when
+      // the first block from chain2 is pushed to chain1. This is to ensure LIBs
+      // on chain1 and chain2 are the same, and further blocks from chain2 can be
       // pushed into chain1's forkdb.
       chain1.control->allow_voting(false);
       chain1.produce_block();
@@ -830,7 +829,7 @@ bool test_fork(uint32_t stride, uint32_t max_retained_files) {
    auto create_account_trace_id = create_account_traces[0]->id;
 
    if constexpr (std::is_same_v<T, state_history_tester<savanna_tester>>) {
-      // Disable voting on chain2 such that new blocks produced form a fork when
+      // Disable voting on chain2 such that chain2's blocks can form a fork when
       // pushed to chain1
       chain2.control->allow_voting(false);
    }
@@ -838,7 +837,7 @@ bool test_fork(uint32_t stride, uint32_t max_retained_files) {
    auto b = chain2.produce_block();
    chain2.produce_blocks(11+12, true);
 
-   // Merge blocks from chain2 to chain1 and select chain2 as the best chain.
+   // Merge blocks from chain2 to chain1 and make the chain from chain2 as the best chain.
    // Specifically in Savanna, as voting is disabled on both chains, block timestamps
    // are used to decide best chain. chain2 is selected because its last block's
    // timestamp is bigger than chain1's last block's.

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -620,9 +620,10 @@ struct state_history_tester_logs  {
    eosio::state_history::trace_converter trace_converter;
 };
 
-struct state_history_tester : state_history_tester_logs, legacy_tester {
+template<typename T>
+struct state_history_tester : state_history_tester_logs, T {
    state_history_tester(const std::filesystem::path& dir, const eosio::state_history::state_history_log_config& config)
-   : state_history_tester_logs(dir, config), legacy_tester ([this](eosio::chain::controller& control) {
+   : state_history_tester_logs(dir, config), T ([this](eosio::chain::controller& control) {
       control.applied_transaction().connect(
        [&](std::tuple<const transaction_trace_ptr&, const packed_transaction_ptr&> t) {
           trace_converter.add_transaction(std::get<0>(t), std::get<1>(t));
@@ -645,6 +646,9 @@ struct state_history_tester : state_history_tester_logs, legacy_tester {
       });
    }) {}
 };
+
+using state_history_testers = boost::mpl::list<state_history_tester<legacy_tester>,
+                                               state_history_tester<savanna_tester>>;
 
 static std::vector<char> get_decompressed_entry(eosio::state_history::log_catalog& log, block_num_type block_num) {
    std::optional<eosio::state_history::ship_log_entry> entry = log.get_entry(block_num);


### PR DESCRIPTION
Make SHiP unit tests run in both Savanna and Legacy:
* Fix a bug in libtester `produce_blocks()` which enables voting when it should not.
* Fix `test_splitted_log` such that it works in Savanna.
* Fix `test_fork` such that it works in Savanna.
* Update the rest of SHiP unit tests to work in both Savanna and Legacy.

Resolved https://github.com/AntelopeIO/spring/issues/179