### PR TITLE
[1.0-beta4 -> main] Log when block has no QCs

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3777,12 +3777,19 @@ struct controller_impl {
                      invalid_qc_claim,
                      "Block #${b} doesn't have a finality header extension even though its predecessor does.",
                      ("b", block_num) );
+
+         dlog("received block: #${bn} ${t} ${prod} ${id}, no qc claim, previous: ${p}",
+              ("bn", block_num)("t", b->timestamp)("prod", b->producer)("id", id)("p", b->previous));
          return;
       }
 
       assert(header_ext);
       const auto& f_ext        = std::get<finality_extension>(*header_ext);
       const auto  new_qc_claim = f_ext.qc_claim;
+
+      dlog("received block: #${bn} ${t} ${prod} ${id}, qc claim: ${qc}, previous: ${p}",
+           ("bn", block_num)("t", b->timestamp)("prod", b->producer)("id", id)
+           ("qc", new_qc_claim)("p", b->previous));
 
       // If there is a header extension, but the previous block does not have a header extension,
       // ensure the block does not have a QC and the QC claim of the current block has a block_num

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -25,7 +25,7 @@ namespace eosio::chain {
    std::string log_fork_comparison(const block_state& bs) {
       std::string r;
       r += "[ latest_qc_block_timestamp: " + bs.latest_qc_block_timestamp().to_time_point().to_iso_string() + ", ";
-      r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string();
+      r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string() + ", ";
       r += "id: " + bs.id().str();
       r += " ]";
       return r;
@@ -35,7 +35,7 @@ namespace eosio::chain {
       std::string r;
       r += "[ irreversible_blocknum: " + std::to_string(bs.irreversible_blocknum()) + ", ";
       r += "block_num: " + std::to_string(bs.block_num()) + ", ";
-      r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string();
+      r += "timestamp: " + bs.timestamp().to_time_point().to_iso_string() + ", ";
       r += "id: " + bs.id().str();
       r += " ]";
       return r;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -684,6 +684,10 @@ public:
                auto missing = chain.missing_votes(id, qc_ext.qc);
                log_missing_votes(block, id, missing);
             }
+         } else if (block->is_proper_svnn_block()) {
+            fc_ilog(vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no votes",
+                 ("id", id.str().substr(8, 16))("n", block->block_num())("t", block->timestamp)("p", block->producer)
+                 ("l", (fc::time_point::now() - block->timestamp).count() / 1000));
          }
       }
    }


### PR DESCRIPTION
Helpful to distinguish between only missing one vote or no votes making into a block.
Add log of all recevied blocks with qc claim, previous, and timestamp.

Merges `release/1.0-beta4` into `main` including #434 