### PR TITLE
[1.0-beta4] Test: forkdb can be ahead of chain head in speculative/head mode

### DIFF
--- a/tests/nodeos_irreversible_mode_test.py
+++ b/tests/nodeos_irreversible_mode_test.py
@@ -118,14 +118,17 @@ def confirmLibOfIrrMode(nodeToTest, headLibAndForkDbHeadBeforeSwitchMode=None):
 
 # Confirm the head lib and fork db of speculative mode
 # Under any condition of speculative mode:
-# - forkDbHead == head >= lib
+#  - forkDbHead >= head >= lib
+# For a stable network with no forks and all nodes in-sync, the fork db can have one non-processed block received from
+# the network but not yet applied to chain head.
+#  - forDbHead == (head || head+1) >= lib
 # headLibAndForkDbHeadBeforeSwitchMode should be only passed IF production is disabled, otherwise it provides erroneous check
-# When comparing with the the state before node is switched:
+# When comparing with the state before node is switched:
 # - head == forkDbHeadBeforeSwitchMode == forkDbHead and lib == headBeforeSwitchMode == libBeforeSwitchMode
 def confirmHeadLibAndForkDbHeadOfSpecMode(nodeToTest, headLibAndForkDbHeadBeforeSwitchMode=None):
    head, lib, forkDbHead = getHeadLibAndForkDbHead(nodeToTest)
    assert head >= lib, "Head should be larger or equal to lib (head: {}, lib: {})".format(head, lib)
-   assert head == forkDbHead, "Head ({}) should be equal to fork db head ({})".format(head, forkDbHead)
+   assert (forkDbHead == head) or (forkDbHead == head+1), "Head ({}) should be equal to fork db head or one behind ({})".format(head, forkDbHead)
 
    if headLibAndForkDbHeadBeforeSwitchMode:
       headBeforeSwitchMode, libBeforeSwitchMode, forkDbHeadBeforeSwitchMode = headLibAndForkDbHeadBeforeSwitchMode


### PR DESCRIPTION
In speculative or head mode the fork db head can be ahead of the chain head. Update test expected conditions now that blocks are put into the fork db as soon as header evaluation is complete.

Resolves #427 