### PR TITLE
update pinned build to clang 18.1.8

### DIFF
--- a/tools/reproducible.Dockerfile
+++ b/tools/reproducible.Dockerfile
@@ -56,7 +56,8 @@ RUN tar xf cmake-*.tar.gz && \
     cd cmake*[0-9] && \
     echo 'set(CMAKE_USE_OPENSSL OFF CACHE BOOL "" FORCE)' > spring-init.cmake && \
     ./bootstrap --parallel=$(nproc) --init=spring-init.cmake --generator=Ninja && \
-    ninja install
+    ninja install && \
+    rm -rf cmake*
 
 RUN tar xf llvm-project-${_SPRING_CLANG_VERSION}.src.tar.xz && \
     cmake -S llvm-project-${_SPRING_CLANG_VERSION}.src/llvm -B build-toolchain -GNinja -DLLVM_INCLUDE_DOCS=Off -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release \
@@ -64,7 +65,8 @@ RUN tar xf llvm-project-${_SPRING_CLANG_VERSION}.src.tar.xz && \
                                                                                      -DCOMPILER_RT_BUILD_SANITIZERS=Off \
                                                                                      -DLLVM_ENABLE_PROJECTS='lld;clang;clang-tools-extra' \
                                                                                      -DLLVM_ENABLE_RUNTIMES='compiler-rt;libc;libcxx;libcxxabi;libunwind' && \
-    cmake --build build-toolchain -t install
+    cmake --build build-toolchain -t install && \
+    rm -rf build*
 
 COPY <<-"EOF" /pinnedtoolchain/pinnedtoolchain.cmake
    set(CMAKE_C_COMPILER ${CMAKE_CURRENT_LIST_DIR}/bin/clang)
@@ -89,9 +91,8 @@ RUN tar xf llvm-project-${_SPRING_LLVM_VERSION}.src.tar.xz && \
     cmake -S llvm-project-${_SPRING_LLVM_VERSION}.src/llvm -B build-pinllvm -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=Off \
                                                                                   -DLLVM_ENABLE_RTTI=On -DLLVM_ENABLE_TERMINFO=Off -DLLVM_ENABLE_PIC=Off \
                                                                                   -DCMAKE_INSTALL_PREFIX=/pinnedtoolchain/pinllvm && \
-    cmake --build build-pinllvm -t install
-
-RUN rm -rf llvm* build* cmake*
+    cmake --build build-pinllvm -t install && \
+    rm -rf build* llvm*
 
 FROM builder AS build
 

--- a/tools/reproducible.Dockerfile
+++ b/tools/reproducible.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get -y upgrade && DEBIAN_FRONTEND=noninteractive apt-g
                                                                                               zstd \
                                                                                               ;
 
-ARG _SPRING_CLANG_VERSION=17.0.2
+ARG _SPRING_CLANG_VERSION=18.1.8
 ARG _SPRING_LLVM_VERSION=11.1.0
 ARG _SPRING_CMAKE_VERSION=3.27.6
 


### PR DESCRIPTION
Update the pinned build to clang 18.1.8. Normally I wouldn't have advocated for moving from 17->18 but I stumbled on a c++20 feature that while it's in libstdc++10, is still missing from libc++17 but just added to libc++18: `jthread`. There seems to be an appetite to take on environment upgrades (e.g. #336) so nice to fill out c++20 support more before 1.0 release.

I measured something around a 0.5% speed improvement for a replay over blocks 381452700 through 381632370 (sadly I didn't think to include #344 as part of that; though at least we know #344 wouldn't have been resolved just by updating to clang18).

The upgrade may also unlock another useful feature: `_LIBCPP_HARDENING_MODE` was added in 18 and is similar to `_GLIBCXX_ASSERTIONS` in enabling stdlib hardening checks intended to be operational in production. To be explored still.

This PR also tweaks the Dockerfile to remove intermediary build files at each step instead of at the end. This reduces the size of Docker's build cache from ~20GB to ~14GB