### PR TITLE
undo an unneeded nested `block_handle_accessor::apply()`

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2075,12 +2075,8 @@ struct controller_impl {
          section.add_row(chain_snapshot_header(), db);
       });
 
-      block_handle_accessor::apply<void>(chain_head, [&](const auto& head) {
-         snapshot_detail::snapshot_block_state_data_v7 block_state_data(get_block_state_to_snapshot());
-
-         snapshot->write_section("eosio::chain::block_state", [&]( auto& section ) {
-            section.add_row(block_state_data, db);
-         });
+      snapshot->write_section("eosio::chain::block_state", [&]( auto& section ) {
+         section.add_row(snapshot_detail::snapshot_block_state_data_v7(get_block_state_to_snapshot()), db);
       });
       
       controller_index_set::walk_indices([this, &snapshot]( auto utils ){


### PR DESCRIPTION
The `block_handle_accessor::apply<>()`'s `head` in `add_to_snapshot()` goes unused, and then `get_block_state_to_snapshot()` just calls `block_handle_accessor::apply<>()` again,
https://github.com/AntelopeIO/spring/blob/feeb75a2592eda08fe1fed224255b36e67ba62a2/libraries/chain/controller.cpp#L2054-L2068
So no need for the outer `apply` here in `add_to_snapshot()` afaict