### PR TITLE
add `LIBCXX_HARDENING_MODE=fast` to pinned reproducible builds

### DIFF
--- a/tools/reproducible.Dockerfile
+++ b/tools/reproducible.Dockerfile
@@ -63,6 +63,7 @@ RUN tar xf llvm-project-${_SPRING_CLANG_VERSION}.src.tar.xz && \
     cmake -S llvm-project-${_SPRING_CLANG_VERSION}.src/llvm -B build-toolchain -GNinja -DLLVM_INCLUDE_DOCS=Off -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release \
                                                                                      -DCMAKE_INSTALL_PREFIX=/pinnedtoolchain \
                                                                                      -DCOMPILER_RT_BUILD_SANITIZERS=Off \
+                                                                                     -DLIBCXX_HARDENING_MODE=fast \
                                                                                      -DLLVM_ENABLE_PROJECTS='lld;clang;clang-tools-extra' \
                                                                                      -DLLVM_ENABLE_RUNTIMES='compiler-rt;libc;libcxx;libcxxabi;libunwind' && \
     cmake --build build-toolchain -t install && \


### PR DESCRIPTION
clang18 introduced `LIBCXX_HARDENING_MODE`. This is similar to `GLIBCXX_ASSERTIONS`: hardening checks in the c++ stdlib that are intended for production use. Many, maybe most, distros build their packages with `GLIBCXX_ASSERTIONS`: it is widely considered a good security practice and something like gcc's new `-fhardened` also enables it by default.

For more on `LIBCXX_HARDENING_MODE` see,
https://libcxx.llvm.org/Hardening.html

We already harden our reproducible builds with `-D_FORTIFY_SOURCE=2 -fstack-protector-strong` so let's add `LIBCXX_HARDENING_MODE=fast`. I am not seeing any performance degradation on a replay (within ~0.25%)

A nice feature of libc++'s implementation is that we can set a default at the build time of libc++ and that's always used by default even for user compiled code. That is the approach taken here.

As an example of this option working, see b84fab4 (on main w/o `LIBCXX_HARDENING_MODE=fast`) and cfbb581 (on this branch w/ `LIBCXX_HARDENING_MODE=fast`). Unfortunately just going to have to ignore the `svnn_ibc_unit_test` failures in these examples due to something on main being broken.
b84fab4: https://github.com/AntelopeIO/spring/actions/runs/10098083767/job/27924876431 You can see here that `test_fc` passes
cfbb581: https://github.com/AntelopeIO/spring/actions/runs/10098027444/job/27925337461 You can see here that `test_fc` fails