### PR TITLE
guard against throwing in `random_access_file`'s `write_datastream` dtor

### DIFF
--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -277,6 +277,8 @@ private:
          const uint32_t num_blocks_in_log = _end_block - _begin_block;
          fc::raw::pack(appender, num_blocks_in_log);
       }
+
+      appender.flush();
    }
 
    std::optional<chain::block_id_type> get_block_id(uint32_t block_num) {


### PR DESCRIPTION
I encountered an unfortunate design deficiency in `random_access_file`'s `write_datastream`. Upon destruction `write_datastream` will flush its buffer via `do_write()` but that call can throw. When this occurs obviously it's Game Over.

This tweaks the interface to `write_datastream`: exceptions during dtor are swallowed (with a log warning); if a user of the class wants errors to be reported they must call a new `flush()` which still throws if writing the buffer fails.

I don't really like that and I'm open to other potential tweaks, but this pattern does have some precedent in `ofstream` (with `basic_filebuf`).