### PR TITLE
Fix a sign-compare warning in snapshot_tests.cpp

### DIFF
--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -61,7 +61,7 @@ public:
       controller::config copied_config = (copy_files_from_config == copy_config_files)
                                          ? copy_config_and_files(config, ordinal) : copy_config(config, ordinal);
 
-      BOOST_CHECK_GT(snapshot->total_row_count(), 0);
+      BOOST_CHECK_GT(snapshot->total_row_count(), 0u);
       init(copied_config, snapshot);
    }
 


### PR DESCRIPTION
```
unittests/snapshot_tests.cpp:64:7:   required from here
libraries/boost/libs/test/include/boost/test/tools/old/impl.hpp:185:21:    warning: comparison of integer expressions of different signedness: ‘const long unsigned int’ and  ‘const int’ [-Wsign-compare]
  185 |         return left > right;
```