### PR TITLE
Remove unneeded snapshot_block_state_legacy_v7

### DIFF
--- a/libraries/chain/block_state_legacy.cpp
+++ b/libraries/chain/block_state_legacy.cpp
@@ -78,10 +78,4 @@ namespace eosio::chain {
    ,action_mroot_savanna( action_receipt_digests_savanna ? std::optional<digest_type>(calculate_merkle(*action_receipt_digests_savanna)) : std::nullopt )
    {}
 
-   block_state_legacy::block_state_legacy(snapshot_detail::snapshot_block_state_legacy_v7&& sbs)
-      : block_header_state_legacy(std::move(static_cast<snapshot_detail::snapshot_block_header_state_legacy_v3&>(sbs)))
-        // , valid(std::move(sbs.valid) // [snapshot todo]
-   {
-   }
-
 } /// eosio::chain

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2134,7 +2134,8 @@ struct controller_impl {
                section.read_row(block_state_data, db);
                assert(block_state_data.bs_l || block_state_data.bs);
                if (block_state_data.bs_l) {
-                  auto legacy_ptr = std::make_shared<block_state_legacy>(std::move(*block_state_data.bs_l));
+                  auto legacy_ptr = std::make_shared<block_state_legacy>();
+                  static_cast<block_header_state_legacy&>(*legacy_ptr) = block_header_state_legacy(std::move(*block_state_data.bs_l));
                   chain_head = block_handle{legacy_ptr};
                   result.first = std::move(legacy_ptr);
 

--- a/libraries/chain/include/eosio/chain/block_state_legacy.hpp
+++ b/libraries/chain/include/eosio/chain/block_state_legacy.hpp
@@ -7,10 +7,6 @@
 
 namespace eosio::chain {
 
-   namespace snapshot_detail {
-      struct snapshot_block_state_legacy_v7;
-   }
-
    struct block_state_legacy_accessor;
 
    struct block_state_legacy : public block_header_state_legacy {
@@ -32,8 +28,6 @@ namespace eosio::chain {
                           const validator_t& validator,
                           const signer_callback_type& signer
                 );
-
-      explicit block_state_legacy(snapshot_detail::snapshot_block_state_legacy_v7&& sbs);
 
       block_state_legacy() = default;
 

--- a/libraries/chain/include/eosio/chain/snapshot_detail.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot_detail.hpp
@@ -94,20 +94,6 @@ namespace eosio::chain::snapshot_detail {
     *      Snapshot V7 Data structures
     *      ---------------------------
     */
-   struct snapshot_block_state_legacy_v7 : public snapshot_block_header_state_legacy_v3 {
-      // additional member that can be present in `Transition Legacy Block` and
-      // is needed to convert to `Transition IF Block` (see https://github.com/AntelopeIO/leap/issues/2080)
-      using valid_t = uint32_t; // snapshot todo
-      std::optional<valid_t> valid;
-
-      snapshot_block_state_legacy_v7() = default;
-
-      explicit snapshot_block_state_legacy_v7(const block_state_legacy& bs)
-         : snapshot_block_header_state_legacy_v3(bs)
-         , valid(0)  // snapshot todo
-      {}
-   };
-
    struct snapshot_block_state_v7 {
       // from block_header_state
       block_id_type                                       block_id;
@@ -148,15 +134,15 @@ namespace eosio::chain::snapshot_detail {
       static constexpr uint32_t minimum_version = 7;
       static constexpr uint32_t maximum_version = 7;
 
-      std::optional<snapshot_block_state_legacy_v7> bs_l;
-      std::optional<snapshot_block_state_v7>        bs;
+      std::optional<snapshot_block_header_state_legacy_v3> bs_l;
+      std::optional<snapshot_block_state_v7>               bs;
 
       snapshot_block_state_data_v7() = default;
 
       explicit snapshot_block_state_data_v7(const block_state_pair& p)
       {
          if (p.first)
-            bs_l = snapshot_block_state_legacy_v7(*p.first);
+            bs_l = snapshot_block_header_state_legacy_v3(*p.first);
          if (p.second)
             bs = snapshot_block_state_v7(*p.second);
       }
@@ -204,11 +190,6 @@ FC_REFLECT( eosio::chain::snapshot_detail::snapshot_block_header_state_legacy_v3
           ( activated_protocol_features )
           ( additional_signatures )
 )
-
-FC_REFLECT_DERIVED( eosio::chain::snapshot_detail::snapshot_block_state_legacy_v7,
-                    (eosio::chain::snapshot_detail::snapshot_block_header_state_legacy_v3),
-                    (valid)
-   )
 
 FC_REFLECT( eosio::chain::snapshot_detail::snapshot_block_state_v7,
             (block_id)


### PR DESCRIPTION
Cleanup a leftover TODO. Remove unneeded `snapshot_block_state_legacy_v7` and use existing `snapshot_block_header_state_legacy_v3`.

