### PR TITLE
[1.0-beta4] Test: Reduce connection retry interval 

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -268,6 +268,9 @@ class Cluster(object):
             nodeosArgs += f" --p2p-max-nodes-per-host {maximumP2pPerHost}"
         if "--max-clients" not in extraNodeosArgs:
             nodeosArgs += f" --max-clients {maximumClients}"
+        if "--connection-cleanup-period" not in extraNodeosArgs:
+            # Quicker retry, default is 30s, since many tests launch multiple nodes at the same time
+            nodeosArgs += f" --connection-cleanup-period 15"
         if Utils.Debug and "--contracts-console" not in extraNodeosArgs:
             nodeosArgs += " --contracts-console"
         if PFSetupPolicy.hasPreactivateFeature(pfSetupPolicy):


### PR DESCRIPTION
Many of the integration tests start multiple nodes at the same time. Since a node can't connect until its peer is up in running this causes a situation where the first attempt to connect fails. The node then waits the default 30 seconds to attempt to reconnect. For the integration tests, reduce this from 30 seconds to 15 seconds. This should reduce the number of flakey failures due to a test running too slow.

Resolves #424 