### PR TITLE
[1.0-beta4 -> main] Remove last_final_block_timestamp from fork choice rule

### DIFF
--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -24,8 +24,7 @@ namespace eosio::chain {
 
    std::string log_fork_comparison(const block_state& bs) {
       std::string r;
-      r += "[ last_final_block_timestamp: " + bs.last_final_block_timestamp().to_time_point().to_iso_string() + ", ";
-      r += "latest_qc_block_timestamp: " + bs.latest_qc_block_timestamp().to_time_point().to_iso_string() + ", ";
+      r += "[ latest_qc_block_timestamp: " + bs.latest_qc_block_timestamp().to_time_point().to_iso_string() + ", ";
       r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string();
       r += "id: " + bs.id().str();
       r += " ]";
@@ -69,11 +68,10 @@ namespace eosio::chain {
       using by_best_branch_if_t = ordered_unique<
          tag<by_best_branch>,
          composite_key<block_state,
-                       const_mem_fun<block_state,     block_timestamp_type, &block_state::last_final_block_timestamp>,
                        const_mem_fun<block_state,     block_timestamp_type, &block_state::latest_qc_block_timestamp>,
                        const_mem_fun<block_state,     block_timestamp_type, &block_state::timestamp>,
                        const_mem_fun<block_state,     const block_id_type&, &block_state::id>>,
-         composite_key_compare<std::greater<block_timestamp_type>, std::greater<block_timestamp_type>,
+         composite_key_compare<std::greater<block_timestamp_type>,
                                std::greater<block_timestamp_type>, std::greater<block_id_type>>>;
 
       using by_best_branch_t = std::conditional_t<std::is_same_v<bs_t, block_state>,


### PR DESCRIPTION
Remove last_final_block_timestamp from fork choice rule which can prevent a switch to a fork with a locked block to extend via safety.

Merges `release/1.0-beta4` into `main` including #441 