### PR TITLE
add progress logs during snapshot loading

### DIFF
--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -110,8 +110,8 @@ namespace eosio { namespace chain {
       });
    }
 
-   void authorization_manager::read_from_snapshot( const snapshot_reader_ptr& snapshot ) {
-      authorization_index_set::walk_indices([this, &snapshot]( auto utils ){
+   void authorization_manager::read_from_snapshot( const snapshot_reader_ptr& snapshot, snapshot_loaded_row_counter& row_counter ) {
+      authorization_index_set::walk_indices([this, &snapshot, &row_counter]( auto utils ){
          using section_t = typename decltype(utils)::index_t::value_type;
 
          // skip the permission_usage_index as its inlined with permission_index
@@ -119,12 +119,13 @@ namespace eosio { namespace chain {
             return;
          }
 
-         snapshot->read_section<section_t>([this]( auto& section ) {
+         snapshot->read_section<section_t>([this, &row_counter]( auto& section ) {
             bool more = !section.empty();
             while(more) {
                decltype(utils)::create(_db, [this, &section, &more]( auto &row ) {
                   more = section.read_row(row, _db);
                });
+               row_counter.progress();
             }
          });
       });

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2061,8 +2061,8 @@ struct controller_impl {
       });
    }
 
-   void read_contract_tables_from_snapshot( const snapshot_reader_ptr& snapshot ) {
-      snapshot->read_section("contract_tables", [this]( auto& section ) {
+   void read_contract_tables_from_snapshot( const snapshot_reader_ptr& snapshot, snapshot_loaded_row_counter& row_counter ) {
+      snapshot->read_section("contract_tables", [this, &row_counter]( auto& section ) {
          bool more = !section.empty();
          while (more) {
             // read the row for the table
@@ -2071,19 +2071,22 @@ struct controller_impl {
                section.read_row(row, db);
                t_id = row.id;
             });
+            row_counter.progress();
 
             // read the size and data rows for each type of table
-            contract_database_index_set::walk_indices([this, &section, &t_id, &more](auto utils) {
+            contract_database_index_set::walk_indices([this, &section, &t_id, &more, &row_counter](auto utils) {
                using utils_t = decltype(utils);
 
                unsigned_int size;
                more = section.read_row(size, db);
+               row_counter.progress();
 
                for (size_t idx = 0; idx < size.value; idx++) {
                   utils_t::create(db, [this, &section, &more, &t_id](auto& row) {
                      row.t_id = t_id;
                      more = section.read_row(row, db);
                   });
+                  row_counter.progress();
                }
             });
          }
@@ -2158,6 +2161,8 @@ struct controller_impl {
    }
 
    block_state_pair read_from_snapshot( const snapshot_reader_ptr& snapshot, uint32_t blog_start, uint32_t blog_end ) {
+      snapshot_loaded_row_counter row_counter(snapshot->total_row_count());
+
       chain_snapshot_header header;
       snapshot->read_section<chain_snapshot_header>([this, &header]( auto &section ){
          section.read_row(header, db);
@@ -2230,7 +2235,7 @@ struct controller_impl {
                   ("block_log_last_num", blog_end)
       );
 
-      controller_index_set::walk_indices([this, &snapshot, &header]( auto utils ){
+      controller_index_set::walk_indices([this, &snapshot, &header, &row_counter]( auto utils ){
          using value_t = typename decltype(utils)::index_t::value_type;
 
          // skip the table_id_object as its inlined with contract tables section
@@ -2303,20 +2308,21 @@ struct controller_impl {
             }
          }
 
-         snapshot->read_section<value_t>([this]( auto& section ) {
+         snapshot->read_section<value_t>([this,&row_counter]( auto& section ) {
             bool more = !section.empty();
             while(more) {
                decltype(utils)::create(db, [this, &section, &more]( auto &row ) {
                   more = section.read_row(row, db);
                });
+               row_counter.progress();
             }
          });
       });
 
-      read_contract_tables_from_snapshot(snapshot);
+      read_contract_tables_from_snapshot(snapshot, row_counter);
 
-      authorization.read_from_snapshot(snapshot);
-      resource_limits.read_from_snapshot(snapshot);
+      authorization.read_from_snapshot(snapshot, row_counter);
+      resource_limits.read_from_snapshot(snapshot, row_counter);
 
       db.set_revision( chain_head.block_num() );
       db.create<database_header_object>([](const auto& header){

--- a/libraries/chain/include/eosio/chain/authorization_manager.hpp
+++ b/libraries/chain/include/eosio/chain/authorization_manager.hpp
@@ -25,7 +25,7 @@ namespace eosio { namespace chain {
          void add_indices();
          void initialize_database();
          void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const;
-         void read_from_snapshot( const snapshot_reader_ptr& snapshot );
+         void read_from_snapshot( const snapshot_reader_ptr& snapshot, snapshot_loaded_row_counter& row_counter );
 
          const permission_object& create_permission( account_name account,
                                                      permission_name name,

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -72,7 +72,7 @@ namespace eosio { namespace chain {
          void add_indices();
          void initialize_database();
          void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const;
-         void read_from_snapshot( const snapshot_reader_ptr& snapshot );
+         void read_from_snapshot( const snapshot_reader_ptr& snapshot, snapshot_loaded_row_counter& row_counter );
 
          void initialize_account( const account_name& account, bool is_trx_transient );
          void set_block_parameters( const elastic_limit_parameters& cpu_limit_parameters, const elastic_limit_parameters& net_limit_parameters );

--- a/libraries/chain/include/eosio/chain/snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot.hpp
@@ -277,6 +277,8 @@ namespace eosio { namespace chain {
 
       virtual void return_to_header() = 0;
 
+      virtual size_t total_row_count() = 0;
+
       virtual ~snapshot_reader(){};
 
       protected:
@@ -313,6 +315,7 @@ namespace eosio { namespace chain {
          bool empty ( ) override;
          void clear_section() override;
          void return_to_header() override;
+         size_t total_row_count() override;
 
       private:
          const fc::variant& snapshot;
@@ -364,6 +367,7 @@ namespace eosio { namespace chain {
          bool empty ( ) override;
          void clear_section() override;
          void return_to_header() override;
+         size_t total_row_count() override;
 
       private:
          bool validate_section() const;
@@ -385,6 +389,7 @@ namespace eosio { namespace chain {
          bool empty ( ) override;
          void clear_section() override;
          void return_to_header() override;
+         size_t total_row_count() override;
 
       private:
          bool validate_section() const;
@@ -406,4 +411,16 @@ namespace eosio { namespace chain {
 
    };
 
+   struct snapshot_loaded_row_counter {
+      snapshot_loaded_row_counter(const size_t total) : total(total) {}
+      void progress() {
+         if(++count % 50000 == 0 && time(NULL) - last_print >= 5) {
+            ilog("Snapshot initialization ${pct}% complete", ("pct",(unsigned)(((double)count/total)*100)));
+            last_print = time(NULL);
+         }
+      }
+      size_t count = 0;
+      const size_t total = 0;
+      time_t last_print = time(NULL);
+   };
 }}

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -81,14 +81,15 @@ void resource_limits_manager::add_to_snapshot( const snapshot_writer_ptr& snapsh
    });
 }
 
-void resource_limits_manager::read_from_snapshot( const snapshot_reader_ptr& snapshot ) {
-   resource_index_set::walk_indices([this, &snapshot]( auto utils ){
-      snapshot->read_section<typename decltype(utils)::index_t::value_type>([this]( auto& section ) {
+void resource_limits_manager::read_from_snapshot( const snapshot_reader_ptr& snapshot, snapshot_loaded_row_counter& row_counter ) {
+   resource_index_set::walk_indices([this, &snapshot, &row_counter]( auto utils ){
+      snapshot->read_section<typename decltype(utils)::index_t::value_type>([this, &row_counter]( auto& section ) {
          bool more = !section.empty();
          while(more) {
             decltype(utils)::create(_db, [this, &section, &more]( auto &row ) {
                more = section.read_row(row, _db);
             });
+            row_counter.progress();
          }
       });
    });

--- a/libraries/chain/snapshot.cpp
+++ b/libraries/chain/snapshot.cpp
@@ -118,6 +118,16 @@ void variant_snapshot_reader::return_to_header() {
    clear_section();
 }
 
+size_t variant_snapshot_reader::total_row_count() {
+   size_t total = 0;
+
+   const fc::variants& sections = snapshot["sections"].get_array();
+   for(const fc::variant& section : sections)
+      total += section["rows"].get_array().size();
+
+   return total;
+}
+
 ostream_snapshot_writer::ostream_snapshot_writer(std::ostream& snapshot)
 :snapshot(snapshot)
 ,header_pos(snapshot.tellp())
@@ -337,6 +347,34 @@ void istream_snapshot_reader::return_to_header() {
    clear_section();
 }
 
+size_t istream_snapshot_reader::total_row_count() {
+   size_t total = 0;
+
+   auto restore_pos = fc::make_scoped_exit([this,pos=snapshot.tellg()](){
+      snapshot.seekg(pos);
+   });
+
+   const std::streamoff header_size = sizeof(ostream_snapshot_writer::magic_number) + sizeof(current_snapshot_version);
+
+   std::streamoff next_section_pos = header_pos + header_size;
+
+   while(true) {
+      snapshot.seekg(next_section_pos);
+      uint64_t section_size = 0;
+      snapshot.read((char*)&section_size, sizeof(section_size));
+      if(section_size == std::numeric_limits<uint64_t>::max())
+         break;
+      next_section_pos = snapshot.tellg() + std::streamoff(section_size);
+
+      uint64_t row_count = 0;
+      snapshot.read((char*)&row_count, sizeof(row_count));
+
+      total += row_count;
+   }
+
+   return total;
+}
+
 struct istream_json_snapshot_reader_impl {
    uint64_t num_rows;
    uint64_t cur_row;
@@ -420,6 +458,16 @@ void istream_json_snapshot_reader::clear_section() {
 
 void istream_json_snapshot_reader::return_to_header() {
    clear_section();
+}
+
+size_t istream_json_snapshot_reader::total_row_count() {
+   size_t total = 0;
+
+   for(const auto& section : impl->doc.GetObject())
+      if(section.value.IsObject() && section.value.HasMember("num_rows"))
+        total += section.value["num_rows"].GetUint64();
+
+   return total;
 }
 
 integrity_hash_snapshot_writer::integrity_hash_snapshot_writer(fc::sha256::encoder& enc)

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -61,6 +61,7 @@ public:
       controller::config copied_config = (copy_files_from_config == copy_config_files)
                                          ? copy_config_and_files(config, ordinal) : copy_config(config, ordinal);
 
+      BOOST_CHECK_GT(snapshot->total_row_count(), 0);
       init(copied_config, snapshot);
    }
 


### PR DESCRIPTION
Adds progress logs during snapshot loading; can look something like
```
info  2024-07-24T03:30:21.700 nodeos    controller.cpp:1831           startup              ] Starting initialization from snapshot and no block log, this may take a significant amount of time
info  2024-07-24T03:30:26.008 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 2% complete
info  2024-07-24T03:30:31.001 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 4% complete
info  2024-07-24T03:30:36.003 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 17% complete
info  2024-07-24T03:30:41.008 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 28% complete
...
info  2024-07-24T03:31:31.029 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 90% complete
info  2024-07-24T03:31:36.009 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 92% complete
info  2024-07-24T03:31:41.019 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 93% complete
info  2024-07-24T03:31:46.035 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 96% complete
info  2024-07-24T03:31:51.017 nodeos    snapshot.hpp:418              progress             ] Snapshot initialization 99% complete
info  2024-07-24T03:31:53.283 nodeos    controller.cpp:1838           startup              ] Snapshot loaded, lib: 310859547
```

Resolves AntelopeIO/leap#1167