### PR TITLE
Add endpoint to chain_api that reports active (and pending if different) finalizer policies and each finalizers last tracked vote

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3722,7 +3722,15 @@ struct controller_impl {
       block_state_ptr bsp = fork_db_fetch_bsp_on_branch_by_num(id, qc.block_num);
       if (!bsp)
          return {};
-      return bsp->aggregating_qc.vote_metrics(qc);
+
+      // Get voting metrics from QC
+      auto result =  bsp->aggregating_qc.vote_metrics(qc);
+
+      // Populate block related information
+      result.voted_block_id        = bsp->id();
+      result.voted_block_timestamp = bsp->timestamp();
+
+      return result;
    }
 
 
@@ -5425,6 +5433,12 @@ const producer_authority_schedule* controller::next_producers()const {
 finalizer_policy_ptr controller::head_active_finalizer_policy()const {
    return block_handle_accessor::apply_s<finalizer_policy_ptr>(my->chain_head, [](const auto& head) {
       return head->active_finalizer_policy;
+   });
+}
+
+finalizer_policy_ptr controller::head_pending_finalizer_policy()const {
+   return block_handle_accessor::apply_s<finalizer_policy_ptr>(my->chain_head, [](const auto& head) {
+      return (head->pending_finalizer_policy ? head->pending_finalizer_policy->second : nullptr);
    });
 }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3744,8 +3744,8 @@ struct controller_impl {
       auto result =  bsp->aggregating_qc.vote_metrics(qc);
 
       // Populate block related information
-      result.voted_block_id        = bsp->id();
-      result.voted_block_timestamp = bsp->timestamp();
+      result.voted_for_block_id        = bsp->id();
+      result.voted_for_block_timestamp = bsp->timestamp();
 
       return result;
    }

--- a/libraries/chain/finality/qc.cpp
+++ b/libraries/chain/finality/qc.cpp
@@ -439,11 +439,12 @@ qc_vote_metrics_t aggregating_qc_t::vote_metrics(const qc_t& qc) const {
          if (votes[i]) {
             results.insert(qc_vote_metrics_t::fin_auth{
                   .fin_auth   = finalizer_authority_ptr{finalizer_policy, &finalizer_policy->finalizers[i]}, // use aliasing shared_ptr constructor
-                                                                                                           // add_policy_votes and add_votes in turn  is called on
-                                                                                                           // pending_finalizer_policy after on active_finalizer_policy.
-                                                                                                           // Therefore pending_finalizer_policy generation will be used
-                                                                                                           // for generation if the finalizer votes on both active and
-                                                                                                           // pending finalizer policies.
+
+                  // add_policy_votes and add_votes in turn is called on
+                  // pending_finalizer_policy after on active_finalizer_policy.
+                  // Therefore pending_finalizer_policy generation will be used
+                  // for generation if the finalizer votes on both active and
+                  // pending finalizer policies.
                   .generation = finalizer_policy->generation});
             ++added;
          }

--- a/libraries/chain/finality/qc.cpp
+++ b/libraries/chain/finality/qc.cpp
@@ -437,7 +437,14 @@ qc_vote_metrics_t aggregating_qc_t::vote_metrics(const qc_t& qc) const {
       size_t added = 0;
       for (size_t i = 0; i < votes.size(); ++i) {
          if (votes[i]) {
-            results.insert(finalizer_authority_ptr{finalizer_policy, &finalizer_policy->finalizers[i]}); // use aliasing shared_ptr constructor
+            results.insert(qc_vote_metrics_t::fin_auth_ele{
+                  .fin_auth   = finalizer_authority_ptr{finalizer_policy, &finalizer_policy->finalizers[i]}, // use aliasing shared_ptr constructor
+                                                                                                           // add_policy_votes and add_votes in turn  is called on
+                                                                                                           // pending_finalizer_policy after on active_finalizer_policy.
+                                                                                                           // Therefore pending_finalizer_policy generation will be used
+                                                                                                           // for generation if the finalizer votes on both active and
+                                                                                                           // pending finalizer policies.
+                  .generation = finalizer_policy->generation});
             ++added;
          }
       }
@@ -462,14 +469,6 @@ qc_vote_metrics_t aggregating_qc_t::vote_metrics(const qc_t& qc) const {
          }
          not_voted.flip();
          add_votes(finalizer_policy, not_voted, result.missing_votes);
-      }
-
-      if (added) {
-         // add_policy_votes is called on pending_finalizer_policy after
-         // on active_finalizer_policy. Therefore pending_finalizer_policy
-         // generation will be used for voted_policy_generation if there
-         // are votes for pending_finalizer_policy
-         result.voted_policy_generation = finalizer_policy->generation;
       }
    };
 
@@ -498,7 +497,9 @@ qc_vote_metrics_t::fin_auth_set_t aggregating_qc_t::missing_votes(const qc_t& qc
       assert(!other_votes || other_votes->size() == finalizers.size());
       for (size_t i = 0; i < votes.size(); ++i) {
          if (!votes[i] && !check_other(other_votes, i)) {
-            not_voted.insert(finalizer_authority_ptr{finalizer_policy, &finalizers[i]}); // use aliasing shared_ptr constructor
+            not_voted.insert(qc_vote_metrics_t::fin_auth_ele{
+                  .fin_auth   = finalizer_authority_ptr{finalizer_policy, &finalizers[i]}, // use aliasing shared_ptr constructor
+                                                                                                           .generation = finalizer_policy->generation});
          }
       }
    };

--- a/libraries/chain/finality/qc.cpp
+++ b/libraries/chain/finality/qc.cpp
@@ -499,7 +499,7 @@ qc_vote_metrics_t::fin_auth_set_t aggregating_qc_t::missing_votes(const qc_t& qc
          if (!votes[i] && !check_other(other_votes, i)) {
             not_voted.insert(qc_vote_metrics_t::fin_auth_ele{
                   .fin_auth   = finalizer_authority_ptr{finalizer_policy, &finalizers[i]}, // use aliasing shared_ptr constructor
-                                                                                                           .generation = finalizer_policy->generation});
+                  .generation = finalizer_policy->generation});
          }
       }
    };

--- a/libraries/chain/finality/qc.cpp
+++ b/libraries/chain/finality/qc.cpp
@@ -463,6 +463,14 @@ qc_vote_metrics_t aggregating_qc_t::vote_metrics(const qc_t& qc) const {
          not_voted.flip();
          add_votes(finalizer_policy, not_voted, result.missing_votes);
       }
+
+      if (added) {
+         // add_policy_votes is called on pending_finalizer_policy after
+         // on active_finalizer_policy. Therefore pending_finalizer_policy
+         // generation will be used for voted_policy_generation if there
+         // are votes for pending_finalizer_policy
+         result.voted_policy_generation = finalizer_policy->generation;
+      }
    };
 
    add_policy_votes(active_finalizer_policy, qc.active_policy_sig);

--- a/libraries/chain/finality/qc.cpp
+++ b/libraries/chain/finality/qc.cpp
@@ -437,7 +437,7 @@ qc_vote_metrics_t aggregating_qc_t::vote_metrics(const qc_t& qc) const {
       size_t added = 0;
       for (size_t i = 0; i < votes.size(); ++i) {
          if (votes[i]) {
-            results.insert(qc_vote_metrics_t::fin_auth_ele{
+            results.insert(qc_vote_metrics_t::fin_auth{
                   .fin_auth   = finalizer_authority_ptr{finalizer_policy, &finalizer_policy->finalizers[i]}, // use aliasing shared_ptr constructor
                                                                                                            // add_policy_votes and add_votes in turn  is called on
                                                                                                            // pending_finalizer_policy after on active_finalizer_policy.
@@ -497,7 +497,7 @@ qc_vote_metrics_t::fin_auth_set_t aggregating_qc_t::missing_votes(const qc_t& qc
       assert(!other_votes || other_votes->size() == finalizers.size());
       for (size_t i = 0; i < votes.size(); ++i) {
          if (!votes[i] && !check_other(other_votes, i)) {
-            not_voted.insert(qc_vote_metrics_t::fin_auth_ele{
+            not_voted.insert(qc_vote_metrics_t::fin_auth{
                   .fin_auth   = finalizer_authority_ptr{finalizer_policy, &finalizers[i]}, // use aliasing shared_ptr constructor
                   .generation = finalizer_policy->generation});
          }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -276,8 +276,8 @@ namespace eosio::chain {
          // post-instant-finality this always returns nullptr
          const producer_authority_schedule*         pending_producers_legacy()const;
 
-         finalizer_policy_ptr              head_active_finalizer_policy()const; // returns nullptr pre-savanna, thread-safe
-         finalizer_policy_ptr              head_pending_finalizer_policy()const; // returns nullptr pre-savanna
+         finalizer_policy_ptr   head_active_finalizer_policy()const; // returns nullptr pre-savanna
+         finalizer_policy_ptr   head_pending_finalizer_policy()const; // returns nullptr pre-savanna
 
          /// Return the vote metrics for qc.block_num
          /// thread-safe

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -276,9 +276,8 @@ namespace eosio::chain {
          // post-instant-finality this always returns nullptr
          const producer_authority_schedule*         pending_producers_legacy()const;
 
-         // returns nullptr pre-savanna
-         finalizer_policy_ptr                       head_active_finalizer_policy()const;
-         // returns nullptr pre-savanna, thread-safe, block_num according to branch corresponding to id
+         finalizer_policy_ptr              head_active_finalizer_policy()const; // returns nullptr pre-savanna, thread-safe
+         finalizer_policy_ptr              head_pending_finalizer_policy()const; // returns nullptr pre-savanna
 
          /// Return the vote metrics for qc.block_num
          /// thread-safe

--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -202,9 +202,12 @@ namespace eosio::chain {
       };
       using fin_auth_set_t = std::set<finalizer_authority_ptr, fin_auth_less>;
 
-      fin_auth_set_t strong_votes;
-      fin_auth_set_t weak_votes;
-      fin_auth_set_t missing_votes;
+      fin_auth_set_t       strong_votes;
+      fin_auth_set_t       weak_votes;
+      fin_auth_set_t       missing_votes;
+      uint32_t             voted_policy_generation{0}; // pick the pending over the active if both are present
+      block_timestamp_type voted_block_timestamp;
+      block_id_type        voted_block_id;
    };
 
    /**

--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -195,17 +195,22 @@ namespace eosio::chain {
 
    // finalizer authority of strong, weak, or missing votes
    struct qc_vote_metrics_t {
+      struct fin_auth_ele {
+         finalizer_authority_ptr fin_auth;
+         // If the finalizer votes in both active and pending policies,
+         // use pending finalizer policy's generation.
+         uint32_t                generation{0};
+      };
       struct fin_auth_less {
-         bool operator()(const finalizer_authority_ptr& lhs, const finalizer_authority_ptr& rhs) const {
-            return lhs->public_key < rhs->public_key;
+         bool operator()(const fin_auth_ele& lhs, const fin_auth_ele& rhs) const {
+            return lhs.fin_auth->public_key < rhs.fin_auth->public_key;
          };
       };
-      using fin_auth_set_t = std::set<finalizer_authority_ptr, fin_auth_less>;
+      using fin_auth_set_t = std::set<fin_auth_ele, fin_auth_less>;
 
       fin_auth_set_t       strong_votes;
       fin_auth_set_t       weak_votes;
       fin_auth_set_t       missing_votes;
-      uint32_t             voted_policy_generation{0}; // pick the pending over the active if both are present
       block_timestamp_type voted_block_timestamp;
       block_id_type        voted_block_id;
    };

--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -195,18 +195,18 @@ namespace eosio::chain {
 
    // finalizer authority of strong, weak, or missing votes
    struct qc_vote_metrics_t {
-      struct fin_auth_ele {
+      struct fin_auth {
          finalizer_authority_ptr fin_auth;
          // If the finalizer votes in both active and pending policies,
          // use pending finalizer policy's generation.
          uint32_t                generation{0};
       };
       struct fin_auth_less {
-         bool operator()(const fin_auth_ele& lhs, const fin_auth_ele& rhs) const {
+         bool operator()(const fin_auth& lhs, const fin_auth& rhs) const {
             return lhs.fin_auth->public_key < rhs.fin_auth->public_key;
          };
       };
-      using fin_auth_set_t = std::set<fin_auth_ele, fin_auth_less>;
+      using fin_auth_set_t = std::set<fin_auth, fin_auth_less>;
 
       fin_auth_set_t       strong_votes;
       fin_auth_set_t       weak_votes;

--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -211,8 +211,8 @@ namespace eosio::chain {
       fin_auth_set_t       strong_votes;
       fin_auth_set_t       weak_votes;
       fin_auth_set_t       missing_votes;
-      block_timestamp_type voted_block_timestamp;
-      block_id_type        voted_block_id;
+      block_timestamp_type voted_for_block_timestamp;
+      block_id_type        voted_for_block_id;
    };
 
    /**

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -140,6 +140,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_abi, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_raw_code_and_abi, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_raw_abi, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_finalizer_info, 200, http_params_types::no_params),
       CHAIN_RO_CALL_POST(get_table_rows, chain_apis::read_only::get_table_rows_result, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_table_by_scope, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_currency_balance, 200, http_params_types::params_required),

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library( chain_plugin
              trx_finality_status_processing.cpp
              chain_plugin.cpp
              trx_retry_db.cpp
+             tracked_votes.cpp
              ${HEADERS} )
 
 if(EOSIO_ENABLE_DEVELOPER_OPTIONS)

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1775,6 +1775,11 @@ read_only::get_finalizer_info_result read_only::get_finalizer_info( const read_o
       }
    }
 
+   // Sort last_tracked_votes by description
+   std::sort( result.last_tracked_votes.begin(), result.last_tracked_votes.end(), []( const tracked_votes::vote_info& lhs, const tracked_votes::vote_info& rhs ) {
+      return lhs.description < rhs.description;
+   });
+
    return result;
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1,5 +1,6 @@
 #include <eosio/chain_plugin/chain_plugin.hpp>
 #include <eosio/chain_plugin/trx_retry_db.hpp>
+#include <eosio/chain_plugin/tracked_votes.hpp>
 #include <eosio/chain/block_log.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/authorization_manager.hpp>
@@ -197,6 +198,7 @@ public:
    std::optional<chain_apis::account_query_db>                        _account_query_db;
    std::optional<chain_apis::trx_retry_db>                            _trx_retry_db;
    chain_apis::trx_finality_status_processing_ptr                     _trx_finality_status_processing;
+   std::optional<chain_apis::tracked_votes>                           _last_tracked_votes;
 
    static void handle_guard_exception(const chain::guard_exception& e);
    void do_hard_replay(const variables_map& options);
@@ -1040,6 +1042,10 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
             _trx_finality_status_processing->signal_accepted_block(block, id);
          }
 
+         if (_last_tracked_votes) {
+            _last_tracked_votes->on_accepted_block(block, id);
+         }
+
          accepted_block_channel.publish( priority::high, t );
       } );
 
@@ -1141,6 +1147,7 @@ void chain_plugin_impl::plugin_startup()
       } FC_LOG_AND_DROP(("Unable to enable account queries"));
    }
 
+   _last_tracked_votes.emplace(*chain);
 
 } FC_CAPTURE_AND_RETHROW() }
 
@@ -1190,7 +1197,7 @@ chain_apis::read_write chain_plugin::get_read_write_api(const fc::microseconds& 
 }
 
 chain_apis::read_only chain_plugin::get_read_only_api(const fc::microseconds& http_max_response_time) const {
-   return chain_apis::read_only(chain(), my->_account_query_db, get_abi_serializer_max_time(), http_max_response_time, my->_trx_finality_status_processing.get());
+   return chain_apis::read_only(chain(), my->_account_query_db, my->_last_tracked_votes, get_abi_serializer_max_time(), http_max_response_time, my->_trx_finality_status_processing.get());
 }
 
 
@@ -1734,6 +1741,41 @@ fc::variant get_global_row( const database& db, const abi_def& abi, const abi_se
    vector<char> data;
    read_only::copy_inline_row(*it, data);
    return abis.binary_to_variant(abis.get_table_type("global"_n), data, abi_serializer::create_yield_function( abi_serializer_max_time_us ), shorten_abi_errors );
+}
+
+read_only::get_finalizer_info_result read_only::get_finalizer_info( const read_only::get_finalizer_info_params& p, const fc::time_point& ) const {
+   read_only::get_finalizer_info_result result;
+
+   // Finalizer keys present in active_finalizer_policy and pending_finalizer_policy.
+   // Use std::set for eliminating duplications.
+   std::set<string> finalizer_keys;
+
+   // Populate a particular finalizer policy
+   auto add_policy_to_result = [&](const finalizer_policy_ptr& from_policy, fc::variant& to_policy) {
+      if (from_policy) {
+         // Use string format of public key for easy uses
+         to_variant(finalizer_policy_with_string_key{*from_policy}, to_policy);
+
+         for (const auto& f: from_policy->finalizers) {
+            finalizer_keys.insert(f.public_key.to_string());
+         }
+      }
+   };
+
+   // Populate active_finalizer_policy and pending_finalizer_policy
+   add_policy_to_result(db.head_active_finalizer_policy(), result.active_finalizer_policy);
+   add_policy_to_result(db.head_pending_finalizer_policy(), *result.pending_finalizer_policy);
+
+   // Populate last_tracked_votes
+   if (last_tracked_votes) {
+      for (const auto& k: finalizer_keys) {
+         if (const auto& v = last_tracked_votes->get_last_vote_info(k)) {
+            result.last_tracked_votes.emplace_back(*v);
+         }
+      }
+   }
+
+   return result;
 }
 
 read_only::get_producers_result

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1748,7 +1748,7 @@ read_only::get_finalizer_info_result read_only::get_finalizer_info( const read_o
 
    // Finalizer keys present in active_finalizer_policy and pending_finalizer_policy.
    // Use std::set for eliminating duplications.
-   std::set<string> finalizer_keys;
+   std::set<fc::crypto::blslib::bls_public_key> finalizer_keys;
 
    // Populate a particular finalizer policy
    auto add_policy_to_result = [&](const finalizer_policy_ptr& from_policy, fc::variant& to_policy) {
@@ -1757,7 +1757,7 @@ read_only::get_finalizer_info_result read_only::get_finalizer_info( const read_o
          to_variant(finalizer_policy_with_string_key{*from_policy}, to_policy);
 
          for (const auto& f: from_policy->finalizers) {
-            finalizer_keys.insert(f.public_key.to_string());
+            finalizer_keys.insert(f.public_key);
          }
       }
    };

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1764,7 +1764,7 @@ read_only::get_finalizer_info_result read_only::get_finalizer_info( const read_o
 
    // Populate active_finalizer_policy and pending_finalizer_policy
    add_policy_to_result(db.head_active_finalizer_policy(), result.active_finalizer_policy);
-   add_policy_to_result(db.head_pending_finalizer_policy(), *result.pending_finalizer_policy);
+   add_policy_to_result(db.head_pending_finalizer_policy(), result.pending_finalizer_policy);
 
    // Populate last_tracked_votes
    if (last_tracked_votes) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1754,7 +1754,7 @@ read_only::get_finalizer_info_result read_only::get_finalizer_info( const read_o
    auto add_policy_to_result = [&](const finalizer_policy_ptr& from_policy, fc::variant& to_policy) {
       if (from_policy) {
          // Use string format of public key for easy uses
-         to_variant(finalizer_policy_with_string_key{*from_policy}, to_policy);
+         to_variant(*from_policy, to_policy);
 
          for (const auto& f: from_policy->finalizers) {
             finalizer_keys.insert(f.public_key);

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -3,6 +3,7 @@
 #include <eosio/chain_plugin/account_query_db.hpp>
 #include <eosio/chain_plugin/trx_retry_db.hpp>
 #include <eosio/chain_plugin/trx_finality_status_processing.hpp>
+#include <eosio/chain_plugin/tracked_votes.hpp>
 
 #include <eosio/chain/application.hpp>
 #include <eosio/chain/asset.hpp>
@@ -139,6 +140,7 @@ protected:
 class read_only : public api_base {
    const controller& db;
    const std::optional<account_query_db>& aqdb;
+   const std::optional<tracked_votes>& last_tracked_votes;
    const fc::microseconds abi_serializer_max_time;
    const fc::microseconds http_max_response_time;
    bool  shorten_abi_errors = true;
@@ -149,10 +151,12 @@ public:
    static const string KEYi64;
 
    read_only(const controller& db, const std::optional<account_query_db>& aqdb,
+             const std::optional<tracked_votes>& last_tracked_votes,
              const fc::microseconds& abi_serializer_max_time, const fc::microseconds& http_max_response_time,
              const trx_finality_status_processing* trx_finality_status_proc)
       : db(db)
       , aqdb(aqdb)
+      , last_tracked_votes(last_tracked_votes)
       , abi_serializer_max_time(abi_serializer_max_time)
       , http_max_response_time(http_max_response_time)
       , trx_finality_status_proc(trx_finality_status_proc) {
@@ -485,6 +489,17 @@ public:
    };
 
    fc::variant get_currency_stats( const get_currency_stats_params& params, const fc::time_point& deadline )const;
+
+   struct get_finalizer_info_params {
+   };
+
+   struct get_finalizer_info_result {
+      fc::variant                       active_finalizer_policy;
+      std::optional<fc::variant>        pending_finalizer_policy; // if existing
+      vector<tracked_votes::vote_info>  last_tracked_votes;
+   };
+
+   get_finalizer_info_result get_finalizer_info( const get_finalizer_info_params& params, const fc::time_point& deadline )const;
 
    struct get_producers_params {
       bool        json = false;
@@ -1046,6 +1061,9 @@ FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_result, (rows)(more
 FC_REFLECT( eosio::chain_apis::read_only::get_currency_balance_params, (code)(account)(symbol));
 FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_params, (code)(symbol));
 FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_result, (supply)(max_supply)(issuer));
+
+FC_REFLECT_EMPTY( eosio::chain_apis::read_only::get_finalizer_info_params )
+FC_REFLECT( eosio::chain_apis::read_only::get_finalizer_info_result, (active_finalizer_policy)(pending_finalizer_policy)(last_tracked_votes) );
 
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit)(time_limit_ms) )
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_result, (rows)(total_producer_vote_weight)(more) );

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -494,8 +494,13 @@ public:
    };
 
    struct get_finalizer_info_result {
-      fc::variant                            active_finalizer_policy;
-      fc::variant                            pending_finalizer_policy;
+      fc::variant                            active_finalizer_policy;  // current active policy
+      fc::variant                            pending_finalizer_policy; // current pending policy. Empty if not existing
+
+      // Last tracked vote information for each of the finalizers in
+      // active_finalizer_policy and pending_finalizer_policy.
+      // if a finalizer votes on both active_finalizer_policy and pending_finalizer_policy,
+      // the vote information on pending_finalizer_policy is used.
       std::vector<tracked_votes::vote_info>  last_tracked_votes;
    };
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -494,9 +494,9 @@ public:
    };
 
    struct get_finalizer_info_result {
-      fc::variant                       active_finalizer_policy;
-      fc::variant                       pending_finalizer_policy;
-      vector<tracked_votes::vote_info>  last_tracked_votes;
+      fc::variant                            active_finalizer_policy;
+      fc::variant                            pending_finalizer_policy;
+      std::vector<tracked_votes::vote_info>  last_tracked_votes;
    };
 
    get_finalizer_info_result get_finalizer_info( const get_finalizer_info_params& params, const fc::time_point& deadline )const;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -495,7 +495,7 @@ public:
 
    struct get_finalizer_info_result {
       fc::variant                       active_finalizer_policy;
-      std::optional<fc::variant>        pending_finalizer_policy; // if existing
+      fc::variant                       pending_finalizer_policy;
       vector<tracked_votes::vote_info>  last_tracked_votes;
    };
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/block.hpp>
+#include <eosio/chain/controller.hpp>
+
+namespace eosio::chain_apis {
+   /**
+    * This class manages the ephemeral data that is needed by `get_finalizers_info` RPC call.
+    * There is no persistence and the cache is recreated when the class is instantiated
+    * based on the current state of the chain.
+    */
+   class tracked_votes {
+   public:
+
+      /**
+       * Instantiate a new tracked votes cache from the given chain controller
+       * The caller is expected to manage lifetimes such that this controller reference does not go stale
+       * for the life of the tracked votes cache
+       * @param chain - controller to read data from
+       */
+      tracked_votes( const class eosio::chain::controller& chain );
+      ~tracked_votes();
+
+      /**
+       * vote information for a given finalizer.
+       */
+      struct vote_info {
+         std::string          public_key;
+         std::string          description;
+         bool                 is_vote_strong{false};
+         chain::block_id_type voted_block_id;
+         uint32_t             voted_block_num{0};
+         fc::time_point       voted_block_timestamp;
+      };
+
+      // Called on accepted_block signal. Retrieve vote information from
+      // QC in the block and store it in last_votes.
+      void on_accepted_block(const chain::signed_block_ptr& block, const chain::block_id_type& id);
+
+      // Returns last vote information by a given finalizer
+      std::optional<vote_info> get_last_vote_info(const std::string& finalizer_pub_key) const;
+
+   private:
+      std::unique_ptr<struct tracked_votes_impl> _impl;
+   };
+
+}
+
+FC_REFLECT( eosio::chain_apis::tracked_votes::vote_info, (public_key)(description)(is_vote_strong)(voted_block_id)(voted_block_num)(voted_block_timestamp))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
@@ -25,13 +25,13 @@ namespace eosio::chain_apis {
        * vote information for a given finalizer.
        */
       struct vote_info {
-         std::string          public_key;
-         std::string          description;
-         bool                 is_vote_strong{false};
-         uint32_t             voted_policy_generation{0};
-         chain::block_id_type voted_block_id;
-         uint32_t             voted_block_num{0};
-         fc::time_point       voted_block_timestamp;
+         std::string          public_key;  // voting finalizer's public key
+         std::string          description; // voting finalizer's description
+         bool                 is_vote_strong{false}; // indicating the vote is strong or not
+         uint32_t             voted_policy_generation{0}; // the generation of finalizer policy being used to vote
+         chain::block_id_type voted_block_id;  // block id of the block being voted
+         uint32_t             voted_block_num{0}; // block number of the block being voted
+         fc::time_point       voted_block_timestamp; // block timestamp of the block being voted
       };
 
       // Called on accepted_block signal. Retrieve vote information from

--- a/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
@@ -28,6 +28,7 @@ namespace eosio::chain_apis {
          std::string          public_key;
          std::string          description;
          bool                 is_vote_strong{false};
+         uint32_t             voted_policy_generation{0};
          chain::block_id_type voted_block_id;
          uint32_t             voted_block_num{0};
          fc::time_point       voted_block_timestamp;
@@ -46,4 +47,4 @@ namespace eosio::chain_apis {
 
 }
 
-FC_REFLECT( eosio::chain_apis::tracked_votes::vote_info, (public_key)(description)(is_vote_strong)(voted_block_id)(voted_block_num)(voted_block_timestamp))
+FC_REFLECT( eosio::chain_apis::tracked_votes::vote_info, (public_key)(description)(is_vote_strong)(voted_policy_generation)(voted_block_id)(voted_block_num)(voted_block_timestamp))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
@@ -18,7 +18,7 @@ namespace eosio::chain_apis {
        * for the life of the tracked votes cache
        * @param chain - controller to read data from
        */
-      tracked_votes( const class eosio::chain::controller& chain );
+      explicit tracked_votes( const class eosio::chain::controller& chain );
       ~tracked_votes();
 
       /**

--- a/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
@@ -39,7 +39,7 @@ namespace eosio::chain_apis {
       void on_accepted_block(const chain::signed_block_ptr& block, const chain::block_id_type& id);
 
       // Returns last vote information by a given finalizer
-      std::optional<vote_info> get_last_vote_info(const std::string& finalizer_pub_key) const;
+      std::optional<vote_info> get_last_vote_info(const fc::crypto::blslib::bls_public_key& finalizer_pub_key) const;
 
    private:
       std::unique_ptr<struct tracked_votes_impl> _impl;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
@@ -25,13 +25,13 @@ namespace eosio::chain_apis {
        * vote information for a given finalizer.
        */
       struct vote_info {
-         std::string          public_key;  // voting finalizer's public key
          std::string          description; // voting finalizer's description
+         std::string          public_key;  // voting finalizer's public key
          bool                 is_vote_strong{false}; // indicating the vote is strong or not
-         uint32_t             voted_policy_generation{0}; // the generation of finalizer policy being used to vote
-         chain::block_id_type voted_block_id;  // block id of the block being voted
-         uint32_t             voted_block_num{0}; // block number of the block being voted
-         fc::time_point       voted_block_timestamp; // block timestamp of the block being voted
+         uint32_t             finalizer_policy_generation{0}; // the generation of finalizer policy being used to vote
+         chain::block_id_type voted_for_block_id;  // block id of the block being voted
+         uint32_t             voted_for_block_num{0}; // block number of the block being voted
+         fc::time_point       voted_for_block_timestamp; // block timestamp of the block being voted
       };
 
       // Called on accepted_block signal. Retrieve vote information from
@@ -47,4 +47,4 @@ namespace eosio::chain_apis {
 
 }
 
-FC_REFLECT( eosio::chain_apis::tracked_votes::vote_info, (public_key)(description)(is_vote_strong)(voted_policy_generation)(voted_block_id)(voted_block_num)(voted_block_timestamp))
+FC_REFLECT( eosio::chain_apis::tracked_votes::vote_info, (description)(public_key)(is_vote_strong)(finalizer_policy_generation)(voted_for_block_id)(voted_for_block_num)(voted_for_block_timestamp))

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -16,7 +16,7 @@ namespace eosio::chain_apis {
 
       // Cache to store last vote information for each known finalizer.
       // A map of finalizer public key --> vote info.
-      std::unordered_map<std::string, tracked_votes::vote_info> last_votes;
+      std::map<fc::crypto::blslib::bls_public_key, tracked_votes::vote_info> last_votes;
 
       // A handle to the controller.
       const chain::controller& controller;
@@ -46,7 +46,7 @@ namespace eosio::chain_apis {
                   .voted_block_timestamp    = vm.voted_block_timestamp
                };
 
-               last_votes.emplace(f->public_key.to_string(), v_info); // track the voting information for the finalizer
+               last_votes.emplace(f->public_key, v_info); // track the voting information for the finalizer
             }
          };
 
@@ -55,7 +55,7 @@ namespace eosio::chain_apis {
       }
 
       // Returns last vote information by a given finalizer
-      std::optional<tracked_votes::vote_info> get_last_vote_info(const std::string& finalizer_pub_key) const {
+      std::optional<tracked_votes::vote_info> get_last_vote_info(const fc::crypto::blslib::bls_public_key& finalizer_pub_key) const {
          auto it = last_votes.find(finalizer_pub_key);
          if (it != last_votes.end()) {
              return it->second;
@@ -76,7 +76,7 @@ namespace eosio::chain_apis {
       _impl->on_accepted_block(block, id);
    }
 
-   std::optional<tracked_votes::vote_info> tracked_votes::get_last_vote_info(const std::string& finalizer_pub_key) const {
+   std::optional<tracked_votes::vote_info> tracked_votes::get_last_vote_info(const fc::crypto::blslib::bls_public_key& finalizer_pub_key) const {
       return _impl->get_last_vote_info(finalizer_pub_key);
    }
 } // namespace eosio::chain_apis

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -10,7 +10,7 @@ namespace eosio::chain_apis {
     * Implementation details of the last tracked cache
     */
    struct tracked_votes_impl {
-      tracked_votes_impl(const chain::controller& controller)
+      explicit tracked_votes_impl(const chain::controller& controller)
       :controller(controller)
       {}
 

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -38,13 +38,13 @@ namespace eosio::chain_apis {
                   assert(f.fin_auth);
 
                   tracked_votes::vote_info v_info {
-                     .public_key               = f.fin_auth->public_key.to_string(),
-                     .description              = f.fin_auth->description,
-                     .is_vote_strong           = is_strong,
-                     .voted_policy_generation  = f.generation,
-                     .voted_block_id           = vm.voted_block_id,
-                     .voted_block_num          = chain::block_header::num_from_id(vm.voted_block_id),
-                     .voted_block_timestamp    = vm.voted_block_timestamp
+                     .description                  = f.fin_auth->description,
+                     .public_key                   = f.fin_auth->public_key.to_string(),
+                     .is_vote_strong               = is_strong,
+                     .finalizer_policy_generation  = f.generation,
+                     .voted_for_block_id           = vm.voted_for_block_id,
+                     .voted_for_block_num          = chain::block_header::num_from_id(vm.voted_for_block_id),
+                     .voted_for_block_timestamp    = vm.voted_for_block_timestamp
                   };
 
                   last_votes.emplace(f.fin_auth->public_key, std::move(v_info)); // track the voting information for the finalizer

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -37,12 +37,13 @@ namespace eosio::chain_apis {
                assert(f);
 
                tracked_votes::vote_info v_info {
-                  .public_key            = f->public_key.to_string(),
-                  .description           = f->description,
-                  .is_vote_strong        = true,
-                  .voted_block_id        = vm.voted_block_id,
-                  .voted_block_num       = chain::block_header::num_from_id(vm.voted_block_id),
-                  .voted_block_timestamp = vm.voted_block_timestamp
+                  .public_key               = f->public_key.to_string(),
+                  .description              = f->description,
+                  .is_vote_strong           = true,
+                  .voted_policy_generation  = vm.voted_policy_generation,
+                  .voted_block_id           = vm.voted_block_id,
+                  .voted_block_num          = chain::block_header::num_from_id(vm.voted_block_id),
+                  .voted_block_timestamp    = vm.voted_block_timestamp
                };
 
                last_votes.emplace(f->public_key.to_string(), v_info); // track the voting information for the finalizer

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -35,19 +35,19 @@ namespace eosio::chain_apis {
 
             auto track_votes = [&](const chain::qc_vote_metrics_t::fin_auth_set_t& finalizers, bool is_strong) {
                for (auto& f: finalizers) {
-                  assert(f);
+                  assert(f.fin_auth);
 
                   tracked_votes::vote_info v_info {
-                     .public_key               = f->public_key.to_string(),
-                     .description              = f->description,
+                     .public_key               = f.fin_auth->public_key.to_string(),
+                     .description              = f.fin_auth->description,
                      .is_vote_strong           = is_strong,
-                     .voted_policy_generation  = vm.voted_policy_generation,
+                     .voted_policy_generation  = f.generation,
                      .voted_block_id           = vm.voted_block_id,
                      .voted_block_num          = chain::block_header::num_from_id(vm.voted_block_id),
                      .voted_block_timestamp    = vm.voted_block_timestamp
                   };
 
-                  last_votes.emplace(f->public_key, std::move(v_info)); // track the voting information for the finalizer
+                  last_votes.emplace(f.fin_auth->public_key, std::move(v_info)); // track the voting information for the finalizer
                }
             };
 

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -39,7 +39,7 @@ namespace eosio::chain_apis {
                tracked_votes::vote_info v_info {
                   .public_key               = f->public_key.to_string(),
                   .description              = f->description,
-                  .is_vote_strong           = true,
+                  .is_vote_strong           = is_strong,
                   .voted_policy_generation  = vm.voted_policy_generation,
                   .voted_block_id           = vm.voted_block_id,
                   .voted_block_num          = chain::block_header::num_from_id(vm.voted_block_id),

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -47,7 +47,7 @@ namespace eosio::chain_apis {
                      .voted_block_timestamp    = vm.voted_block_timestamp
                   };
 
-                  last_votes.emplace(f->public_key, v_info); // track the voting information for the finalizer
+                  last_votes.emplace(f->public_key, std::move(v_info)); // track the voting information for the finalizer
                }
             };
 

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -1,0 +1,81 @@
+#include <eosio/chain_plugin/tracked_votes.hpp>
+
+#include <shared_mutex>
+
+using namespace eosio;
+using namespace eosio::chain::literals;
+
+namespace eosio::chain_apis {
+   /**
+    * Implementation details of the last tracked cache
+    */
+   struct tracked_votes_impl {
+      tracked_votes_impl(const chain::controller& controller)
+      :controller(controller)
+      {}
+
+      // Cache to store last vote information for each known finalizer.
+      // A map of finalizer public key --> vote info.
+      std::unordered_map<std::string, tracked_votes::vote_info> last_votes;
+
+      // A handle to the controller.
+      const chain::controller& controller;
+
+      // Called on accepted_block signal. Retrieve vote information from
+      // QC in the block and store it in last_votes.
+      void on_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
+         if (!block->contains_extension(chain::quorum_certificate_extension::extension_id())) {
+            return;
+         }
+
+         // Retrieve vote information from QC
+         const auto& qc_ext = block->extract_extension<chain::quorum_certificate_extension>();
+         chain::qc_vote_metrics_t vm = controller.vote_metrics(id, qc_ext.qc);
+
+         auto track_votes = [&](const chain::qc_vote_metrics_t::fin_auth_set_t& finalizers, bool is_strong) {
+            for (auto& f: finalizers) {
+               assert(f);
+
+               tracked_votes::vote_info v_info {
+                  .public_key            = f->public_key.to_string(),
+                  .description           = f->description,
+                  .is_vote_strong        = true,
+                  .voted_block_id        = vm.voted_block_id,
+                  .voted_block_num       = chain::block_header::num_from_id(vm.voted_block_id),
+                  .voted_block_timestamp = vm.voted_block_timestamp
+               };
+
+               last_votes.emplace(f->public_key.to_string(), v_info); // track the voting information for the finalizer
+            }
+         };
+
+         track_votes(vm.strong_votes, true);
+         track_votes(vm.weak_votes, false);
+      }
+
+      // Returns last vote information by a given finalizer
+      std::optional<tracked_votes::vote_info> get_last_vote_info(const std::string& finalizer_pub_key) const {
+         auto it = last_votes.find(finalizer_pub_key);
+         if (it != last_votes.end()) {
+             return it->second;
+         }
+
+         return {};
+      }
+   }; // tracked_votes_impl
+
+   tracked_votes::tracked_votes( const chain::controller& controller )
+   :_impl(std::make_unique<tracked_votes_impl>(controller))
+   {
+   }
+
+   tracked_votes::~tracked_votes() = default;
+
+   void tracked_votes::on_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
+      _impl->on_accepted_block(block, id);
+   }
+
+   std::optional<tracked_votes::vote_info> tracked_votes::get_last_vote_info(const std::string& finalizer_pub_key) const {
+      return _impl->get_last_vote_info(finalizer_pub_key);
+   }
+} // namespace eosio::chain_apis

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -637,7 +637,7 @@ public:
             std::string not_voted;
             for (const auto& f : missing_votes) {
                if (_finalizers.contains(f.fin_auth->public_key)) {
-                  fc_wlog(vote_logger, "Local finalizer ${f} did not vote on block ${n} : ${id} for block ${m_n}",
+                  fc_wlog(vote_logger, "Local finalizer ${f} did not vote in block ${n} : ${id} for block ${m_n}",
                           ("f", f.fin_auth->description)("n", block->block_num())("id", id.str().substr(8,16))("m_n", missed_block_num));
                }
                not_voted += f.fin_auth->description;
@@ -645,9 +645,9 @@ public:
             }
             if (!not_voted.empty()) {
                not_voted.resize(not_voted.size() - 1); // remove ','
-               fc_ilog(vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no votes from finalizers: ${v}",
+               fc_ilog(vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no votes for block #${m_n} from finalizers: ${v}",
                     ("id", id.str().substr(8, 16))("n", block->block_num())("t", block->timestamp)("p", block->producer)
-                    ("l", (now - block->timestamp).count() / 1000)("v", not_voted));
+                    ("l", (now - block->timestamp).count() / 1000)("v", not_voted)("m_n", missed_block_num));
             }
          }
       }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -629,15 +629,16 @@ public:
    }
 
    void log_missing_votes(const signed_block_ptr& block, const block_id_type& id,
-                          const qc_vote_metrics_t::fin_auth_set_t& missing_votes) {
+                          const qc_vote_metrics_t::fin_auth_set_t& missing_votes,
+                          uint32_t missed_block_num) {
       if (vote_logger.is_enabled(fc::log_level::info)) {
          auto now = fc::time_point::now();
          if (now - block->timestamp < fc::minutes(5) || (block->block_num() % 1000 == 0)) {
             std::string not_voted;
             for (const auto& f : missing_votes) {
                if (_finalizers.contains(f.fin_auth->public_key)) {
-                  fc_wlog(vote_logger, "Local finalizer ${f} did not vote on block ${n} : ${id}",
-                          ("f", f.fin_auth->description)("n", block->block_num())("id", id.str().substr(8,16)));
+                  fc_wlog(vote_logger, "Local finalizer ${f} did not vote on block ${n} : ${id} for block ${m_n}",
+                          ("f", f.fin_auth->description)("n", block->block_num())("id", id.str().substr(8,16))("m_n", missed_block_num));
                }
                not_voted += f.fin_auth->description;
                not_voted += ',';
@@ -678,11 +679,11 @@ public:
             const auto& qc_ext = block->extract_extension<quorum_certificate_extension>();
             if (_update_vote_block_metrics) {
                qc_vote_metrics_t vm = chain.vote_metrics(id, qc_ext.qc);
-               log_missing_votes(block, id, vm.missing_votes);
+               log_missing_votes(block, id, vm.missing_votes, qc_ext.qc.block_num);
                update_vote_block_metrics(block->block_num(), vm);
             } else {
                auto missing = chain.missing_votes(id, qc_ext.qc);
-               log_missing_votes(block, id, missing);
+               log_missing_votes(block, id, missing, qc_ext.qc.block_num);
             }
          } else if (block->is_proper_svnn_block()) {
             fc_ilog(vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no votes",

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -635,11 +635,11 @@ public:
          if (now - block->timestamp < fc::minutes(5) || (block->block_num() % 1000 == 0)) {
             std::string not_voted;
             for (const auto& f : missing_votes) {
-               if (_finalizers.contains(f->public_key)) {
+               if (_finalizers.contains(f.fin_auth->public_key)) {
                   fc_wlog(vote_logger, "Local finalizer ${f} did not vote on block ${n} : ${id}",
-                          ("f", f->description)("n", block->block_num())("id", id.str().substr(8,16)));
+                          ("f", f.fin_auth->description)("n", block->block_num())("id", id.str().substr(8,16)));
                }
-               not_voted += f->description;
+               not_voted += f.fin_auth->description;
                not_voted += ',';
             }
             if (!not_voted.empty()) {
@@ -659,9 +659,9 @@ public:
       m.weak_votes.resize(vm.weak_votes.size());
       m.no_votes.resize(vm.missing_votes.size());
 
-      std::ranges::transform(vm.strong_votes, m.strong_votes.begin(), [](const auto& f) { return f->description; });
-      std::ranges::transform(vm.weak_votes, m.weak_votes.begin(), [](const auto& f) { return f->description; });
-      std::ranges::transform(vm.missing_votes, m.no_votes.begin(), [](const auto& f) { return f->description; });
+      std::ranges::transform(vm.strong_votes, m.strong_votes.begin(), [](const auto& f) { return f.fin_auth->description; });
+      std::ranges::transform(vm.weak_votes, m.weak_votes.begin(), [](const auto& f) { return f.fin_auth->description; });
+      std::ranges::transform(vm.missing_votes, m.no_votes.begin(), [](const auto& f) { return f.fin_auth->description; });
       _update_vote_block_metrics(std::move(m));
    }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -371,15 +371,15 @@ set_tests_properties(http_plugin_test PROPERTIES TIMEOUT 100)
 set_property(TEST http_plugin_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_api_test COMMAND tests/plugin_http_api_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_tests_properties(plugin_http_api_test PROPERTIES TIMEOUT 120)
+set_tests_properties(plugin_http_api_test PROPERTIES TIMEOUT 50)
 set_property(TEST plugin_http_api_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_api_test_savanna COMMAND tests/plugin_http_api_test_savanna.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_tests_properties(plugin_http_api_test_savanna PROPERTIES TIMEOUT 300)
+set_tests_properties(plugin_http_api_test_savanna PROPERTIES TIMEOUT 240)
 set_property(TEST plugin_http_api_test_savanna PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_category_api_test COMMAND tests/plugin_http_api_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_tests_properties(plugin_http_category_api_test PROPERTIES TIMEOUT 120 ENVIRONMENT "PLUGIN_HTTP_TEST_CATEGORY=ON")
+set_tests_properties(plugin_http_category_api_test PROPERTIES TIMEOUT 50 ENVIRONMENT "PLUGIN_HTTP_TEST_CATEGORY=ON")
 set_property(TEST plugin_http_category_api_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME trace_plugin_test COMMAND tests/trace_plugin_test.py -v WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/disaster_recovery_3.py ${CMAKE_CURREN
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_test.py ${CMAKE_CURRENT_BINARY_DIR}/trx_finality_status_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_forked_test.py ${CMAKE_CURRENT_BINARY_DIR}/trx_finality_status_forked_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plugin_http_api_test.py ${CMAKE_CURRENT_BINARY_DIR}/plugin_http_api_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plugin_http_api_test_savanna.py ${CMAKE_CURRENT_BINARY_DIR}/plugin_http_api_test_savanna.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_contrl_c_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_contrl_c_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/read_only_trx_test.py ${CMAKE_CURRENT_BINARY_DIR}/read_only_trx_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resource_monitor_plugin_test.py ${CMAKE_CURRENT_BINARY_DIR}/resource_monitor_plugin_test.py COPYONLY)
@@ -372,6 +373,10 @@ set_property(TEST http_plugin_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME plugin_http_api_test COMMAND tests/plugin_http_api_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(plugin_http_api_test PROPERTIES TIMEOUT 50)
 set_property(TEST plugin_http_api_test PROPERTY LABELS nonparallelizable_tests)
+
+add_test(NAME plugin_http_api_test_savanna COMMAND tests/plugin_http_api_test_savanna.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_tests_properties(plugin_http_api_test_savanna PROPERTIES TIMEOUT 50)
+set_property(TEST plugin_http_api_test_savanna PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_category_api_test COMMAND tests/plugin_http_api_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(plugin_http_category_api_test PROPERTIES TIMEOUT 50 ENVIRONMENT "PLUGIN_HTTP_TEST_CATEGORY=ON")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -371,15 +371,15 @@ set_tests_properties(http_plugin_test PROPERTIES TIMEOUT 100)
 set_property(TEST http_plugin_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_api_test COMMAND tests/plugin_http_api_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_tests_properties(plugin_http_api_test PROPERTIES TIMEOUT 50)
+set_tests_properties(plugin_http_api_test PROPERTIES TIMEOUT 120)
 set_property(TEST plugin_http_api_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_api_test_savanna COMMAND tests/plugin_http_api_test_savanna.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_tests_properties(plugin_http_api_test_savanna PROPERTIES TIMEOUT 240)
+set_tests_properties(plugin_http_api_test_savanna PROPERTIES TIMEOUT 300)
 set_property(TEST plugin_http_api_test_savanna PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_category_api_test COMMAND tests/plugin_http_api_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_tests_properties(plugin_http_category_api_test PROPERTIES TIMEOUT 50 ENVIRONMENT "PLUGIN_HTTP_TEST_CATEGORY=ON")
+set_tests_properties(plugin_http_category_api_test PROPERTIES TIMEOUT 120 ENVIRONMENT "PLUGIN_HTTP_TEST_CATEGORY=ON")
 set_property(TEST plugin_http_category_api_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME trace_plugin_test COMMAND tests/trace_plugin_test.py -v WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -375,7 +375,7 @@ set_tests_properties(plugin_http_api_test PROPERTIES TIMEOUT 50)
 set_property(TEST plugin_http_api_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_api_test_savanna COMMAND tests/plugin_http_api_test_savanna.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-set_tests_properties(plugin_http_api_test_savanna PROPERTIES TIMEOUT 50)
+set_tests_properties(plugin_http_api_test_savanna PROPERTIES TIMEOUT 240)
 set_property(TEST plugin_http_api_test_savanna PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME plugin_http_category_api_test COMMAND tests/plugin_http_api_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
    chain_apis::read_only::get_raw_block_params param{headnumstr};
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
 
    // block should be decoded successfully
    auto block = plugin.get_raw_block(param, fc::time_point::maximum());
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
    tester t{setup_policy::old_wasm_parser};
    t.produce_block();
 
-   chain_apis::read_only plugin(*(t.control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
+   chain_apis::read_only plugin(*(t.control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
 
    auto parms = plugin.get_consensus_parameters({}, fc::time_point::maximum());
 
@@ -190,7 +190,7 @@ BOOST_FIXTURE_TEST_CASE( get_account, validating_tester ) try {
 
    produce_block();
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
+   chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
 
    chain_apis::read_only::get_account_params p{"alice"_n};
 

--- a/tests/get_producers_tests.cpp
+++ b/tests/get_producers_tests.cpp
@@ -16,7 +16,7 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, T, testers ) { try {
       T chain;
 
-      eosio::chain_apis::read_only plugin(*(chain.control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
       eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
       auto results = plugin.get_producers(params, fc::time_point::maximum());
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers_from_table, T, eosio_system::eosio_
       // ensure that enough voting is occurring so that producer1111 is elected as the producer
       chain.cross_15_percent_threshold();
 
-      eosio::chain_apis::read_only plugin(*(chain.control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
       eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
       auto results = plugin.get_producers(params, fc::time_point::maximum());

--- a/tests/get_table_seckey_tests.cpp
+++ b/tests/get_table_seckey_tests.cpp
@@ -43,7 +43,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    set_abi( "test"_n, test_contracts::get_table_seckey_test_abi() );
    produce_block();
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params = []{
       chain_apis::read_only::get_table_rows_params params{};
       params.json=true;

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -90,7 +90,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
    produce_block();
 
    // iterate over scope
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_by_scope_params param{"eosio.token"_n, "accounts"_n, "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param, fc::time_point::maximum());
 
@@ -195,7 +195,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    produce_block();
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio.token"_n;
    p.scope = "inita";
@@ -365,7 +365,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
    produce_block();
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio"_n;
    p.scope = "eosio";
@@ -517,7 +517,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    // }
 
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params = []{
       chain_apis::read_only::get_table_rows_params params{};
       params.json=true;

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -572,6 +572,22 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
         self.assertEqual(ret_json["code"], 400)
 
+        # Make sure calling get_finalizer_info in Legacy does not do any harm and
+        # returns empty JSON.
+        # Tests in Savanna are in plugin_http_api_test_savanna.py.
+        #
+        # get_finalizer_info with empty parameter
+        command = "get_finalizer_info"
+        ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
+        self.assertEqual(type(ret_json["payload"]["active_finalizer_policy"]), None)
+        # get_finalizer_info with empty content parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
+        self.assertEqual(type(ret_json["payload"]["active_finalizer_policy"]), None)
+        # get_finalizer_info with invalid parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
         # get_producers with empty parameter
         command = "get_producers"
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -579,10 +579,10 @@ class PluginHttpTest(unittest.TestCase):
         # get_finalizer_info with empty parameter
         command = "get_finalizer_info"
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
-        self.assertEqual(type(ret_json["payload"]["active_finalizer_policy"]), None)
+        self.assertEqual(ret_json["payload"]["active_finalizer_policy"], None)
         # get_finalizer_info with empty content parameter
         ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
-        self.assertEqual(type(ret_json["payload"]["active_finalizer_policy"]), None)
+        self.assertEqual(ret_json["payload"]["active_finalizer_policy"], None)
         # get_finalizer_info with invalid parameter
         ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
         self.assertEqual(ret_json["code"], 400)

--- a/tests/plugin_http_api_test_savanna.py
+++ b/tests/plugin_http_api_test_savanna.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 import json
-import os
-import re
-import shutil
 import signal
 
 from TestHarness import Cluster, TestHelper, Utils, WalletMgr
@@ -11,11 +8,11 @@ from TestHarness import Cluster, TestHelper, Utils, WalletMgr
 ###############################################################
 # plugin_http_api_test_savanna.py
 # 
-# Savanna specific HTTP RPC endpoints are placed in this file.
+# Tests of Savanna specific HTTP RPC endpoints are placed in this file.
 #
-# plugin_http_api_test.py does not use test Cluster and need to
-# test protocol feature activation, it is not suitable for tests
-# involving Savanna.
+# Note: plugin_http_api_test.py does not use test Cluster and need to
+#       test protocol feature activation, it is not suitable for tests
+#       involving Savanna.
 ###############################################################
 
 Print=Utils.Print
@@ -27,6 +24,7 @@ cluster=Cluster(unshared=args.unshared, keepRunning=args.leave_running, keepLogs
 dumpErrorDetails=args.dump_error_details
 walletPort=TestHelper.DEFAULT_WALLET_PORT
 
+# Setup 4 nodes such that to verify multiple finalizers in get_finalizer_info test
 totalProducerNodes=3
 totalNonProducerNodes=1
 totalNodes=totalProducerNodes+totalNonProducerNodes

--- a/tests/plugin_http_api_test_savanna.py
+++ b/tests/plugin_http_api_test_savanna.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import shutil
+import signal
+
+from TestHarness import Cluster, TestHelper, Utils, WalletMgr
+
+###############################################################
+# plugin_http_api_test_savanna.py
+# 
+# Savanna specific HTTP RPC endpoints are placed in this file.
+#
+# plugin_http_api_test.py does not use test Cluster and need to
+# test protocol feature activation, it is not suitable for tests
+# involving Savanna.
+###############################################################
+
+Print=Utils.Print
+
+args = TestHelper.parse_args({"--dump-error-details","--keep-logs","-v","--leave-running","--unshared"})
+
+Utils.Debug=args.v
+cluster=Cluster(unshared=args.unshared, keepRunning=args.leave_running, keepLogs=args.keep_logs)
+dumpErrorDetails=args.dump_error_details
+walletPort=TestHelper.DEFAULT_WALLET_PORT
+
+totalProducerNodes=3
+totalNonProducerNodes=1
+totalNodes=totalProducerNodes+totalNonProducerNodes
+
+walletMgr=WalletMgr(True, port=walletPort)
+testSuccessful=False
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+
+    cluster.setWalletMgr(walletMgr)
+    Print("Stand up cluster")
+
+    if cluster.launch(topo="mesh", pnodes=totalProducerNodes, totalNodes=totalNodes,
+                      activateIF=True) is False:
+        Utils.cmdError("launcher")
+        Utils.errorExit("Failed to stand up cluster.")
+
+    # Verify nodes are in sync and advancing
+    cluster.waitOnClusterSync(blockAdvancing=5)
+    Print("Cluster in Sync")
+
+    Print("Shutdown unneeded bios node")
+    cluster.biosNode.kill(signal.SIGTERM)
+
+    node = cluster.nodes[0]
+    resource = "chain"
+    payload = {}
+    empty_content_dict = {}
+    http_post_invalid_param = '{invalid}'
+
+    # get_finalizer_info with empty parameter
+    command = "get_finalizer_info"
+    ret_json = node.processUrllibRequest(resource, command, payload)
+    assert type(ret_json["payload"]["active_finalizer_policy"]) == dict
+    assert type(ret_json["payload"]["last_tracked_votes"]) == list
+    # get_finalizer_info with empty content parameter
+    ret_json = node.processUrllibRequest(resource, command, empty_content_dict, payload)
+    assert type(ret_json["payload"]["active_finalizer_policy"]) == dict
+    assert type(ret_json["payload"]["last_tracked_votes"]) == list
+    # get_finalizer_info with invalid parameter
+    ret_json = node.processUrllibRequest(resource, command, http_post_invalid_param, payload)
+    assert ret_json["code"] == 400
+    assert ret_json["error"]["code"] == 3200006
+
+    testSuccessful = True
+
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, dumpErrorDetails=dumpErrorDetails)
+
+errorCode = 0 if testSuccessful else 1
+exit(errorCode)

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -226,7 +226,7 @@ public:
     read_only::get_account_results get_account_info(const account_name acct){
        auto account_object = control->get_account(acct);
        read_only::get_account_params params = { account_object.name };
-       chain_apis::read_only plugin(*(control.get()), {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+       chain_apis::read_only plugin(*(control.get()), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
        auto res =   plugin.get_account(params, fc::time_point::maximum())();
        BOOST_REQUIRE(!std::holds_alternative<fc::exception_ptr>(res));
        return std::get<chain_apis::read_only::get_account_results>(std::move(res));


### PR DESCRIPTION
Provide a `chain_api` RPC endpoint `get_finalizer_info` that reports
* active finalizer policy,
* pending finalizer policy if different from the active finalizer policy
* last tracked vote associated with each finalizer in the active (an pending if exist) policy, including the timestamp, block ID, block number of that block it last voted on, whether that vote was strong or weak, and the generation number of the policy it voted as part of.

Resolves https://github.com/AntelopeIO/spring/issues/419

A sample output of the endpoint from a test run:

```
{
  "code": 200,
  "payload": {
    "active_finalizer_policy": {
      "generation": 1,
      "threshold": 3,
      "finalizers": [
        {
          "description": "finalizer #1",
          "weight": 1,
          "public_key": "PUB_BLS_GzRFeCxWX8vtIEW9ll-tU9lDOo8c5YK-rUJcihzyGDDT9Qr_WXnnZrh4J0vdZjwViyZTXT6x73MhQ3z849MGi1LHVXVtcLYWuFZV1aXJ21Ms7kTkCZ15RfZCObszcS8YT4DUJw"
        },
        {
          "description": "finalizer #2",
          "weight": 1,
          "public_key": "PUB_BLS_7OxmIgNcXRwhzfrpO7-qdjMTmlDIIkndWnVQBT_7SfeZy2Vhe9xG-KjcUqSniYEGfs5wth8BdPXIh2ooUxvcgFyYP2AJs8WgOrcUxSmaDeApERGbjGZAckSV5QgRCJkZ68nygQ"
        },
        {
          "description": "finalizer #3",
          "weight": 1,
          "public_key": "PUB_BLS_JUmRKdx4pWijSy5iuy3p3jvTRVqF6McpYIPUH5BF2XcUeyo8ZjJCGqfKK8rV61wXwlI_qQRTKvHKx59pihxCVq0NLD0Wd9NVE06ka_GEHx5kl-ra6kBfaor7gDv7rTcTZuCQNA"
        },
        {
          "description": "finalizer #4",
          "weight": 1,
          "public_key": "PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q"
        }
      ]
    },
    "pending_finalizer_policy": "None",
    "last_tracked_votes": [
      {
        "description": "finalizer #1",
        "public_key": "PUB_BLS_GzRFeCxWX8vtIEW9ll-tU9lDOo8c5YK-rUJcihzyGDDT9Qr_WXnnZrh4J0vdZjwViyZTXT6x73MhQ3z849MGi1LHVXVtcLYWuFZV1aXJ21Ms7kTkCZ15RfZCObszcS8YT4DUJw",
        "is_vote_strong": "True",
        "finalizer_policy_generation": 1,
        "voted_for_block_id": "000000437e6f3004e6b7bab061ff04dfae4b7b6dfabe625fca3226d77e1b7bf1",
        "voted_for_block_num": 67,
        "voted_for_block_timestamp": "2024-08-02T01:16:18.500"
      },
      {
        "description": "finalizer #2",
        "public_key": "PUB_BLS_7OxmIgNcXRwhzfrpO7-qdjMTmlDIIkndWnVQBT_7SfeZy2Vhe9xG-KjcUqSniYEGfs5wth8BdPXIh2ooUxvcgFyYP2AJs8WgOrcUxSmaDeApERGbjGZAckSV5QgRCJkZ68nygQ",
        "is_vote_strong": "True",
        "finalizer_policy_generation": 1,
        "voted_for_block_id": "000000437e6f3004e6b7bab061ff04dfae4b7b6dfabe625fca3226d77e1b7bf1",
        "voted_for_block_num": 67,
        "voted_for_block_timestamp": "2024-08-02T01:16:18.500"
      },
      {
        "description": "finalizer #3",
        "public_key": "PUB_BLS_JUmRKdx4pWijSy5iuy3p3jvTRVqF6McpYIPUH5BF2XcUeyo8ZjJCGqfKK8rV61wXwlI_qQRTKvHKx59pihxCVq0NLD0Wd9NVE06ka_GEHx5kl-ra6kBfaor7gDv7rTcTZuCQNA",
        "is_vote_strong": "True",
        "finalizer_policy_generation": 1,
        "voted_for_block_id": "000000437e6f3004e6b7bab061ff04dfae4b7b6dfabe625fca3226d77e1b7bf1",
        "voted_for_block_num": 67,
        "voted_for_block_timestamp": "2024-08-02T01:16:18.500"
      },
      {
        "description": "finalizer #4",
        "public_key": "PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q",
        "is_vote_strong": "True",
        "finalizer_policy_generation": 1,
        "voted_for_block_id": "000000437e6f3004e6b7bab061ff04dfae4b7b6dfabe625fca3226d77e1b7bf1",
        "voted_for_block_num": 67,
        "voted_for_block_timestamp": "2024-08-02T01:16:18.500"
      }
    ]
  }
}
```