### PR TITLE
Simplify API for accessing controller's `head`

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -470,7 +470,7 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
       trx.ref_block_prefix = 0;
    } else {
       trx.expiration = time_point_sec{control.pending_block_time() + fc::microseconds(999'999)}; // Rounds up to nearest second (makes expiration check unnecessary)
-      trx.set_reference_block(control.head_block_id()); // No TaPoS check necessary
+      trx.set_reference_block(control.head().id()); // No TaPoS check necessary
    }
 
    // Charge ahead of time for the additional net usage needed to retire the deferred transaction

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5080,6 +5080,10 @@ block_handle controller::head()const {
    return my->chain_head;
 }
 
+time_point controller::head_block_time()const {
+   return my->chain_head.block_time();
+}
+
 block_state_legacy_ptr controller::head_block_state_legacy()const {
    // returns null after instant finality activated
    return block_handle_accessor::apply_l<block_state_legacy_ptr>(my->chain_head, [](const auto& head) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5080,10 +5080,6 @@ block_handle controller::head()const {
    return my->chain_head;
 }
 
-uint32_t controller::head_block_num()const {
-   return my->chain_head.block_num();
-}
-
 block_state_legacy_ptr controller::head_block_state_legacy()const {
    // returns null after instant finality activated
    return block_handle_accessor::apply_l<block_state_legacy_ptr>(my->chain_head, [](const auto& head) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1049,6 +1049,13 @@ struct controller_impl {
    }
 
    // --------------- access fork_db head ----------------------------------------------------------------------
+   block_handle fork_db_head()const {
+      return fork_db.apply<block_handle>(
+         [&](const auto& forkdb) {
+            return block_handle{forkdb.head(include_root_t::yes)};
+         });
+   }
+
    uint32_t fork_db_head_block_num() const {
       return fork_db.apply<uint32_t>(
          [&](const auto& forkdb) {
@@ -2989,7 +2996,7 @@ struct controller_impl {
 
       EOS_ASSERT( skip_db_sessions(s) || db.revision() == chain_head.block_num(), database_exception,
                   "db revision is not on par with head block",
-                  ("db.revision()", db.revision())("controller_head_block", chain_head.block_num())("fork_db_head_block", fork_db_head_block_num()) );
+                  ("db.revision()", db.revision())("controller_head_block", chain_head.block_num())("fork_db_head_block", fork_db_head().block_num()) );
 
       block_handle_accessor::apply<void>(chain_head, overloaded{
                     [&](const block_state_legacy_ptr& head) {
@@ -5118,6 +5125,10 @@ const signed_block_ptr& controller::head_block()const {
 
 std::optional<finality_data_t> controller::head_finality_data() const {
    return my->head_finality_data();
+}
+
+block_handle controller::fork_db_head()const {
+   return my->fork_db_head();
 }
 
 uint32_t controller::fork_db_head_block_num()const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5083,9 +5083,22 @@ block_handle controller::head()const {
 uint32_t controller::head_block_num()const {
    return my->chain_head.block_num();
 }
-
+block_timestamp_type controller::head_block_timestamp()const {
+   return my->chain_head.block_time();
+}
 time_point controller::head_block_time()const {
    return my->chain_head.block_time();
+}
+block_id_type controller::head_block_id()const {
+   return my->chain_head.id();
+}
+
+account_name  controller::head_block_producer()const {
+   return my->chain_head.producer();
+}
+
+const block_header& controller::head_block_header()const {
+   return my->chain_head.header();
 }
 
 block_state_legacy_ptr controller::head_block_state_legacy()const {
@@ -5093,6 +5106,10 @@ block_state_legacy_ptr controller::head_block_state_legacy()const {
    return block_handle_accessor::apply_l<block_state_legacy_ptr>(my->chain_head, [](const auto& head) {
       return head;
    });
+}
+
+const signed_block_ptr& controller::head_block()const {
+   return my->chain_head.block();
 }
 
 std::optional<finality_data_t> controller::head_finality_data() const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5089,9 +5089,6 @@ block_timestamp_type controller::head_block_timestamp()const {
 time_point controller::head_block_time()const {
    return my->chain_head.block_time();
 }
-block_id_type controller::head_block_id()const {
-   return my->chain_head.id();
-}
 
 block_state_legacy_ptr controller::head_block_state_legacy()const {
    // returns null after instant finality activated

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5093,19 +5093,11 @@ block_id_type controller::head_block_id()const {
    return my->chain_head.id();
 }
 
-const block_header& controller::head_block_header()const {
-   return my->chain_head.header();
-}
-
 block_state_legacy_ptr controller::head_block_state_legacy()const {
    // returns null after instant finality activated
    return block_handle_accessor::apply_l<block_state_legacy_ptr>(my->chain_head, [](const auto& head) {
       return head;
    });
-}
-
-const signed_block_ptr& controller::head_block()const {
-   return my->chain_head.block();
 }
 
 std::optional<finality_data_t> controller::head_finality_data() const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4319,7 +4319,7 @@ struct controller_impl {
       //Look for expired transactions in the deduplication list, and remove them.
       auto& transaction_idx = db.get_mutable_index<transaction_multi_index>();
       const auto& dedupe_index = transaction_idx.indices().get<by_expiration>();
-      auto now = is_building_block() ? pending_block_time() : chain_head.block_time().to_time_point();
+      auto now = is_building_block() ? pending_block_time() : chain_head.timestamp().to_time_point();
       const auto total = dedupe_index.size();
       uint32_t num_removed = 0;
       while( (!dedupe_index.empty()) && ( now > dedupe_index.begin()->expiration.to_time_point() ) ) {
@@ -5082,9 +5082,6 @@ block_handle controller::head()const {
 
 uint32_t controller::head_block_num()const {
    return my->chain_head.block_num();
-}
-block_timestamp_type controller::head_block_timestamp()const {
-   return my->chain_head.block_time();
 }
 time_point controller::head_block_time()const {
    return my->chain_head.block_time();

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5093,10 +5093,6 @@ block_id_type controller::head_block_id()const {
    return my->chain_head.id();
 }
 
-account_name  controller::head_block_producer()const {
-   return my->chain_head.producer();
-}
-
 const block_header& controller::head_block_header()const {
    return my->chain_head.header();
 }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5080,6 +5080,10 @@ block_handle controller::head()const {
    return my->chain_head;
 }
 
+uint32_t controller::head_block_num()const {
+   return my->chain_head.block_num();
+}
+
 time_point controller::head_block_time()const {
    return my->chain_head.block_time();
 }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5083,9 +5083,6 @@ block_handle controller::head()const {
 uint32_t controller::head_block_num()const {
    return my->chain_head.block_num();
 }
-time_point controller::head_block_time()const {
-   return my->chain_head.block_time();
-}
 
 block_state_legacy_ptr controller::head_block_state_legacy()const {
    // returns null after instant finality activated

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -160,7 +160,7 @@ void apply_eosio_setcode(apply_context& context) {
       old_size  = (int64_t)old_code_entry.code.size() * config::setcode_ram_bytes_multiplier;
       if( old_code_entry.code_ref_count == 1 ) {
          db.remove(old_code_entry);
-         context.control.code_block_num_last_used(account.code_hash, account.vm_type, account.vm_version, context.control.head_block_num() + 1);
+         context.control.code_block_num_last_used(account.code_hash, account.vm_type, account.vm_version, context.control.head().block_num() + 1);
       } else {
          db.modify(old_code_entry, [](code_object& o) {
             --o.code_ref_count;
@@ -180,7 +180,7 @@ void apply_eosio_setcode(apply_context& context) {
             o.code_hash = code_hash;
             o.code.assign(act.code.data(), code_size);
             o.code_ref_count = 1;
-            o.first_block_used = context.control.head_block_num() + 1;
+            o.first_block_used = context.control.head().block_num() + 1;
             o.vm_type = act.vmtype;
             o.vm_version = act.vmversion;
          });

--- a/libraries/chain/include/eosio/chain/block_handle.hpp
+++ b/libraries/chain/include/eosio/chain/block_handle.hpp
@@ -28,7 +28,7 @@ public:
 
    uint32_t                block_num() const { return std::visit([](const auto& bsp) { return bsp->block_num(); }, _bsp); }
    block_timestamp_type    timestamp() const { return std::visit([](const auto& bsp) { return bsp->timestamp(); }, _bsp); };
-   time_point              block_time() const { return std::visit([](const auto& bsp) { return bsp->timestamp(); }, _bsp); };
+   time_point              block_time() const { return std::visit([](const auto& bsp) { return time_point{bsp->timestamp()}; }, _bsp); };
    const block_id_type&    id() const { return std::visit<const block_id_type&>([](const auto& bsp) -> const block_id_type& { return bsp->id(); }, _bsp); }
    const block_id_type&    previous() const { return std::visit<const block_id_type&>([](const auto& bsp) -> const block_id_type& { return bsp->previous(); }, _bsp); }
    const signed_block_ptr& block() const { return std::visit<const signed_block_ptr&>([](const auto& bsp) -> const signed_block_ptr& { return bsp->block; }, _bsp); }

--- a/libraries/chain/include/eosio/chain/block_handle.hpp
+++ b/libraries/chain/include/eosio/chain/block_handle.hpp
@@ -27,7 +27,8 @@ public:
    bool is_valid() const { return !_bsp.valueless_by_exception() && std::visit([](const auto& bsp) { return !!bsp; }, _bsp); }
 
    uint32_t                block_num() const { return std::visit([](const auto& bsp) { return bsp->block_num(); }, _bsp); }
-   block_timestamp_type    block_time() const { return std::visit([](const auto& bsp) { return bsp->timestamp(); }, _bsp); };
+   block_timestamp_type    timestamp() const { return std::visit([](const auto& bsp) { return bsp->timestamp(); }, _bsp); };
+   time_point              block_time() const { return std::visit([](const auto& bsp) { return bsp->timestamp(); }, _bsp); };
    const block_id_type&    id() const { return std::visit<const block_id_type&>([](const auto& bsp) -> const block_id_type& { return bsp->id(); }, _bsp); }
    const block_id_type&    previous() const { return std::visit<const block_id_type&>([](const auto& bsp) -> const block_id_type& { return bsp->previous(); }, _bsp); }
    const signed_block_ptr& block() const { return std::visit<const signed_block_ptr&>([](const auto& bsp) -> const signed_block_ptr& { return bsp->block; }, _bsp); }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -239,6 +239,7 @@ namespace eosio::chain {
          void   set_disable_replay_opts( bool v );
 
          block_handle         head()const;
+         time_point           head_block_time()const;
 
          // returns nullptr after instant finality enabled
          block_state_legacy_ptr head_block_state_legacy()const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -239,8 +239,14 @@ namespace eosio::chain {
          void   set_disable_replay_opts( bool v );
 
          block_handle         head()const;
-         uint32_t             head_block_num()const;
-         time_point           head_block_time()const;
+
+         [[deprecated("Use head().block_num().")]]  uint32_t             head_block_num()const;
+         [[deprecated("Use head().block_time().")]] time_point           head_block_time()const;
+         [[deprecated("Use head().timestamp().")]]  block_timestamp_type head_block_timestamp()const;
+         [[deprecated("Use head().id().")]]         block_id_type        head_block_id()const;
+         [[deprecated("Use head().producer().")]]   account_name         head_block_producer()const;
+         [[deprecated("Use head().header().")]]     const block_header&  head_block_header()const;
+         [[deprecated("Use head().block().")]]      const signed_block_ptr& head_block()const;
 
          // returns nullptr after instant finality enabled
          block_state_legacy_ptr head_block_state_legacy()const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -239,13 +239,7 @@ namespace eosio::chain {
          void   set_disable_replay_opts( bool v );
 
          block_handle         head()const;
-         uint32_t             head_block_num()const;
-         time_point           head_block_time()const;
-         block_timestamp_type head_block_timestamp()const;
-         block_id_type        head_block_id()const;
-         account_name         head_block_producer()const;
-         const block_header&  head_block_header()const;
-         const signed_block_ptr& head_block()const;
+
          // returns nullptr after instant finality enabled
          block_state_legacy_ptr head_block_state_legacy()const;
          // returns finality_data associated with chain head for SHiP when in Savanna,

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -239,6 +239,7 @@ namespace eosio::chain {
          void   set_disable_replay_opts( bool v );
 
          block_handle         head()const;
+         uint32_t             head_block_num()const;
          time_point           head_block_time()const;
 
          // returns nullptr after instant finality enabled

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -240,6 +240,7 @@ namespace eosio::chain {
          void   set_disable_replay_opts( bool v );
 
          block_handle         head()const;
+         block_handle         fork_db_head()const;
 
          [[deprecated("Use head().block_num().")]]  uint32_t             head_block_num()const;
          [[deprecated("Use head().block_time().")]] time_point           head_block_time()const;
@@ -255,8 +256,8 @@ namespace eosio::chain {
          // std::nullopt in Legacy
          std::optional<finality_data_t> head_finality_data() const;
 
-         uint32_t             fork_db_head_block_num()const;
-         block_id_type        fork_db_head_block_id()const;
+         [[deprecated("Use fork_db_head().block_num().")]] uint32_t      fork_db_head_block_num()const;
+         [[deprecated("Use fork_db_head().id().")]]        block_id_type fork_db_head_block_id()const;
 
          time_point                     pending_block_time()const;
          block_timestamp_type           pending_block_timestamp()const;

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -159,7 +159,7 @@ void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chai
 void snapshot_scheduler::create_snapshot(next_function<snapshot_information> next, chain::controller& chain, std::function<void(void)> predicate) {
    auto head_id = chain.head().id();
    const auto head_block_num = chain.head_block_num();
-   const auto head_block_time = chain.head_block_time();
+   const auto head_block_time = chain.head().block_time();
    const auto& snapshot_path = pending_snapshot<snapshot_information>::get_final_path(head_id, _snapshots_dir);
    const auto& temp_path = pending_snapshot<snapshot_information>::get_temp_path(head_id, _snapshots_dir);
 

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -157,7 +157,7 @@ void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chai
 }
 
 void snapshot_scheduler::create_snapshot(next_function<snapshot_information> next, chain::controller& chain, std::function<void(void)> predicate) {
-   auto head_id = chain.head_block_id();
+   auto head_id = chain.head().id();
    const auto head_block_num = chain.head_block_num();
    const auto head_block_time = chain.head_block_time();
    const auto& snapshot_path = pending_snapshot<snapshot_information>::get_final_path(head_id, _snapshots_dir);

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -158,7 +158,7 @@ void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chai
 
 void snapshot_scheduler::create_snapshot(next_function<snapshot_information> next, chain::controller& chain, std::function<void(void)> predicate) {
    auto head_id = chain.head().id();
-   const auto head_block_num = chain.head_block_num();
+   const auto head_block_num = chain.head().block_num();
    const auto head_block_time = chain.head().block_time();
    const auto& snapshot_path = pending_snapshot<snapshot_information>::get_final_path(head_id, _snapshots_dir);
    const auto& temp_path = pending_snapshot<snapshot_information>::get_temp_path(head_id, _snapshots_dir);

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -58,7 +58,7 @@ namespace eosio::chain {
          undo_session.emplace(c.mutable_db().start_undo_session(true));
       }
       trace->id = id;
-      trace->block_num = c.head_block_num() + 1;
+      trace->block_num = c.head().block_num() + 1;
       trace->block_time = c.pending_block_time();
       trace->producer_block_id = c.pending_producer_block_id();
 
@@ -838,7 +838,7 @@ namespace eosio::chain {
       EOS_ASSERT(producers.size() <= config::max_proposers, wasm_execution_error,
                  "Producer schedule exceeds the maximum proposer count for this chain");
 
-      trx_blk_context.proposed_schedule_block_num = control.head_block_num() + 1;
+      trx_blk_context.proposed_schedule_block_num = control.head().block_num() + 1;
       // proposed_schedule.version is set in assemble_block
       trx_blk_context.proposed_schedule.producers = std::move(producers);
 
@@ -846,7 +846,7 @@ namespace eosio::chain {
    }
 
    void transaction_context::set_proposed_finalizers(finalizer_policy&& fin_pol) {
-      trx_blk_context.proposed_fin_pol_block_num = control.head_block_num() + 1;
+      trx_blk_context.proposed_fin_pol_block_num = control.head().block_num() + 1;
       trx_blk_context.proposed_fin_pol = std::move(fin_pol);
    }
 

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -791,7 +791,7 @@ namespace eosio::testing {
       bool validate() {
         const auto& hbh = control->head().header();
         const auto& vn_hbh = validating_node->head().header();
-        bool ok = control->head_block_id() == validating_node->head_block_id() &&
+        bool ok = control->head().id() == validating_node->head().id() &&
                hbh.previous == vn_hbh.previous &&
                hbh.timestamp == vn_hbh.timestamp &&
                hbh.transaction_mroot == vn_hbh.transaction_mroot &&

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -514,7 +514,7 @@ namespace eosio::testing {
          // -----------------------------------------------------------------
          void check_head_finalizer_policy(uint32_t generation,
                                           std::span<const bls_public_key> keys_span) {
-            auto finpol = active_finalizer_policy(control->head_block_header().calculate_id());
+            auto finpol = active_finalizer_policy(control->head().header().calculate_id());
             BOOST_REQUIRE(!!finpol);
             BOOST_REQUIRE_EQUAL(finpol->generation, generation);
             BOOST_REQUIRE_EQUAL(keys_span.size(), finpol->finalizers.size());
@@ -789,8 +789,8 @@ namespace eosio::testing {
       }
 
       bool validate() {
-        const auto& hbh = control->head_block_header();
-        const auto& vn_hbh = validating_node->head_block_header();
+        const auto& hbh = control->head().header();
+        const auto& vn_hbh = validating_node->head().header();
         bool ok = control->head_block_id() == validating_node->head_block_id() &&
                hbh.previous == vn_hbh.previous &&
                hbh.timestamp == vn_hbh.timestamp &&

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -507,7 +507,11 @@ namespace eosio::testing {
             return {cfg, gen};
          }
 
+         // ideally, users of `tester` should not access the controller directly
+         // so we provide APIs to access the chain head and fork_db head
+         // --------------------------------------------------------------------
          block_handle head() const { return control->head(); }
+         block_handle fork_db_head() const { return control->fork_db_head(); }
 
          // checks that the active `finalizer_policy` for `block` matches the
          // passed `generation` and `keys_span`.

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -458,7 +458,7 @@ namespace eosio::testing {
    }
 
    transaction_trace_ptr base_tester::_start_block(fc::time_point block_time) {
-      auto head_block_number = control->head_block_num();
+      auto head_block_number = control->head().block_num();
       auto producer = control->head_active_producers().get_scheduled_producer(block_time);
 
       auto last_produced_block_num = control->last_irreversible_block_num();
@@ -570,7 +570,7 @@ namespace eosio::testing {
       while(true) {
          blocks_per_round = control->active_producers().producers.size() * config::producer_repetitions;
          produce_block();
-         if (control->head_block_num() % blocks_per_round == (blocks_per_round - 1)) break;
+         if (control->head().block_num() % blocks_per_round == (blocks_per_round - 1)) break;
       }
    }
 
@@ -1145,11 +1145,11 @@ namespace eosio::testing {
       if (control->head().id() == other.control->head().id())
          return;
       // If other has a longer chain than we do, sync it to us first
-      if (control->head_block_num() < other.control->head_block_num())
+      if (control->head().block_num() < other.control->head().block_num())
          return other.sync_with(*this);
 
       auto sync_dbs = [](base_tester& a, base_tester& b) {
-         for( uint32_t i = 1; i <= a.control->head_block_num(); ++i ) {
+         for( uint32_t i = 1; i <= a.control->head().block_num(); ++i ) {
 
             auto block = a.control->fetch_block_by_number(i);
             if( block ) { //&& !b.control->is_known_block(block->id()) ) {
@@ -1355,7 +1355,7 @@ namespace eosio::testing {
    void base_tester::preactivate_builtin_protocol_features(const std::vector<builtin_protocol_feature_t>& builtins) {
       const auto& pfm = control->get_protocol_feature_manager();
       const auto& pfs = pfm.get_protocol_feature_set();
-      const auto current_block_num  =  control->head_block_num() + (control->is_building_block() ? 1 : 0);
+      const auto current_block_num  =  control->head().block_num() + (control->is_building_block() ? 1 : 0);
       const auto current_block_time = ( control->is_building_block() ? control->pending_block_time()
                                         : control->head().block_time() + fc::milliseconds(config::block_interval_ms) );
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -182,7 +182,7 @@ namespace eosio::testing {
    }
 
    bool base_tester::is_same_chain( base_tester& other ) {
-     return control->head_block_id() == other.control->head_block_id();
+     return control->head().id() == other.control->head().id();
    }
 
    void base_tester::init(const setup_policy policy, db_read_mode read_mode, std::optional<uint32_t> genesis_max_inline_action_size) {
@@ -599,7 +599,7 @@ namespace eosio::testing {
 
    void base_tester::set_transaction_headers( transaction& trx, uint32_t expiration, uint32_t delay_sec ) const {
       trx.expiration = fc::time_point_sec{control->head_block_time() + fc::seconds(expiration)};
-      trx.set_reference_block( control->head_block_id() );
+      trx.set_reference_block( control->head().id() );
 
       trx.max_net_usage_words = 0; // No limit
       trx.max_cpu_usage_ms = 0; // No limit
@@ -1142,7 +1142,7 @@ namespace eosio::testing {
 
    void base_tester::sync_with(base_tester& other) {
       // Already in sync?
-      if (control->head_block_id() == other.control->head_block_id())
+      if (control->head().id() == other.control->head().id())
          return;
       // If other has a longer chain than we do, sync it to us first
       if (control->head_block_num() < other.control->head_block_num())

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -414,7 +414,7 @@ namespace eosio::testing {
    produce_block_result_t base_tester::_produce_block( fc::microseconds skip_time, bool skip_pending_trxs, bool no_throw ) {
       produce_block_result_t res;
 
-      auto head_time = control->head_block_time();
+      auto head_time = control->head().block_time();
       auto next_time = head_time + skip_time;
       static transaction_trace_ptr onblock_trace;
 
@@ -598,7 +598,7 @@ namespace eosio::testing {
 
 
    void base_tester::set_transaction_headers( transaction& trx, uint32_t expiration, uint32_t delay_sec ) const {
-      trx.expiration = fc::time_point_sec{control->head_block_time() + fc::seconds(expiration)};
+      trx.expiration = fc::time_point_sec{control->head().block_time() + fc::seconds(expiration)};
       trx.set_reference_block( control->head().id() );
 
       trx.max_net_usage_words = 0; // No limit
@@ -659,7 +659,7 @@ namespace eosio::testing {
                                                       )
    { try {
       if( !control->is_building_block() )
-         _start_block(control->head_block_time() + fc::microseconds(config::block_interval_us));
+         _start_block(control->head().block_time() + fc::microseconds(config::block_interval_us));
 
       auto ptrx = std::make_shared<packed_transaction>(trx);
       auto time_limit = deadline == fc::time_point::maximum() ?
@@ -680,7 +680,7 @@ namespace eosio::testing {
                                                       )
    { try {
       if( !control->is_building_block() )
-         _start_block(control->head_block_time() + fc::microseconds(config::block_interval_us));
+         _start_block(control->head().block_time() + fc::microseconds(config::block_interval_us));
       auto c = packed_transaction::compression_type::none;
 
       if( fc::raw::pack_size(trx) > 1000 ) {
@@ -1357,7 +1357,7 @@ namespace eosio::testing {
       const auto& pfs = pfm.get_protocol_feature_set();
       const auto current_block_num  =  control->head_block_num() + (control->is_building_block() ? 1 : 0);
       const auto current_block_time = ( control->is_building_block() ? control->pending_block_time()
-                                        : control->head_block_time() + fc::milliseconds(config::block_interval_ms) );
+                                        : control->head().block_time() + fc::milliseconds(config::block_interval_ms) );
 
       set<digest_type>    preactivation_set;
       vector<digest_type> preactivations;

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -146,7 +146,7 @@ namespace eosio::chain_apis {
 
          // build a initial time to block number map
          const auto lib_num = controller.last_irreversible_block_num();
-         const auto head_num = controller.head_block_num();
+         const auto head_num = controller.head().block_num();
 
          for (uint32_t block_num = lib_num + 1; block_num <= head_num; block_num++) {
             const auto block_p = controller.fetch_block_by_number(block_num);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1019,7 +1019,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
             } );
 
       get_head_block_id_provider = app().get_method<methods::get_head_block_id>().register_provider( [this]() {
-         return chain->head_block_id();
+         return chain->head().id();
       } );
 
       get_last_irreversible_block_number_provider = app().get_method<methods::get_last_irreversible_block_number>().register_provider(
@@ -1289,7 +1289,7 @@ const string read_only::KEYi64 = "i64";
 read_only::get_info_results read_only::get_info(const read_only::get_info_params&, const fc::time_point&) const {
    const auto& rm = db.get_resource_limits_manager();
 
-   auto head_id = db.head_block_id();
+   auto head_id = db.head().id();
    auto lib_id = db.last_irreversible_block_id();
    auto fhead_id = db.fork_db_head_block_id();
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1291,7 +1291,7 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
 
    auto head_id = db.head().id();
    auto lib_id = db.last_irreversible_block_id();
-   auto fhead_id = db.fork_db_head_block_id();
+   auto fhead_id = db.fork_db_head().id();
 
    return {
       itoh(static_cast<uint32_t>(app().version())),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1132,10 +1132,10 @@ void chain_plugin_impl::plugin_startup()
 
    if (genesis) {
       ilog("Blockchain started; head block is #${num}, genesis timestamp is ${ts}",
-           ("num", chain->head_block_num())("ts", genesis->initial_timestamp));
+           ("num", chain->head().block_num())("ts", genesis->initial_timestamp));
    }
    else {
-      ilog("Blockchain started; head block is #${num}", ("num", chain->head_block_num()));
+      ilog("Blockchain started; head block is #${num}", ("num", chain->head().block_num()));
    }
 
    chain_config.reset();
@@ -2392,7 +2392,7 @@ read_only::get_account_return_t read_only::get_account( const get_account_params
    const auto& d = db.db();
    const auto& rm = db.get_resource_limits_manager();
 
-   result.head_block_num  = db.head_block_num();
+   result.head_block_num  = db.head().block_num();
    result.head_block_time = db.head().block_time();
 
    rm.get_account_limits( result.account_name, result.ram_quota, result.net_weight, result.cpu_weight );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1300,7 +1300,7 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       block_header::num_from_id(lib_id),
       lib_id,
       head_id,
-      db.head_block_time(),
+      db.head().block_time(),
       db.head().producer(),
       rm.get_virtual_block_cpu_limit(),
       rm.get_virtual_block_net_limit(),
@@ -2393,7 +2393,7 @@ read_only::get_account_return_t read_only::get_account( const get_account_params
    const auto& rm = db.get_resource_limits_manager();
 
    result.head_block_num  = db.head_block_num();
-   result.head_block_time = db.head_block_time();
+   result.head_block_time = db.head().block_time();
 
    rm.get_account_limits( result.account_name, result.ram_quota, result.net_weight, result.cpu_weight );
 
@@ -2405,7 +2405,7 @@ read_only::get_account_return_t read_only::get_account( const get_account_params
    result.created          = accnt_obj.creation_date;
 
    uint32_t greylist_limit = db.is_resource_greylisted(result.account_name) ? 1 : config::maximum_elastic_resource_multiplier;
-   const block_timestamp_type current_usage_time (db.head_block_time());
+   const block_timestamp_type current_usage_time (db.head().block_time());
    result.net_limit.set( rm.get_account_net_limit_ex( result.account_name, greylist_limit, current_usage_time).first );
    if ( result.net_limit.last_usage_update_time && (result.net_limit.last_usage_update_time->slot == 0) ) {   // account has no action yet
       result.net_limit.last_usage_update_time = accnt_obj.creation_date;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1301,7 +1301,7 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       lib_id,
       head_id,
       db.head_block_time(),
-      db.head_block_producer(),
+      db.head().producer(),
       rm.get_virtual_block_cpu_limit(),
       rm.get_virtual_block_net_limit(),
       rm.get_block_cpu_limit(),

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3297,7 +3297,7 @@ namespace eosio {
          fc::lock_guard g( chain_info_mtx );
          chain_info.lib_id = cc.last_irreversible_block_id();
          chain_info.lib_num = lib_num = block_header::num_from_id(chain_info.lib_id);
-         chain_info.head_id = cc.head_block_id();
+         chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
          chain_info.fork_head_id = cc.fork_db_head_block_id();
          chain_info.fork_head_num = fork_head_num = block_header::num_from_id(chain_info.fork_head_id);
@@ -3313,7 +3313,7 @@ namespace eosio {
          fc::lock_guard g( chain_info_mtx );
          chain_info.lib_id = lib;
          chain_info.lib_num = lib_num = block_header::num_from_id(lib);
-         chain_info.head_id = cc.head_block_id();
+         chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
          chain_info.fork_head_id = cc.fork_db_head_block_id();
          chain_info.fork_head_num = fork_head_num = block_header::num_from_id(chain_info.fork_head_id);

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3299,7 +3299,7 @@ namespace eosio {
          chain_info.lib_num = lib_num = block_header::num_from_id(chain_info.lib_id);
          chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
-         chain_info.fork_head_id = cc.fork_db_head_block_id();
+         chain_info.fork_head_id = cc.fork_db_head().id();
          chain_info.fork_head_num = fork_head_num = block_header::num_from_id(chain_info.fork_head_id);
       }
       fc_dlog( logger, "updating chain info lib ${lib}, head ${h} fhead ${f}", ("lib", lib_num)("h", head_num)("f", fork_head_num) );
@@ -3315,7 +3315,7 @@ namespace eosio {
          chain_info.lib_num = lib_num = block_header::num_from_id(lib);
          chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
-         chain_info.fork_head_id = cc.fork_db_head_block_id();
+         chain_info.fork_head_id = cc.fork_db_head().id();
          chain_info.fork_head_num = fork_head_num = block_header::num_from_id(chain_info.fork_head_id);
       }
       fc_dlog( logger, "updating chain info lib ${lib}, head ${h} fhead ${f}", ("lib", lib_num)("h", head_num)("f", fork_head_num) );

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2741,7 +2741,7 @@ void producer_plugin_impl::produce_block() {
    br.total_time += fc::time_point::now() - start;
    chain.commit_block(br);
 
-   const auto& new_b = chain.head_block();
+   const auto& new_b = chain.head().block();
    if (_update_produced_block_metrics) {
       producer_plugin::produced_block_metrics metrics;
       metrics.unapplied_transactions_total = _unapplied_transactions.size();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -450,7 +450,7 @@ public:
          reschedule.cancel();
       }
 
-      return {chain.head_block_id(), chain.calculate_integrity_hash()};
+      return {chain.head().id(), chain.calculate_integrity_hash()};
    }
 
    void create_snapshot(producer_plugin::next_function<chain::snapshot_scheduler::snapshot_information> next) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -845,7 +845,7 @@ public:
 
    void restart_speculative_block() {
       // log message is used by Node.py verifyStartingBlockMessages in distributed-transactions-test.py test
-      fc_dlog(_log, "Restarting exhausted speculative block #${n}", ("n", chain_plug->chain().head_block_num() + 1));
+      fc_dlog(_log, "Restarting exhausted speculative block #${n}", ("n", chain_plug->chain().head().block_num() + 1));
       // abort the pending block
       abort_block();
       schedule_production_loop();
@@ -1456,7 +1456,7 @@ void producer_plugin_impl::plugin_startup() {
             ilog("Launching block production for ${n} producers at ${time}.", ("n", _producers.size())("time", fc::time_point::now()));
 
             if (_production_enabled) {
-               if (chain.head_block_num() == 0) {
+               if (chain.head().block_num() == 0) {
                   new_chain_banner(chain);
                }
             }
@@ -1628,7 +1628,7 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<chain::snap
 chain::snapshot_scheduler::snapshot_schedule_result
 producer_plugin::schedule_snapshot(const chain::snapshot_scheduler::snapshot_request_params& srp) {
    chain::controller& chain = my->chain_plug->chain();
-   const auto head_block_num = chain.head_block_num();
+   const auto head_block_num = chain.head().block_num();
 
    // missing start/end is set to head block num, missing end to UINT32_MAX
    chain::snapshot_scheduler::snapshot_request_information sri = {
@@ -1859,7 +1859,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    chain.maybe_switch_forks([this](const transaction_metadata_ptr& trx) { _unapplied_transactions.add_forked(trx); },
                             [this](const transaction_id_type& id) { return _unapplied_transactions.get_trx(id); });
 
-   uint32_t head_block_num = chain.head_block_num();
+   uint32_t head_block_num = chain.head().block_num();
 
    if (chain.get_terminate_at_block() > 0 && chain.get_terminate_at_block() <= head_block_num) {
       ilog("Block ${n} reached configured maximum block ${num}; terminating", ("n",head_block_num)("num", chain.get_terminate_at_block()));
@@ -2176,17 +2176,17 @@ void producer_plugin_impl::log_trx_results(const packed_transaction_ptr& trx,
       if (in_producing_mode()) {
          fc_dlog(is_transient ? _transient_trx_failed_trace_log : _trx_failed_trace_log,
                  "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING ${desc}tx: ${txid}, auth: ${a}, ${details}",
-                 ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())("desc", is_transient ? "transient " : "")
+                 ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())("desc", is_transient ? "transient " : "")
                  ("txid", trx->id())("a", trx->get_transaction().first_authorizer())
                  ("details", get_detailed_contract_except_info(trx, trace, except_ptr)));
 
          if (!is_transient) {
             fc_dlog(_trx_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING tx: ${trx}",
-                    ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())
+                    ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())
                     ("trx", chain_plug->get_log_trx(trx->get_transaction())));
             fc_dlog(_trx_trace_failure_log,
                     "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING tx: ${entire_trace}",
-                    ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())
+                    ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())
                     ("entire_trace", get_trace(trace, except_ptr)));
          }
       } else {
@@ -2206,14 +2206,14 @@ void producer_plugin_impl::log_trx_results(const packed_transaction_ptr& trx,
       if (in_producing_mode()) {
          fc_dlog(is_transient ? _transient_trx_successful_trace_log : _trx_successful_trace_log,
                  "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING ${desc}tx: ${txid}, auth: ${a}, cpu: ${cpu}",
-                 ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())("desc", is_transient ? "transient " : "")
+                 ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())("desc", is_transient ? "transient " : "")
                  ("txid", trx->id())("a", trx->get_transaction().first_authorizer())("cpu", billed_cpu_us));
          if (!is_transient) {
             fc_dlog(_trx_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING tx: ${trx}",
-                    ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())
+                    ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())
                     ("trx", chain_plug->get_log_trx(trx->get_transaction())));
             fc_dlog(_trx_trace_success_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING tx: ${entire_trace}",
-                    ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())
+                    ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())
                     ("entire_trace", get_trace(trace, except_ptr)));
          }
       } else {
@@ -2255,7 +2255,7 @@ producer_plugin_impl::push_result producer_plugin_impl::push_transaction(const f
          auto except_ptr = std::static_pointer_cast<fc::exception>(std::make_shared<tx_cpu_usage_exceeded>(
             FC_LOG_MESSAGE(error, "transaction ${id} exceeded failure limit for account ${a} until ${next_reset_time}",
                            ("id", trx->id())("a", first_auth)
-                           ("next_reset_time", _account_fails.next_reset_timepoint(chain.head_block_num(), chain.head().block_time())))));
+                           ("next_reset_time", _account_fails.next_reset_timepoint(chain.head().block_num(), chain.head().block_time())))));
          log_trx_results(trx, except_ptr);
          next(except_ptr);
       }
@@ -2310,7 +2310,7 @@ producer_plugin_impl::handle_push_result(const transaction_metadata_ptr&        
          if( in_producing_mode() ) {
             fc_dlog(trx->is_transient() ? _transient_trx_failed_trace_log : _trx_failed_trace_log,
                     "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
-                    ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())("txid", trx->id()));
+                    ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())("txid", trx->id()));
          } else {
             fc_dlog(trx->is_transient() ? _transient_trx_failed_trace_log : _trx_failed_trace_log,
                     "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING", ("txid", trx->id()));
@@ -2461,11 +2461,11 @@ bool producer_plugin_impl::retire_deferred_trxs(const fc::time_point& deadline) 
             } else {
                fc_dlog(_trx_failed_trace_log,
                        "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING scheduled tx: ${txid}, time: ${r}, auth: ${a} : ${details}",
-                       ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())("txid", trx_id)("r", end - start)
+                       ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())("txid", trx_id)("r", end - start)
                        ("a", get_first_authorizer(trace))("details", get_detailed_contract_except_info(nullptr, trace, nullptr)));
                fc_dlog(_trx_trace_failure_log,
                        "[TRX_TRACE] Block ${block_num} for producer ${prod} is REJECTING scheduled tx: ${entire_trace}",
-                       ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())
+                       ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())
                        ("entire_trace", chain_plug->get_log_trx_trace(trace)));
                num_failed++;
             }
@@ -2473,11 +2473,11 @@ bool producer_plugin_impl::retire_deferred_trxs(const fc::time_point& deadline) 
             trx_tracker.trx_success();
             fc_dlog(_trx_successful_trace_log,
                     "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING scheduled tx: ${txid}, time: ${r}, auth: ${a}, cpu: ${cpu}",
-                    ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())("txid", trx_id)("r", end - start)
+                    ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())("txid", trx_id)("r", end - start)
                     ("a", get_first_authorizer(trace))("cpu", trace->receipt ? trace->receipt->cpu_usage_us : 0));
             fc_dlog(_trx_trace_success_log,
                     "[TRX_TRACE] Block ${block_num} for producer ${prod} is ACCEPTING scheduled tx: ${entire_trace}",
-                    ("block_num", chain.head_block_num() + 1)("prod", get_pending_block_producer())
+                    ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())
                     ("entire_trace", chain_plug->get_log_trx_trace(trace)));
             num_applied++;
          }
@@ -2578,7 +2578,7 @@ void producer_plugin_impl::schedule_production_loop() {
       if (!_producers.empty() && !production_disabled_by_policy()) {
          chain::controller& chain = chain_plug->chain();
          fc_dlog(_log, "Waiting till another block is received and scheduling Speculative/Production Change");
-         auto wake_time = block_timing_util::calculate_producer_wake_up_time(_produce_block_cpu_effort, chain.head_block_num(), calculate_pending_block_time(),
+         auto wake_time = block_timing_util::calculate_producer_wake_up_time(_produce_block_cpu_effort, chain.head().block_num(), calculate_pending_block_time(),
                                                                              _producers, chain.head_active_producers().producers,
                                                                              _producer_watermarks);
          schedule_delayed_production_loop(weak_from_this(), wake_time);
@@ -2625,12 +2625,12 @@ void producer_plugin_impl::schedule_maybe_produce_block(bool exhausted) {
       EOS_ASSERT(chain.is_building_block(), missing_pending_block_state, "producing without pending_block_state, start_block succeeded");
       _timer.expires_at(epoch + boost::posix_time::microseconds(deadline.time_since_epoch().count()));
       fc_dlog(_log, "Scheduling Block Production on Normal Block #${num} for ${time}",
-              ("num", chain.head_block_num() + 1)("time", deadline));
+              ("num", chain.head().block_num() + 1)("time", deadline));
    } else {
       EOS_ASSERT(chain.is_building_block(), missing_pending_block_state, "producing without pending_block_state");
       _timer.expires_from_now(boost::posix_time::microseconds(0));
       fc_dlog(_log, "Scheduling Block Production on ${desc} Block #${num} immediately",
-              ("num", chain.head_block_num() + 1)("desc", block_is_exhausted() ? "Exhausted" : "Deadline exceeded"));
+              ("num", chain.head().block_num() + 1)("desc", block_is_exhausted() ? "Exhausted" : "Deadline exceeded"));
    }
 
    _timer.async_wait(app().executor().wrap(
@@ -2640,7 +2640,7 @@ void producer_plugin_impl::schedule_maybe_produce_block(bool exhausted) {
          auto self = weak_this.lock();
          if (self && ec != boost::asio::error::operation_aborted && cid == self->_timer_corelation_id) {
             // pending_block_state expected, but can't assert inside async_wait
-            auto block_num = chain.is_building_block() ? chain.head_block_num() + 1 : 0;
+            auto block_num = chain.is_building_block() ? chain.head().block_num() + 1 : 0;
             fc_dlog(_log, "Produce block timer for ${num} running at ${time}", ("num", block_num)("time", fc::time_point::now()));
             auto res = self->maybe_produce_block();
             fc_dlog(_log, "Producing Block #${num} returned: ${res}", ("num", block_num)("res", res));
@@ -2753,7 +2753,7 @@ void producer_plugin_impl::produce_block() {
       metrics.total_time_us = br.total_time.count();
       metrics.net_usage_us = br.total_net_usage;
       metrics.last_irreversible = chain.last_irreversible_block_num();
-      metrics.head_block_num = chain.head_block_num();
+      metrics.head_block_num = chain.head().block_num();
       _update_produced_block_metrics(metrics);
 
       _time_tracker.add_other_time();
@@ -2840,7 +2840,7 @@ void producer_plugin_impl::switch_to_read_window() {
    fc_dlog(_log, "Read only queue size ${s1}, read exclusive size ${s2}",
            ("s1", app().executor().read_only_queue_size())("s2", app().executor().read_exclusive_queue_size()));
 
-   uint32_t pending_block_num = chain.head_block_num() + 1;
+   uint32_t pending_block_num = chain.head().block_num() + 1;
    _ro_read_window_start_time = fc::time_point::now();
    _ro_window_deadline        = _ro_read_window_start_time + _ro_read_window_effective_time_us;
    app().executor().set_to_read_window([received_block = &_received_block, pending_block_num, ro_window_deadline = _ro_window_deadline]() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -825,7 +825,7 @@ public:
       }
 
       now             = fc::time_point::now();
-      if (chain.head_block_timestamp().next().to_time_point() >= now) {
+      if (chain.head().timestamp().next().to_time_point() >= now) {
          _production_enabled = true;
       }
 

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -176,7 +176,7 @@ private:
    get_status_result_v1 fill_current_status_result() {
       get_status_result_v1 ret;
 
-      ret.head              = {controller.head_block_num(), controller.head_block_id()};
+      ret.head              = {controller.head_block_num(), controller.head().id()};
       ret.last_irreversible = {controller.last_irreversible_block_num(), controller.last_irreversible_block_id()};
       ret.chain_id          = controller.get_chain_id();
       if(trace_log)
@@ -241,7 +241,7 @@ private:
                if(self.send_credits && self.next_block_cursor <= latest_to_consider && self.next_block_cursor < self.current_blocks_request.end_block_num) {
                   block_to_send.emplace( block_package{
                      .blocks_result_base = {
-                        .head = {self.controller.head_block_num(), self.controller.head_block_id()},
+                        .head = {self.controller.head_block_num(), self.controller.head().id()},
                         .last_irreversible = {self.controller.last_irreversible_block_num(), self.controller.last_irreversible_block_id()}
                      },
                      .is_v1_request = self.current_blocks_request_v1_finality.has_value()

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -176,7 +176,7 @@ private:
    get_status_result_v1 fill_current_status_result() {
       get_status_result_v1 ret;
 
-      ret.head              = {controller.head_block_num(), controller.head().id()};
+      ret.head              = {controller.head().block_num(), controller.head().id()};
       ret.last_irreversible = {controller.last_irreversible_block_num(), controller.last_irreversible_block_id()};
       ret.chain_id          = controller.get_chain_id();
       if(trace_log)
@@ -237,11 +237,11 @@ private:
 
                //decide what block -- if any -- to send out
                const chain::block_num_type latest_to_consider = self.current_blocks_request.irreversible_only ?
-                                                                self.controller.last_irreversible_block_num() : self.controller.head_block_num();
+                                                                self.controller.last_irreversible_block_num() : self.controller.head().block_num();
                if(self.send_credits && self.next_block_cursor <= latest_to_consider && self.next_block_cursor < self.current_blocks_request.end_block_num) {
                   block_to_send.emplace( block_package{
                      .blocks_result_base = {
-                        .head = {self.controller.head_block_num(), self.controller.head().id()},
+                        .head = {self.controller.head().block_num(), self.controller.head().id()},
                         .last_irreversible = {self.controller.last_irreversible_block_num(), self.controller.last_irreversible_block_id()}
                      },
                      .is_v1_request = self.current_blocks_request_v1_finality.has_value()

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -338,7 +338,7 @@ void state_history_plugin_impl::plugin_startup() {
       uint32_t block_num = chain.head_block_num();
       if( block_num > 0 && chain_state_log && chain_state_log->empty() ) {
          fc_ilog( _log, "Storing initial state on startup, this can take a considerable amount of time" );
-         store_chain_state( chain.head_block_id(), chain.head().header().previous, block_num );
+         store_chain_state( chain.head().id(), chain.head().header().previous, block_num );
          fc_ilog( _log, "Done storing initial state on startup" );
       }
       first_available_block = chain.earliest_available_block_num();

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -335,7 +335,7 @@ void state_history_plugin_impl::plugin_startup() {
    try {
       const auto& chain = chain_plug->chain();
 
-      uint32_t block_num = chain.head_block_num();
+      uint32_t block_num = chain.head().block_num();
       if( block_num > 0 && chain_state_log && chain_state_log->empty() ) {
          fc_ilog( _log, "Storing initial state on startup, this can take a considerable amount of time" );
          store_chain_state( chain.head().id(), chain.head().header().previous, block_num );

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -338,7 +338,7 @@ void state_history_plugin_impl::plugin_startup() {
       uint32_t block_num = chain.head_block_num();
       if( block_num > 0 && chain_state_log && chain_state_log->empty() ) {
          fc_ilog( _log, "Storing initial state on startup, this can take a considerable amount of time" );
-         store_chain_state( chain.head_block_id(), chain.head_block_header().previous, block_num );
+         store_chain_state( chain.head_block_id(), chain.head().header().previous, block_num );
          fc_ilog( _log, "Done storing initial state on startup" );
       }
       first_available_block = chain.earliest_available_block_num();

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -60,7 +60,7 @@ void test_control_plugin_impl::accepted_block(const chain::block_id_type& id) {
 
 void test_control_plugin_impl::process_next_block_state(const chain::block_id_type& id) {
    // Tests expect the shutdown only after signaling a producer shutdown and seeing a full production cycle
-   const auto block_time = _chain.head_block_time() + fc::microseconds(chain::config::block_interval_us);
+   const auto block_time = _chain.head().block_time() + fc::microseconds(chain::config::block_interval_us);
    // have to fetch bsp due to get_scheduled_producer call
 
    const auto& producer_authority = _chain.active_producers().get_scheduled_producer(block_time);

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -65,7 +65,7 @@ void test_control_plugin_impl::process_next_block_state(const chain::block_id_ty
 
    const auto& producer_authority = _chain.active_producers().get_scheduled_producer(block_time);
    const auto producer_name = producer_authority.producer_name;
-   const auto slot = _chain.head_block_timestamp().slot % chain::config::producer_repetitions;
+   const auto slot = _chain.head().timestamp().slot % chain::config::producer_repetitions;
    if (_producer != account_name()) {
       if( _producer != producer_name ) _clean_producer_sequence = true;
       if( _clean_producer_sequence ) {

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -84,7 +84,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
    produce_block();
 
    // retrieve block num
-   uint32_t headnum = this->control->head_block_num();
+   uint32_t headnum = this->control->head().block_num();
 
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_tests, T, validating_testers) { try {
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    }
 
-   uint64_t now = static_cast<uint64_t>( chain.control->head_block_time().time_since_epoch().count() );
+   uint64_t now = static_cast<uint64_t>( chain.control->head().block_time().time_since_epoch().count() );
    now += config::block_interval_us;
    CALL_TEST_FUNCTION( chain, "test_action", "test_current_time", fc::raw::pack(now));
 
@@ -544,7 +544,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_tests, T, validating_testers) { try {
    chain.produce_block();
 
    // test_publication_time
-   uint64_t pub_time = static_cast<uint64_t>( chain.control->head_block_time().time_since_epoch().count() );
+   uint64_t pub_time = static_cast<uint64_t>( chain.control->head().block_time().time_since_epoch().count() );
    pub_time += config::block_interval_us;
    CALL_TEST_FUNCTION( chain, "test_action", "test_publication_time", fc::raw::pack(pub_time) );
 
@@ -3047,7 +3047,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(permission_usage_tests, T, validating_testers) { t
    BOOST_CHECK_THROW( CALL_TEST_FUNCTION( chain, "test_permission", "test_permission_last_used",
                        fc::raw::pack(test_permission_last_used_action{
                                        "testapi"_n, config::active_name,
-                                       chain.control->head_block_time() + fc::milliseconds(config::block_interval_ms)
+                                       chain.control->head().block_time() + fc::milliseconds(config::block_interval_ms)
                                      })
    ), eosio_assert_message_exception );
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1544,7 +1544,7 @@ void transaction_tests(T& chain) {
    BOOST_TEST_MESSAGE( "sha_expect = " << sha_expect );
    BOOST_CHECK_EQUAL(tx_trace->action_traces.front().console == sha_expect, true);
    // test test_tapos_block_num
-   CALL_TEST_FUNCTION(chain, "test_transaction", "test_tapos_block_num", fc::raw::pack(chain.control->head_block_num()) );
+   CALL_TEST_FUNCTION(chain, "test_transaction", "test_tapos_block_num", fc::raw::pack(chain.control->head().block_num()) );
 
    // test test_tapos_block_prefix
    CALL_TEST_FUNCTION(chain, "test_transaction", "test_tapos_block_prefix", fc::raw::pack(chain.control->head().id()._hash[1]) );

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1547,7 +1547,7 @@ void transaction_tests(T& chain) {
    CALL_TEST_FUNCTION(chain, "test_transaction", "test_tapos_block_num", fc::raw::pack(chain.control->head_block_num()) );
 
    // test test_tapos_block_prefix
-   CALL_TEST_FUNCTION(chain, "test_transaction", "test_tapos_block_prefix", fc::raw::pack(chain.control->head_block_id()._hash[1]) );
+   CALL_TEST_FUNCTION(chain, "test_transaction", "test_tapos_block_prefix", fc::raw::pack(chain.control->head().id()._hash[1]) );
 
    // test send_action_recurse
    BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION(chain, "test_transaction", "send_action_recurse", {}), eosio::chain::transaction_exception,

--- a/unittests/blocks_log_replay_tests.cpp
+++ b/unittests/blocks_log_replay_tests.cpp
@@ -34,7 +34,7 @@ struct blog_replay_fixture {
       BOOST_REQUIRE_NO_THROW(chain.control->get_account("replay3"_n));
 
       // Store head_block_num and irreversible_block_num when the node is stopped
-      last_head_block_num = chain.control->head_block_num();
+      last_head_block_num = chain.control->head().block_num();
       last_irreversible_block_num = chain.control->last_irreversible_block_num();
 
       // Stop the node and save blocks_log
@@ -99,7 +99,7 @@ struct blog_replay_fixture {
       // Make sure replayed irreversible_block_num and head_block_num match
       // with last_irreversible_block_num and last_head_block_num
       BOOST_CHECK(replay_chain_1.control->last_irreversible_block_num() == last_irreversible_block_num);
-      BOOST_CHECK(replay_chain_1.control->head_block_num() == last_head_block_num);
+      BOOST_CHECK(replay_chain_1.control->head().block_num() == last_head_block_num);
    } FC_LOG_AND_RETHROW()
 
    void remove_existing_states(std::filesystem::path& state_path) {
@@ -127,7 +127,7 @@ BOOST_FIXTURE_TEST_CASE(replay_through, blog_replay_fixture) try {
    // Make sure replayed irreversible_block_num and head_block_num match
    // with last_irreversible_block_num and last_head_block_num
    BOOST_CHECK(replay_chain.control->last_irreversible_block_num() == last_irreversible_block_num);
-   BOOST_CHECK(replay_chain.control->head_block_num() == last_head_block_num);
+   BOOST_CHECK(replay_chain.control->head().block_num() == last_head_block_num);
 } FC_LOG_AND_RETHROW()
 
 // Test replay stopping in the middle of blocks log and resuming

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -441,7 +441,7 @@ BOOST_FIXTURE_TEST_CASE( test_proxy_deferred, pre_disable_deferred_trx_currency_
    }
 
    // for now wasm "time" is in seconds, so we have to truncate off any parts of a second that may have applied
-   fc::time_point expected_delivery(fc::seconds(control->head_block_time().sec_since_epoch()) + fc::seconds(10));
+   fc::time_point expected_delivery(fc::seconds(control->head().block_time().sec_since_epoch()) + fc::seconds(10));
    {
       auto trace = push_action("eosio.token"_n, "transfer"_n, mutable_variant_object()
          ("from", eosio_token)
@@ -451,7 +451,7 @@ BOOST_FIXTURE_TEST_CASE( test_proxy_deferred, pre_disable_deferred_trx_currency_
       );
    }
 
-   while(control->head_block_time() < expected_delivery) {
+   while(control->head().block_time() < expected_delivery) {
       produce_block();
       BOOST_REQUIRE_EQUAL(get_balance( "proxy"_n), asset::from_string("5.0000 CUR"));
       BOOST_REQUIRE_EQUAL(get_balance( "alice"_n),   asset::from_string("0.0000 CUR"));

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -56,16 +56,16 @@ BOOST_AUTO_TEST_SUITE(database_tests)
          // Check the last irreversible block number is set correctly.
          if constexpr (std::is_same_v<T, savanna_validating_tester>) {
             // In Savanna, after 3-chain finality is achieved.
-            const auto expected_last_irreversible_block_number = test.control->head_block_num() - 3;
+            const auto expected_last_irreversible_block_number = test.control->head().block_num() - 3;
             BOOST_TEST(test.control->last_irreversible_block_num() == expected_last_irreversible_block_number);
          } else {
             // With one producer, irreversibility should only just 1 block before
-            const auto expected_last_irreversible_block_number = test.control->head_block_num() - 1;
+            const auto expected_last_irreversible_block_number = test.control->head().block_num() - 1;
             BOOST_TEST(test.control->head_block_state_legacy()->dpos_irreversible_blocknum == expected_last_irreversible_block_number);
          }
 
          // Ensure that future block doesn't exist
-         const auto nonexisting_future_block_num = test.control->head_block_num() + 1;
+         const auto nonexisting_future_block_num = test.control->head().block_num() + 1;
          BOOST_TEST(test.control->fetch_block_by_number(nonexisting_future_block_num) == nullptr);
 
          const uint32_t next_num_of_blocks_to_prod = 10;
@@ -73,16 +73,16 @@ BOOST_AUTO_TEST_SUITE(database_tests)
 
          // Check the last irreversible block number is updated correctly
          if constexpr (std::is_same_v<T, savanna_validating_tester>) {
-            const auto next_expected_last_irreversible_block_number = test.control->head_block_num() - 3;
+            const auto next_expected_last_irreversible_block_number = test.control->head().block_num() - 3;
             BOOST_TEST(test.control->last_irreversible_block_num() == next_expected_last_irreversible_block_number);
          } else {
-            const auto next_expected_last_irreversible_block_number = test.control->head_block_num() - 1;
+            const auto next_expected_last_irreversible_block_number = test.control->head().block_num() - 1;
             BOOST_TEST(test.control->head_block_state_legacy()->dpos_irreversible_blocknum == next_expected_last_irreversible_block_number);
          }
          // Previous nonexisting future block should exist by now
          BOOST_CHECK_NO_THROW(test.control->fetch_block_by_number(nonexisting_future_block_num));
          // Check the latest head block match
-         BOOST_TEST(test.control->fetch_block_by_number(test.control->head_block_num())->calculate_id() ==
+         BOOST_TEST(test.control->fetch_block_by_number(test.control->head().block_num())->calculate_id() ==
                     test.control->head().id());
       } FC_LOG_AND_RETHROW()
    }

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
          BOOST_CHECK_NO_THROW(test.control->fetch_block_by_number(nonexisting_future_block_num));
          // Check the latest head block match
          BOOST_TEST(test.control->fetch_block_by_number(test.control->head_block_num())->calculate_id() ==
-                    test.control->head_block_id());
+                    test.control->head().id());
       } FC_LOG_AND_RETHROW()
    }
 

--- a/unittests/fork_test_utilities.cpp
+++ b/unittests/fork_test_utilities.cpp
@@ -38,7 +38,7 @@ bool produce_until_transition( base_tester& t,
                                uint32_t max_num_blocks_to_produce )
 {
    return produce_empty_blocks_until(t, max_num_blocks_to_produce, [&t, last_producer, next_producer]() {
-      return t.control->pending_block_producer() == next_producer && t.control->head_block_producer() == last_producer;
+      return t.control->pending_block_producer() == next_producer && t.control->head().producer() == last_producer;
    });
 }
 
@@ -48,7 +48,7 @@ bool produce_until_blocks_from( base_tester& t,
 {
    auto remaining_producers = expected_producers;
    return produce_empty_blocks_until(t, max_num_blocks_to_produce, [&t, &remaining_producers]() {
-      remaining_producers.erase(t.control->head_block_producer());
+      remaining_producers.erase(t.control->head().producer());
       return remaining_producers.size() == 0;
    });
 }

--- a/unittests/fork_test_utilities.cpp
+++ b/unittests/fork_test_utilities.cpp
@@ -9,8 +9,8 @@ public_key_type  get_public_key( name keyname, string role ){
 }
 
 void push_blocks( tester& from, tester& to, uint32_t block_num_limit ) {
-   block_num_type from_head_num = std::min( from.control->fork_db_head_block_num(), block_num_limit );
-   block_num_type to_head_num = to.control->fork_db_head_block_num();
+   block_num_type from_head_num = std::min( from.control->fork_db_head().block_num(), block_num_limit );
+   block_num_type to_head_num = to.control->fork_db_head().block_num();
    while( to_head_num < from_head_num) {
       auto fb = from.control->fetch_block_by_number( ++to_head_num );
       to.push_block( fb );

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -334,7 +334,7 @@ void test_validator_accepts_valid_blocks() try {
 
    n1.produce_block();
 
-   auto id = n1.control->head_block_id();
+   auto id = n1.control->head().id();
 
    signed_block_ptr first_block;
    block_id_type first_id;
@@ -349,7 +349,7 @@ void test_validator_accepts_valid_blocks() try {
 
    push_blocks( n1, n2 );
 
-   BOOST_CHECK_EQUAL( n2.control->head_block_id(), id );
+   BOOST_CHECK_EQUAL( n2.control->head().id(), id );
 
    BOOST_REQUIRE( first_block );
    const auto& first_bp = n2.control->fetch_block_by_id(first_id);
@@ -360,7 +360,7 @@ void test_validator_accepts_valid_blocks() try {
 
    n3.push_block( first_block );
 
-   BOOST_CHECK_EQUAL( n3.control->head_block_id(), id );
+   BOOST_CHECK_EQUAL( n3.control->head().id(), id );
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( validator_accepts_valid_blocks ) {
@@ -445,7 +445,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
 
    other.produce_block( fc::milliseconds( 13 * config::block_interval_ms ) ); // skip over producer1's round
    BOOST_REQUIRE_EQUAL( other.control->head().producer().to_string(), "producer2" );
-   auto fork_first_block_id = other.control->head_block_id();
+   auto fork_first_block_id = other.control->head().id();
    wlog( "{w}", ("w", fork_first_block_id));
 
    BOOST_REQUIRE( produce_until_transition( other, "producer2"_n, "producer1"_n, 11) ); // finish producer2's round
@@ -540,7 +540,7 @@ void test_reopen_forkdb() try {
    // alice produces a block on fork 1 causing LIB to advance
    c1.produce_block();
 
-   auto fork1_head_block_id = c1.control->head_block_id();
+   auto fork1_head_block_id = c1.control->head().id();
 
    auto fork1_lib_after = c1.control->last_irreversible_block_num();
    BOOST_REQUIRE( fork1_lib_after > fork1_lib_before );
@@ -561,7 +561,7 @@ void test_reopen_forkdb() try {
       c1.push_block( fb );
    }
 
-   BOOST_REQUIRE( fork1_head_block_id == c1.control->head_block_id() ); // new blocks should not cause fork switch
+   BOOST_REQUIRE( fork1_head_block_id == c1.control->head().id() ); // new blocks should not cause fork switch
 
    c1.close();
 

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
    BOOST_REQUIRE_EQUAL(fork_num, c2.control->head_block_num());
 
    auto nextproducer = [](legacy_tester &c, int skip_interval) ->account_name {
-      auto head_time = c.control->head_block_time();
+      auto head_time = c.control->head().block_time();
       auto next_time = head_time + fc::milliseconds(config::block_interval_ms * skip_interval);
       return c.control->active_producers().get_scheduled_producer(next_time).producer_name;
    };
@@ -651,7 +651,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
-      trx.expiration = fc::time_point_sec{c1.control->head_block_time() + fc::seconds( 60 )};
+      trx.expiration = fc::time_point_sec{c1.control->head().block_time() + fc::seconds( 60 )};
       trx.set_reference_block( cb->calculate_id() );
       trx.sign( get_private_key( config::system_account_name, "active" ), c1.control->get_chain_id()  );
       trace1 = c1.push_transaction( trx );
@@ -668,7 +668,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
-      trx.expiration = fc::time_point_sec{c1.control->head_block_time() + fc::seconds( 60 )};
+      trx.expiration = fc::time_point_sec{c1.control->head().block_time() + fc::seconds( 60 )};
       trx.set_reference_block( cb->calculate_id() );
       trx.sign( get_private_key( config::system_account_name, "active" ), c1.control->get_chain_id()  );
       trace2 = c1.push_transaction( trx );
@@ -684,7 +684,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
-      trx.expiration = fc::time_point_sec{c1.control->head_block_time() + fc::seconds( 60 )};
+      trx.expiration = fc::time_point_sec{c1.control->head().block_time() + fc::seconds( 60 )};
       trx.set_reference_block( cb->calculate_id() );
       trx.sign( get_private_key( config::system_account_name, "active" ), c1.control->get_chain_id()  );
       trace3 = c1.push_transaction( trx );
@@ -700,7 +700,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
-      trx.expiration = fc::time_point_sec{c1.control->head_block_time() + fc::seconds( 60 )};
+      trx.expiration = fc::time_point_sec{c1.control->head().block_time() + fc::seconds( 60 )};
       trx.set_reference_block( b->calculate_id() ); // tapos to dan's block should be rejected on fork switch
       trx.sign( get_private_key( config::system_account_name, "active" ), c1.control->get_chain_id()  );
       trace4 = c1.push_transaction( trx );

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -383,12 +383,12 @@ void test_read_modes() try {
 
    TESTER head(setup_policy::none, db_read_mode::HEAD);
    push_blocks(c, head);
-   BOOST_CHECK_EQUAL(head_block_num, head.control->fork_db_head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, head.control->fork_db_head().block_num());
    BOOST_CHECK_EQUAL(head_block_num, head.control->head().block_num());
 
    TESTER irreversible(setup_policy::none, db_read_mode::IRREVERSIBLE);
    push_blocks(c, irreversible);
-   BOOST_CHECK_EQUAL(head_block_num, irreversible.control->fork_db_head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, irreversible.control->fork_db_head().block_num());
    BOOST_CHECK_EQUAL(last_irreversible_block_num, irreversible.control->head().block_num());
 
 } FC_LOG_AND_RETHROW()
@@ -468,13 +468,13 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
 
    push_blocks( main, irreversible, hbn1 );
 
-   BOOST_CHECK_EQUAL( irreversible.control->fork_db_head_block_num(), hbn1 );
+   BOOST_CHECK_EQUAL( irreversible.control->fork_db_head().block_num(), hbn1 );
    BOOST_CHECK_EQUAL( irreversible.control->head().block_num(), lib1 );
    BOOST_CHECK_EQUAL( does_account_exist( irreversible, "alice"_n ), false );
 
    push_blocks( other, irreversible, hbn4 );
 
-   BOOST_CHECK_EQUAL( irreversible.control->fork_db_head_block_num(), hbn4 );
+   BOOST_CHECK_EQUAL( irreversible.control->fork_db_head().block_num(), hbn4 );
    BOOST_CHECK_EQUAL( irreversible.control->head().block_num(), lib4 );
    BOOST_CHECK_EQUAL( does_account_exist( irreversible, "alice"_n ), false );
 
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
       irreversible.push_block( fb );
    }
 
-   BOOST_CHECK_EQUAL( irreversible.control->fork_db_head_block_num(), hbn3 );
+   BOOST_CHECK_EQUAL( irreversible.control->fork_db_head().block_num(), hbn3 );
    BOOST_CHECK_EQUAL( irreversible.control->head().block_num(), lib3 );
    BOOST_CHECK_EQUAL( does_account_exist( irreversible, "alice"_n ), true );
 

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -441,10 +441,10 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    BOOST_CHECK_EQUAL( does_account_exist( main, "alice"_n ), true );
 
    // other forks away from main after hbn2
-   BOOST_REQUIRE_EQUAL( other.control->head_block_producer().to_string(), "producer2" );
+   BOOST_REQUIRE_EQUAL( other.control->head().producer().to_string(), "producer2" );
 
    other.produce_block( fc::milliseconds( 13 * config::block_interval_ms ) ); // skip over producer1's round
-   BOOST_REQUIRE_EQUAL( other.control->head_block_producer().to_string(), "producer2" );
+   BOOST_REQUIRE_EQUAL( other.control->head().producer().to_string(), "producer2" );
    auto fork_first_block_id = other.control->head_block_id();
    wlog( "{w}", ("w", fork_first_block_id));
 

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
    // produce 6 blocks on bios
    for (int i = 0; i < 6; i ++) {
       bios.produce_block();
-      BOOST_REQUIRE_EQUAL( bios.control->head_block()->producer.to_string(), "a" );
+      BOOST_REQUIRE_EQUAL( bios.control->head().block()->producer.to_string(), "a" );
    }
 
    vector<fork_tracker> forks(7);

--- a/unittests/forked_tests_if.cpp
+++ b/unittests/forked_tests_if.cpp
@@ -129,7 +129,7 @@ BOOST_FIXTURE_TEST_CASE(fork_with_bad_block_if, savanna_cluster::cluster_t) try 
    // and all blocks from the forks are validated, which is why we expect an exception when the last
    // block of the fork is pushed.
    // -------------------------------------------------------------------------------------------------
-   auto node0_head = _nodes[0].control->head_block_id();
+   auto node0_head = _nodes[0].control->head().id();
    for (size_t i = 0; i < forks.size(); i++) {
       BOOST_TEST_CONTEXT("Testing Fork: " << i) {
          const auto& fork = forks.at(i);
@@ -145,7 +145,7 @@ BOOST_FIXTURE_TEST_CASE(fork_with_bad_block_if, savanna_cluster::cluster_t) try 
          // push the block which should attempt the corrupted fork and fail
          BOOST_REQUIRE_EXCEPTION(_nodes[0].push_block(fork.blocks.back()), fc::exception,
                                  fc_exception_message_starts_with( "finality_mroot does not match"));
-         BOOST_REQUIRE_EQUAL(_nodes[0].control->head_block_id(), node0_head);
+         BOOST_REQUIRE_EQUAL(_nodes[0].control->head().id(), node0_head);
       }
    }
 

--- a/unittests/get_block_num_tests.cpp
+++ b/unittests/get_block_num_tests.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE( get_block_num ) { try {
    c.produce_block();
 
    c.push_action( tester1_account, "testblock"_n, tester1_account, mutable_variant_object()
-      ("expected_result", c.control->head_block_num()+1)
+      ("expected_result", c.control->head().block_num()+1)
    );
 
 } FC_LOG_AND_RETHROW() }

--- a/unittests/partitioned_block_log_tests.cpp
+++ b/unittests/partitioned_block_log_tests.cpp
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_split_log_util1, T, eosio::testing::testers 
    T chain;
    chain.produce_blocks(160);
 
-   uint32_t head_block_num = chain.control->head_block_num();
+   uint32_t head_block_num = chain.control->head().block_num();
    uint32_t lib_block_num;
    if constexpr (std::is_same_v<T, eosio::testing::savanna_tester>) {
       lib_block_num = head_block_num - 3; // three-chain
@@ -314,7 +314,7 @@ void split_log_replay(uint32_t replay_max_retained_block_files) {
    // produce new blocks to cross the blocks_log_stride boundary
    from_block_log_chain.produce_blocks(stride);
 
-   const auto previous_chunk_end_block_num = (from_block_log_chain.control->head_block_num() / stride) * stride;
+   const auto previous_chunk_end_block_num = (from_block_log_chain.control->head().block_num() / stride) * stride;
    const auto num_removed_blocks = std::min(stride * replay_max_retained_block_files, previous_chunk_end_block_num);
    const auto min_retained_block_number = previous_chunk_end_block_num - num_removed_blocks + 1;
 

--- a/unittests/producer_schedule_savanna_tests.cpp
+++ b/unittests/producer_schedule_savanna_tests.cpp
@@ -32,7 +32,7 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule_after_savanna_activation, lega
          if (new_prod_schd == current_schedule) {
             scheduled_changed_to_new = true;
             if (expected_block_num != 0)
-               BOOST_TEST(control->head_block_num() == expected_block_num);
+               BOOST_TEST(control->head().block_num() == expected_block_num);
 
             // verify eosio.prods updated
             const name usr = config::producers_account_name;
@@ -150,7 +150,7 @@ BOOST_FIXTURE_TEST_CASE( proposer_policy_progression_test, legacy_validating_tes
       BOOST_TEST(new_producer_in_insert);
    };
 
-   while (control->head_block_num() < 3) {
+   while (control->head().block_num() < 3) {
       produce_block();
    }
 
@@ -373,7 +373,7 @@ BOOST_FIXTURE_TEST_CASE( proposer_policy_progression_test, legacy_validating_tes
 BOOST_FIXTURE_TEST_CASE( proposer_policy_misc_tests, legacy_validating_tester ) try {
    create_accounts( {"alice"_n,"bob"_n} );
 
-   while (control->head_block_num() < 3) {
+   while (control->head().block_num() < 3) {
       produce_block();
    }
 

--- a/unittests/producer_schedule_savanna_tests.cpp
+++ b/unittests/producer_schedule_savanna_tests.cpp
@@ -54,7 +54,7 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule_after_savanna_activation, lega
          // Check if the producer is the same as what we expect
          const auto block_time = control->head_block_time();
          const auto& expected_producer = get_expected_producer(current_schedule, block_time);
-         BOOST_TEST(control->head_block_producer() == expected_producer);
+         BOOST_TEST(control->head().producer() == expected_producer);
 
          if (scheduled_changed_to_new)
             break;

--- a/unittests/producer_schedule_savanna_tests.cpp
+++ b/unittests/producer_schedule_savanna_tests.cpp
@@ -52,7 +52,7 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule_after_savanna_activation, lega
          BOOST_TEST( b->confirmed == 0); // must be 0 after instant finality is enabled
 
          // Check if the producer is the same as what we expect
-         const auto block_time = control->head_block_time();
+         const auto block_time = control->head().block_time();
          const auto& expected_producer = get_expected_producer(current_schedule, block_time);
          BOOST_TEST(control->head().producer() == expected_producer);
 

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(verify_producers, T, validating_testers) try {
 
 BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, legacy_validating_tester ) try {
    create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
-   while (control->head_block_num() < 3) {
+   while (control->head().block_num() < 3) {
       produce_block();
    }
 
@@ -203,7 +203,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, legacy_validating_tes
 
 BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, legacy_tester ) try {
    create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
-   while (control->head_block_num() < 3) {
+   while (control->head().block_num() < 3) {
       produce_block();
    }
 
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_producer_schedule_has_no_effect, T, validati
    c.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
 
    c.create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
-   while (c.control->head_block_num() < 3) {
+   while (c.control->head().block_num() < 3) {
       c.produce_block();
    }
 
@@ -438,7 +438,7 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    BOOST_CHECK_EQUAL( c.control->pending_block_producer(), "carol"_n );
    BOOST_REQUIRE_EQUAL( c.control->active_producers().version, 2u );
 
-   auto carol_last_produced_block_num = c.control->head_block_num() + 1;
+   auto carol_last_produced_block_num = c.control->head().block_num() + 1;
    wdump((carol_last_produced_block_num));
 
    c.produce_block();
@@ -451,12 +451,12 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
 
    produce_until_transition( c, "bob"_n, "alice"_n );
 
-   auto bob_last_produced_block_num = c.control->head_block_num();
+   auto bob_last_produced_block_num = c.control->head().block_num();
    wdump((bob_last_produced_block_num));
 
    produce_until_transition( c, "alice"_n, "bob"_n );
 
-   auto alice_last_produced_block_num = c.control->head_block_num();
+   auto alice_last_produced_block_num = c.control->head().block_num();
    wdump((alice_last_produced_block_num));
 
    {
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    BOOST_CHECK_EQUAL( c.control->pending_block_producer(), "bob"_n );
    c.finish_block();
 
-   auto carol_block_num = c.control->head_block_num() + 1;
+   auto carol_block_num = c.control->head().block_num() + 1;
    auto carol_block_time = c.control->head().block_time() + fc::milliseconds(config::block_interval_ms);
    auto confirmed = carol_block_num - carol_last_produced_block_num - 1;
 

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -51,7 +51,7 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, legacy_validating_tester ) tr
          control->abort_block(); // abort started block in produce_block so activate_producers() is off head
 
          // Check if the producer is the same as what we expect
-         const auto block_time = control->head_block_time();
+         const auto block_time = control->head().block_time();
          const auto& expected_producer = get_expected_producer(current_schedule, block_time);
          BOOST_TEST(control->head().producer() == expected_producer);
 
@@ -486,7 +486,7 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    c.finish_block();
 
    auto carol_block_num = c.control->head_block_num() + 1;
-   auto carol_block_time = c.control->head_block_time() + fc::milliseconds(config::block_interval_ms);
+   auto carol_block_time = c.control->head().block_time() + fc::milliseconds(config::block_interval_ms);
    auto confirmed = carol_block_num - carol_last_produced_block_num - 1;
 
    c.control->start_block( carol_block_time, confirmed, {}, controller::block_status::incomplete );

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -53,7 +53,7 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, legacy_validating_tester ) tr
          // Check if the producer is the same as what we expect
          const auto block_time = control->head_block_time();
          const auto& expected_producer = get_expected_producer(current_schedule, block_time);
-         BOOST_TEST(control->head_block_producer() == expected_producer);
+         BOOST_TEST(control->head().producer() == expected_producer);
 
          if (scheduled_changed_to_new)
             break;
@@ -178,7 +178,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, legacy_validating_tes
    produce_block();
    produce_blocks(23); // Alice produces the last block of her first round.
                     // Bob's first block (which advances LIB to Alice's last block) is started but not finalized.
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), "alice"_n );
+   BOOST_REQUIRE_EQUAL( control->head().producer(), "alice"_n );
    BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "bob"_n );
    BOOST_REQUIRE(control->pending_producers_legacy());
    BOOST_CHECK_EQUAL( control->pending_producers_legacy()->version, 2u );
@@ -187,7 +187,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, legacy_validating_tes
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
    produce_blocks(12); // Bob produces his 12th block.
                     // Alice's first block of the second round is started but not finalized (which advances LIB to Bob's last block).
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), "alice"_n );
+   BOOST_REQUIRE_EQUAL( control->head().producer(), "alice"_n );
    BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "bob"_n );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
@@ -196,7 +196,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, legacy_validating_tes
 
    // The next block will be produced according to the new schedule
    produce_block();
-   BOOST_CHECK_EQUAL( control->head_block_producer(), "carol"_n ); // And that next block happens to be produced by Carol.
+   BOOST_CHECK_EQUAL( control->head().producer(), "carol"_n ); // And that next block happens to be produced by Carol.
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
@@ -242,7 +242,7 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, legacy_tester ) try {
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *control->proposed_producers_legacy() ) );
 
    produce_blocks(48);
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), "bob"_n );
+   BOOST_REQUIRE_EQUAL( control->head().producer(), "bob"_n );
    BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "carol"_n );
    BOOST_REQUIRE(control->pending_producers_legacy());
    BOOST_CHECK_EQUAL( control->pending_producers_legacy()->version, 2u );
@@ -251,13 +251,13 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, legacy_tester ) try {
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
    produce_blocks(1);
 
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), "carol"_n );
+   BOOST_REQUIRE_EQUAL( control->head().producer(), "carol"_n );
    BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "alice"_n );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
 
    produce_blocks(2);
-   BOOST_CHECK_EQUAL( control->head_block_producer(), "bob"_n );
+   BOOST_CHECK_EQUAL( control->head().producer(), "bob"_n );
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -61,7 +61,7 @@ BOOST_FIXTURE_TEST_CASE( verify_producer_schedule, legacy_validating_tester ) tr
 
       BOOST_TEST(scheduled_changed_to_new);
 
-      const auto current_schd_ver = control->head_block_header().schedule_version;
+      const auto current_schd_ver = control->head().header().schedule_version;
       BOOST_TEST(current_schd_ver == expected_schd_ver);
    };
 
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    c.control->start_block( carol_block_time, confirmed, {}, controller::block_status::incomplete );
    BOOST_CHECK_EQUAL( c.control->pending_block_producer(), "carol"_n );
    c.produce_block();
-   auto h = c.control->head_block_header();
+   auto h = c.control->head().header();
 
    BOOST_CHECK_EQUAL( h.producer, "carol"_n );
    BOOST_CHECK_EQUAL( h.confirmed,  confirmed );

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(require_preactivation_test, T, testers) try {
    BOOST_CHECK( !c.control->is_builtin_activated( builtin_protocol_feature_t::only_link_to_existing_permission ) );
 
    BOOST_CHECK_EXCEPTION( c.control->start_block(
-                              c.control->head_block_time() + fc::milliseconds(config::block_interval_ms),
+                              c.control->head().block_time() + fc::milliseconds(config::block_interval_ms),
                               0,
                               {},
                               controller::block_status::incomplete
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subjective_restrictions_test, T, testers) try {
    BOOST_CHECK_EXCEPTION(  c.produce_block(),
                            protocol_feature_exception,
                            fc_exception_message_starts_with(
-                              c.control->head_block_time().to_iso_string() +
+                              c.control->head().block_time().to_iso_string() +
                               " is too early for the earliest allowed activation time of the protocol feature"
                            )
    );
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subjective_restrictions_test, T, testers) try {
    BOOST_CHECK_EXCEPTION(  c.preactivate_protocol_features({only_link_to_existing_permission_digest}),
                            subjective_block_production_exception,
                            fc_exception_message_starts_with(
-                              (c.control->head_block_time() + fc::milliseconds(config::block_interval_ms)).to_iso_string() +
+                              (c.control->head().block_time() + fc::milliseconds(config::block_interval_ms)).to_iso_string() +
                               " is too early for the earliest allowed activation time of the protocol feature"
                            )
    );

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -87,14 +87,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(activate_and_restart, T, testers) try {
    c.schedule_protocol_features_wo_preactivation({ *d });
    c.produce_block();
 
-   auto head_block_num = c.control->head_block_num();
+   auto head_block_num = c.control->head().block_num();
 
    BOOST_CHECK( c.control->is_builtin_activated( builtin_protocol_feature_t::preactivate_feature ) );
 
    c.close();
    c.open( std::move( pfs ) );
 
-   BOOST_CHECK_EQUAL( head_block_num, c.control->head_block_num() );
+   BOOST_CHECK_EQUAL( head_block_num, c.control->head().block_num() );
 
    BOOST_CHECK( c.control->is_builtin_activated( builtin_protocol_feature_t::preactivate_feature ) );
 

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -66,11 +66,11 @@ namespace savanna_cluster {
 
       uint32_t lib_num() const { return lib_block->block_num(); }
 
-      uint32_t head_num() const { return control->fork_db_head_block_num(); }
+      uint32_t head_num() const { return control->fork_db_head().block_num(); }
 
       void push_blocks(node_t& to, uint32_t block_num_limit = std::numeric_limits<uint32_t>::max()) const {
          while (to.head_num() < std::min(head_num(), block_num_limit)) {
-            auto sb = control->fetch_block_by_number(to.control->fork_db_head_block_num() + 1);
+            auto sb = control->fetch_block_by_number(to.control->fork_db_head().block_num() + 1);
             to.push_block(sb);
          }
       }

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -315,8 +315,8 @@ void replay_over_snapshot_test()
    // replay the block log from the snapshot child, from the snapshot
    using config_file_handling = snapshotted_tester::config_file_handling;
    snapshotted_tester replay_chain(snap_chain.get_config(), SNAPSHOT_SUITE::get_reader(snapshot), ordinal++, config_file_handling::copy_config_files);
-   const auto replay_head = replay_chain.control->head_block_num();
-   auto snap_head = snap_chain.control->head_block_num();
+   const auto replay_head = replay_chain.control->head().block_num();
+   auto snap_head = snap_chain.control->head().block_num();
    BOOST_REQUIRE_EQUAL(replay_head, snap_chain.control->last_irreversible_block_num());
    for (auto block_num = replay_head + 1; block_num <= snap_head; ++block_num) {
       auto block = snap_chain.control->fetch_block_by_number(block_num);
@@ -332,8 +332,8 @@ void replay_over_snapshot_test()
    verify_integrity_hash<SNAPSHOT_SUITE>(*chain.control, *replay_chain.control);
 
    snapshotted_tester replay2_chain(snap_chain.get_config(), SNAPSHOT_SUITE::get_reader(snapshot), ordinal++, config_file_handling::copy_config_files);
-   const auto replay2_head = replay2_chain.control->head_block_num();
-   snap_head = snap_chain.control->head_block_num();
+   const auto replay2_head = replay2_chain.control->head().block_num();
+   snap_head = snap_chain.control->head().block_num();
    BOOST_REQUIRE_EQUAL(replay2_head, snap_chain.control->last_irreversible_block_num());
    for (auto block_num = replay2_head + 1; block_num <= snap_head; ++block_num) {
       auto block = snap_chain.control->fetch_block_by_number(block_num);
@@ -346,7 +346,7 @@ void replay_over_snapshot_test()
    auto genesis = chain::block_log::extract_genesis_state(chain.get_config().blocks_dir);
    BOOST_REQUIRE(genesis);
    tester from_block_log_chain(copied_config, *genesis);
-   const auto from_block_log_head = from_block_log_chain.control->head_block_num();
+   const auto from_block_log_head = from_block_log_chain.control->head().block_num();
    BOOST_REQUIRE_EQUAL(from_block_log_head, snap_chain.control->last_irreversible_block_num());
    for (auto block_num = from_block_log_head + 1; block_num <= snap_head; ++block_num) {
       auto block = snap_chain.control->fetch_block_by_number(block_num);
@@ -428,7 +428,7 @@ void compatible_versions_test()
       chain.control->abort_block();
 
       // continue until all the above blocks are in the blocks.log
-      auto head_block_num = chain.control->head_block_num();
+      auto head_block_num = chain.control->head().block_num();
       while (chain.control->last_irreversible_block_num() < head_block_num) {
          chain.produce_block();
       }

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -782,10 +782,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_splitted_log, T, state_history_testers) {
 }
 
 void push_blocks( tester& from, tester& to ) {
-   while( to.control->fork_db_head_block_num()
-            < from.control->fork_db_head_block_num() )
+   while( to.control->fork_db_head().block_num()
+            < from.control->fork_db_head().block_num() )
    {
-      auto fb = from.control->fetch_block_by_number( to.control->fork_db_head_block_num()+1 );
+      auto fb = from.control->fetch_block_by_number( to.control->fork_db_head().block_num()+1 );
       to.push_block( fb );
    }
 }

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -781,7 +781,7 @@ bool test_fork(uint32_t stride, uint32_t max_retained_files) {
    tester chain2(setup_policy::none);
    push_blocks(chain1, chain2);
 
-   auto fork_block_num = chain1.control->head_block_num();
+   auto fork_block_num = chain1.control->head().block_num();
 
    chain1.produce_blocks(12, true);
    auto create_account_traces = chain2.create_accounts( {"adam"_n} );
@@ -790,7 +790,7 @@ bool test_fork(uint32_t stride, uint32_t max_retained_files) {
    auto b = chain2.produce_block();
    chain2.produce_blocks(11+12, true);
 
-   for( uint32_t start = fork_block_num + 1, end = chain2.control->head_block_num(); start <= end; ++start ) {
+   for( uint32_t start = fork_block_num + 1, end = chain2.control->head().block_num(); start <= end; ++start ) {
       auto fb = chain2.control->fetch_block_by_number( start );
       chain1.push_block( fb );
    }

--- a/unittests/test_utils.hpp
+++ b/unittests/test_utils.hpp
@@ -66,7 +66,7 @@ auto make_bios_ro_trx(eosio::chain::controller& control) {
 // If account is eosio then signs with the default private key
 auto push_input_trx(appbase::scoped_app& app, eosio::chain::controller& control, account_name account, signed_transaction& trx) {
    trx.expiration = fc::time_point_sec{fc::time_point::now() + fc::seconds(30)};
-   trx.set_reference_block( control.head_block_id() );
+   trx.set_reference_block( control.head().id() );
    if (account == config::system_account_name) {
       auto default_priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("nathan")));
       trx.sign(default_priv_key, control.get_chain_id());

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( simple_no_memory_check, T, validating_testers ) t
    act.name = ""_n;
    act.authorization = vector<permission_level>{{"nomem"_n,config::active_name}};
    trx.actions.push_back(act);
-   trx.expiration = fc::time_point_sec{chain.control->head_block_time()};
+   trx.expiration = fc::time_point_sec{chain.control->head().block_time()};
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "nomem"_n, "active" ), chain.control->get_chain_id());
    BOOST_CHECK_THROW(chain.push_transaction( trx ), wasm_execution_error);

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -320,15 +320,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( blacklist_eosio, T, whitelist_blacklist_testers )
    T tester2;
    tester2.init(false);
 
-   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
-      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+   while( tester2.chain->control->head().block_num() < tester1.chain->control->head().block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head().block_num()+1 );
       tester2.chain->push_block( b );
    }
 
    tester1.chain->produce_block();
 
-   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
-      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+   while( tester2.chain->control->head().block_num() < tester1.chain->control->head().block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head().block_num()+1 );
       tester2.chain->push_block( b );
    }
 } FC_LOG_AND_RETHROW() }
@@ -362,8 +362,8 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
    whitelist_blacklist_tester<tester> tester2;
    tester2.init(false);
 
-   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
-      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+   while( tester2.chain->control->head().block_num() < tester1.chain->control->head().block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head().block_num()+1 );
       tester2.chain->push_block( b );
    }
 
@@ -379,8 +379,8 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
                         );
    tester1.chain->produce_blocks(2, true); // Produce 2 empty blocks (other than onblock of course).
 
-   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
-      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+   while( tester2.chain->control->head().block_num() < tester1.chain->control->head().block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head().block_num()+1 );
       tester2.chain->push_block( b );
    }
 } FC_LOG_AND_RETHROW() }
@@ -479,8 +479,8 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
    whitelist_blacklist_tester<tester> tester2;
    tester2.init(false);
 
-   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
-      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+   while( tester2.chain->control->head().block_num() < tester1.chain->control->head().block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head().block_num()+1 );
       tester2.chain->push_block( b );
    }
 
@@ -535,8 +535,8 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
 
    c1.disconnect();
 
-   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
-      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+   while( tester2.chain->control->head().block_num() < tester1.chain->control->head().block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head().block_num()+1 );
       tester2.chain->push_block( b );
    }
 
@@ -717,8 +717,8 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
    whitelist_blacklist_tester<tester> tester2;
    tester2.init(false);
 
-   while( tester2.chain->control->head_block_num() < tester1.chain->control->head_block_num() ) {
-      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head_block_num()+1 );
+   while( tester2.chain->control->head().block_num() < tester1.chain->control->head().block_num() ) {
+      auto b = tester1.chain->control->fetch_block_by_number( tester2.chain->control->head().block_num()+1 );
       tester2.chain->push_block( b );
    }
 


### PR DESCRIPTION
Just provide access to head's `block_handle`, and use `block_handle` member functions to access:
- block_num() 
- timestamp()
- id()
- etc...

This is just a removal of non-necessary access functions, there is no semantic change.

See [discussion](https://github.com/AntelopeIO/spring/pull/316#discussion_r1659398414) with @arhag . 

`block_handle::internal()` was made private in [previous PR](https://github.com/AntelopeIO/spring/pull/316#discussion_r1659398414).