### PR TITLE
[1.0-beta4] Log when block has no QCs

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3968,6 +3968,10 @@ struct controller_impl {
       auto qc_ext = bsp_in->block->extract_extension<quorum_certificate_extension>();
       const qc_t& received_qc = qc_ext.qc;
 
+      dlog("received block: #${bn} ${t} ${prod} ${id}, qc claim: ${qc}, previous: ${p}",
+           ("bn", bsp_in->block_num())("t", bsp_in->timestamp())("prod", bsp_in->producer())("id", bsp_in->id())
+           ("qc", qc_ext.qc.to_qc_claim())("p", bsp_in->previous()));
+
       block_state_ptr claimed_bsp = fork_db_fetch_bsp_on_branch_by_num( bsp_in->previous(), qc_ext.qc.block_num );
       if( !claimed_bsp ) {
          dlog("qc not found in forkdb, qc: ${qc} for block ${bn} ${id}, previous ${p}",

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3777,12 +3777,19 @@ struct controller_impl {
                      invalid_qc_claim,
                      "Block #${b} doesn't have a finality header extension even though its predecessor does.",
                      ("b", block_num) );
+
+         dlog("received block: #${bn} ${t} ${prod} ${id}, no qc claim, previous: ${p}",
+              ("bn", block_num)("t", b->timestamp)("prod", b->producer)("id", id)("p", b->previous));
          return;
       }
 
       assert(header_ext);
       const auto& f_ext        = std::get<finality_extension>(*header_ext);
       const auto  new_qc_claim = f_ext.qc_claim;
+
+      dlog("received block: #${bn} ${t} ${prod} ${id}, qc claim: ${qc}, previous: ${p}",
+           ("bn", block_num)("t", b->timestamp)("prod", b->producer)("id", id)
+           ("qc", new_qc_claim)("p", b->previous));
 
       // If there is a header extension, but the previous block does not have a header extension,
       // ensure the block does not have a QC and the QC claim of the current block has a block_num
@@ -3967,10 +3974,6 @@ struct controller_impl {
 
       auto qc_ext = bsp_in->block->extract_extension<quorum_certificate_extension>();
       const qc_t& received_qc = qc_ext.qc;
-
-      dlog("received block: #${bn} ${t} ${prod} ${id}, qc claim: ${qc}, previous: ${p}",
-           ("bn", bsp_in->block_num())("t", bsp_in->timestamp())("prod", bsp_in->producer())("id", bsp_in->id())
-           ("qc", qc_ext.qc.to_qc_claim())("p", bsp_in->previous()));
 
       block_state_ptr claimed_bsp = fork_db_fetch_bsp_on_branch_by_num( bsp_in->previous(), qc_ext.qc.block_num );
       if( !claimed_bsp ) {

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -26,7 +26,7 @@ namespace eosio::chain {
       std::string r;
       r += "[ last_final_block_timestamp: " + bs.last_final_block_timestamp().to_time_point().to_iso_string() + ", ";
       r += "latest_qc_block_timestamp: " + bs.latest_qc_block_timestamp().to_time_point().to_iso_string() + ", ";
-      r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string();
+      r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string() + ", ";
       r += "id: " + bs.id().str();
       r += " ]";
       return r;
@@ -36,7 +36,7 @@ namespace eosio::chain {
       std::string r;
       r += "[ irreversible_blocknum: " + std::to_string(bs.irreversible_blocknum()) + ", ";
       r += "block_num: " + std::to_string(bs.block_num()) + ", ";
-      r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string();
+      r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string() + ", ";
       r += "id: " + bs.id().str();
       r += " ]";
       return r;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -684,6 +684,10 @@ public:
                auto missing = chain.missing_votes(id, qc_ext.qc);
                log_missing_votes(block, id, missing);
             }
+         } else if (block->is_proper_svnn_block()) {
+            fc_ilog(vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no votes",
+                 ("id", id.str().substr(8, 16))("n", block->block_num())("t", block->timestamp)("p", block->producer)
+                 ("l", (fc::time_point::now() - block->timestamp).count() / 1000));
          }
       }
    }


### PR DESCRIPTION
Helpful to distinguish between only missing one vote or no votes making into a block.
Add log of all recevied blocks with qc claim, previous, and timestamp.