### PR TITLE
[1.0-beta4] Some misc improvements

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -812,11 +812,11 @@ struct building_block {
 
                assembled_block::assembled_block_if ab{
                   bb.active_producer_authority,
-                  bhs,
+                  std::move(bhs),
                   std::move(bb.pending_trx_metas),
                   std::move(bb.pending_trx_receipts),
-                  valid,
-                  qc_data.qc,
+                  std::move(valid),
+                  std::move(qc_data.qc),
                   action_mroot // caching for constructing finality_data.
                };
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4703,20 +4703,11 @@ struct controller_impl {
    }
 
    bool should_terminate() const {
-      constexpr block_num_type max_reversible_blocks = 1000;
       block_num_type head_block_num = chain_head.block_num();
       if (conf.terminate_at_block > 0 && conf.terminate_at_block <= head_block_num) {
          ilog("Block ${n} reached configured maximum block ${num}; terminating",
               ("n", head_block_num)("num", conf.terminate_at_block) );
          return true;
-      }
-      if (!replaying) {
-         block_num_type lib = fork_db_root_block_num();
-         if (lib > 0 && head_block_num >= lib + max_reversible_blocks) {
-            elog("Exceeded max reversible blocks allowed, head ${h} > LIB ${lib} + ${m}",
-                 ("h", head_block_num)("lib", lib)("m", max_reversible_blocks));
-            return true;
-         }
       }
       return false;
    }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4164,8 +4164,6 @@ struct controller_impl {
                             const forked_callback_t& forked_cb, const trx_meta_cache_lookup& trx_lookup )
    {
       auto do_maybe_switch_forks = [&](auto& forkdb) {
-         dlog("maybe switch forks chain_head ${chn} : ${chid}, new_head ${nhn} : ${nhid}, previous ${p}",
-              ("chn", chain_head.block_num())("chid", chain_head.id())("nhn", new_head->block_num())("nhid", new_head->id())("p", new_head->header.previous));
          if( new_head->header.previous == chain_head.id() ) {
             try {
                apply_block( br, new_head, s, trx_lookup );
@@ -4368,8 +4366,10 @@ struct controller_impl {
             break;
          }
       }
-      dlog("removed ${n} expired transactions of the ${t} input dedup list, pending block time ${pt}",
-           ("n", num_removed)("t", total)("pt", now));
+      if (!replaying && total > 0) {
+         dlog("removed ${n} expired transactions of the ${t} input dedup list, pending block time ${pt}",
+              ("n", num_removed)("t", total)("pt", now));
+      }
    }
 
    bool sender_avoids_whitelist_blacklist_enforcement( account_name sender )const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4648,8 +4648,8 @@ struct controller_impl {
       wasmif.code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
    }
 
-   void set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys, bool enable_immediate_voting) {
-      my_finalizers.set_keys(finalizer_keys, enable_immediate_voting);
+   void set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys) {
+      my_finalizers.set_keys(finalizer_keys);
    }
 
    bool irreversible_mode() const { return read_mode == db_read_mode::IRREVERSIBLE; }
@@ -5830,8 +5830,8 @@ void controller::code_block_num_last_used(const digest_type& code_hash, uint8_t 
    return my->code_block_num_last_used(code_hash, vm_type, vm_version, block_num);
 }
 
-void controller::set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys, bool enable_immediate_voting) {
-   my->set_node_finalizer_keys(finalizer_keys, enable_immediate_voting);
+void controller::set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys) {
+   my->set_node_finalizer_keys(finalizer_keys);
 }
 
 /// Protocol feature activation handlers:

--- a/libraries/chain/finality/finalizer.cpp
+++ b/libraries/chain/finality/finalizer.cpp
@@ -262,7 +262,7 @@ my_finalizers_t::fsi_map my_finalizers_t::load_finalizer_safety_info() {
 }
 
 // ----------------------------------------------------------------------------------------
-void my_finalizers_t::set_keys(const std::map<std::string, std::string>& finalizer_keys, bool enable_immediate_voting) {
+void my_finalizers_t::set_keys(const std::map<std::string, std::string>& finalizer_keys) {
    if (finalizer_keys.empty())
       return;
 

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -302,6 +302,7 @@ namespace eosio::chain {
 
    template<class BSP>
    bool fork_database_t<BSP>::has_root() const {
+      std::lock_guard g( my->mtx );
       return !!my->root;
    }
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -378,7 +378,8 @@ namespace eosio::chain {
 
          db_read_mode get_read_mode()const;
          validation_mode get_validation_mode()const;
-         uint32_t get_terminate_at_block()const;
+         /// @return true if terminate-at-block or other conditions are met meanly application should terminate
+         bool should_terminate()const;
 
          void set_subjective_cpu_leeway(fc::microseconds leeway);
          std::optional<fc::microseconds> get_subjective_cpu_leeway() const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -436,7 +436,7 @@ namespace eosio::chain {
       void set_to_read_window();
       bool is_write_window() const;
       void code_block_num_last_used(const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, uint32_t block_num);
-      void set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys, bool enable_immediate_voting = false);
+      void set_node_finalizer_keys(const bls_pub_priv_key_map_t& finalizer_keys);
 
       private:
          friend class apply_context;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -378,8 +378,11 @@ namespace eosio::chain {
 
          db_read_mode get_read_mode()const;
          validation_mode get_validation_mode()const;
-         /// @return true if terminate-at-block or other conditions are met meanly application should terminate
-         bool should_terminate()const;
+         /// @return true if terminate-at-block reaches terminate block number
+         /// thread-safe
+         bool should_terminate(block_num_type head_block_num) const;
+         /// not-thread-safe
+         bool should_terminate() const;
 
          void set_subjective_cpu_leeway(fc::microseconds leeway);
          std::optional<fc::microseconds> get_subjective_cpu_leeway() const;

--- a/libraries/chain/include/eosio/chain/finality/finalizer.hpp
+++ b/libraries/chain/include/eosio/chain/finality/finalizer.hpp
@@ -145,8 +145,7 @@ namespace eosio::chain {
       }
 
       /// only call on startup
-      /// @param enable_immediate_voting if true enable immediate voting on startup (for testing)
-      void    set_keys(const std::map<std::string, std::string>& finalizer_keys, bool enable_immediate_voting);
+      void    set_keys(const std::map<std::string, std::string>& finalizer_keys);
       void    set_default_safety_information(const fsi_t& fsi);
 
       // following two member functions could be private, but are used in testing, not thread safe

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1276,7 +1276,7 @@ namespace eosio::testing {
                ("pop", pop.to_string()));
       }
 
-      control->set_node_finalizer_keys(local_finalizer_keys, true);
+      control->set_node_finalizer_keys(local_finalizer_keys);
 
       fc::mutable_variant_object fin_policy_variant;
       fin_policy_variant("threshold", input.threshold);
@@ -1294,7 +1294,7 @@ namespace eosio::testing {
          auto [privkey, pubkey, pop] = get_bls_key(name);
          local_finalizer_keys[pubkey.to_string()] = privkey.to_string();
       }
-      control->set_node_finalizer_keys(local_finalizer_keys, true);
+      control->set_node_finalizer_keys(local_finalizer_keys);
    }
 
    base_tester::set_finalizers_output_t base_tester::set_active_finalizers(std::span<const account_name> names) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1830,14 +1830,13 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    chain.maybe_switch_forks([this](const transaction_metadata_ptr& trx) { _unapplied_transactions.add_forked(trx); },
                             [this](const transaction_id_type& id) { return _unapplied_transactions.get_trx(id); });
 
-   uint32_t head_block_num = chain.head().block_num();
 
-   if (chain.get_terminate_at_block() > 0 && chain.get_terminate_at_block() <= head_block_num) {
-      ilog("Block ${n} reached configured maximum block ${num}; terminating", ("n",head_block_num)("num", chain.get_terminate_at_block()));
+   if (chain.should_terminate()) {
       app().quit();
       return start_block_result::failed;
    }
 
+   block_num_type             head_block_num    = chain.head().block_num();
    const fc::time_point       now               = fc::time_point::now();
    const block_timestamp_type block_time        = calculate_pending_block_time();
    const uint32_t             pending_block_num = head_block_num + 1;

--- a/unittests/finalizer_tests.cpp
+++ b/unittests/finalizer_tests.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE( basic_finalizer_safety_file_io ) try {
 
    {
       my_finalizers_t fset{safety_file_path};
-      fset.set_keys(local_finalizers, false);
+      fset.set_keys(local_finalizers);
 
       fset.set_fsi(k.pubkey, fsi);
       fset.save_finalizer_safety_info();
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE( basic_finalizer_safety_file_io ) try {
 
    {
       my_finalizers_t fset{safety_file_path};
-      fset.set_keys(local_finalizers, false); // that's when the finalizer safety file is read
+      fset.set_keys(local_finalizers); // that's when the finalizer safety file is read
 
       // make sure the safety info for our finalizer that we saved above is restored correctly
       BOOST_CHECK_EQUAL(fset.get_fsi(k.pubkey), fsi);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE( corrupt_finalizer_safety_file ) try {
 
    {
       my_finalizers_t fset{safety_file_path};
-      fset.set_keys(local_finalizers, false);
+      fset.set_keys(local_finalizers);
 
       fset.set_fsi(k.pubkey, fsi);
       fset.save_finalizer_safety_info();
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE( corrupt_finalizer_safety_file ) try {
 
    {
       my_finalizers_t fset{safety_file_path};
-      BOOST_REQUIRE_THROW(fset.set_keys(local_finalizers, false),     // that's when the finalizer safety file is read
+      BOOST_REQUIRE_THROW(fset.set_keys(local_finalizers),     // that's when the finalizer safety file is read
                           finalizer_safety_exception);
 
       // make sure the safety info for our finalizer that we saved above is restored correctly
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE( finalizer_safety_file_io ) try {
    {
       my_finalizers_t fset{safety_file_path};
       bls_pub_priv_key_map_t local_finalizers = create_local_finalizers<1, 3, 5, 6>(keys);
-      fset.set_keys(local_finalizers, false);
+      fset.set_keys(local_finalizers);
 
       set_fsi<decltype(fsi), 1, 3, 5, 6>(fset, keys, fsi);
       fset.save_finalizer_safety_info();
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE( finalizer_safety_file_io ) try {
    {
       my_finalizers_t fset{safety_file_path};
       bls_pub_priv_key_map_t local_finalizers = create_local_finalizers<3>(keys);
-      fset.set_keys(local_finalizers, false);
+      fset.set_keys(local_finalizers);
 
       // make sure the safety info for our finalizer that we saved above is restored correctly
       BOOST_CHECK_EQUAL(fset.get_fsi(keys[3].pubkey), fsi[3]);
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE( finalizer_safety_file_io ) try {
    {
       my_finalizers_t fset{safety_file_path};
       bls_pub_priv_key_map_t local_finalizers = create_local_finalizers<3>(keys);
-      fset.set_keys(local_finalizers, false);
+      fset.set_keys(local_finalizers);
 
       // make sure the safety info for our finalizer that we saved above is restored correctly
       BOOST_CHECK_EQUAL(fset.get_fsi(keys[3].pubkey), fsi[4]);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE( finalizer_safety_file_io ) try {
    {
       my_finalizers_t fset{safety_file_path};
       bls_pub_priv_key_map_t local_finalizers = create_local_finalizers<1, 5, 6>(keys);
-      fset.set_keys(local_finalizers, false);
+      fset.set_keys(local_finalizers);
 
       // make sure the safety info for our previously inactive finalizer was preserved
       BOOST_CHECK_EQUAL(fset.get_fsi(keys[1].pubkey), fsi[1]);


### PR DESCRIPTION
- Add missing mutex to `fork_database_t::has_root()`.
- When a block fails to produce, do not attempt to produce until the next block time stamp. This prevents a tight spin on failures. We had an issue somewhere for this, but can't find it. I found the problem when testing a possible alternative to #448.
- Refactors terminate-at-block handling into a function.
- Additional `std::move`  in assemble block.
- Logging improvements
  - Do not log expired transaction count during replay.
  - Do not log expired transaction count if there are none.
  - Remove confusing "maybe switch forks" log statement.
  - Log block timestamp instead of wall clock time (which is always logged anyway) during start block.

I could separate some/all of these into different PRs if desired.
 