### PR TITLE
[1.0-beta4 -> main] Test: Increase leeway for trx_finality_status_test

### DIFF
--- a/tests/trx_finality_status_test.py
+++ b/tests/trx_finality_status_test.py
@@ -192,14 +192,15 @@ try:
         f"\n\nfinal status: {json.dumps(retStatus, indent=1)}"
     validate(retStatus)
 
+    # The transaction status db is purged on timeouts when blocks are processed, leeway allows small delay in blocks
     leeway=4
-    assert testNode.waitForBlock(blockNum=startingBlockNum+(successDuration*2),timeout=successDuration+leeway)
+    assert testNode.waitForBlock(blockNum=startingBlockNum+(successDuration*2)+leeway,timeout=successDuration+leeway)
 
     recentBlockNum=testNode.getBlockNum()
     retStatus=testNode.getTransactionStatus(transId)
     state = getState(retStatus)
     assert state == unknownState, \
-        f"ERROR: Calling getTransactionStatus after the success_duration should have resulted in an \"{irreversibleState}\" state.\nstatus: {json.dumps(retStatus, indent=1)}"
+        f"ERROR: Calling getTransactionStatus after the success_duration should have resulted in an \"{unknownState}\" state.\nstatus: {json.dumps(retStatus, indent=1)}"
     validateTrxState(retStatus, present=False)
     validate(retStatus, knownTrx=False)
     assert recentBlockNum <= retStatus["head_number"], \


### PR DESCRIPTION
The existing `leeway` was passed to the timeout of waiting on the block, but not on how many blocks were needed. The test was setup to wait for the exact number of blocks before the transaction would be purged from the status multi-index. It needs one more block after that to trigger the remove. Appears the node was queried just before the removal. 

Merges `release/1.0-beta4` into `main` including #429 

Resolves #415 