### PR TITLE
progress logging during snapshot creation

### DIFF
--- a/libraries/chain/include/eosio/chain/authorization_manager.hpp
+++ b/libraries/chain/include/eosio/chain/authorization_manager.hpp
@@ -24,7 +24,8 @@ namespace eosio { namespace chain {
 
          void add_indices();
          void initialize_database();
-         void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const;
+         size_t expected_snapshot_row_count() const;
+         void add_to_snapshot( const snapshot_writer_ptr& snapshot, snapshot_written_row_counter& row_counter ) const;
          void read_from_snapshot( const snapshot_reader_ptr& snapshot, snapshot_loaded_row_counter& row_counter );
 
          const permission_object& create_permission( account_name account,

--- a/libraries/chain/include/eosio/chain/pending_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/pending_snapshot.hpp
@@ -51,7 +51,7 @@ public:
                  "Unable to finalize valid snapshot of block number ${bn}: [code: ${ec}] ${message}",
                  ("bn", get_height())("ec", ec.value())("message", ec.message()));
 
-      ilog("Snapshot created at block ${bn} available as file ${fn}", ("bn", block_ptr->block_num())("fn", fs::path(final_path).filename()));
+      ilog("Snapshot created at block ${bn} available at ${fn}", ("bn", block_ptr->block_num())("fn", final_path));
 
       return {block_id, block_ptr->block_num(), block_ptr->timestamp, chain::chain_snapshot_header::current_version, final_path};
    }

--- a/libraries/chain/include/eosio/chain/pending_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/pending_snapshot.hpp
@@ -40,6 +40,7 @@ public:
 
       if(!in_chain) {
          fs::remove(fs::path(pending_path), ec);
+         ilog("Snapshot created at block id ${id} invalidated because block was forked out", ("id", block_id));
          EOS_THROW(chain::snapshot_finalization_exception,
                    "Snapshotted block was forked out of the chain.  ID: ${block_id}",
                    ("block_id", block_id));
@@ -49,6 +50,8 @@ public:
       EOS_ASSERT(!ec, chain::snapshot_finalization_exception,
                  "Unable to finalize valid snapshot of block number ${bn}: [code: ${ec}] ${message}",
                  ("bn", get_height())("ec", ec.value())("message", ec.message()));
+
+      ilog("Snapshot created at block ${bn} available as file ${fn}", ("bn", block_ptr->block_num())("fn", fs::path(final_path).filename()));
 
       return {block_id, block_ptr->block_num(), block_ptr->timestamp, chain::chain_snapshot_header::current_version, final_path};
    }

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -71,7 +71,8 @@ namespace eosio { namespace chain {
 
          void add_indices();
          void initialize_database();
-         void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const;
+         size_t expected_snapshot_row_count() const;
+         void add_to_snapshot( const snapshot_writer_ptr& snapshot, snapshot_written_row_counter& row_counter ) const;
          void read_from_snapshot( const snapshot_reader_ptr& snapshot, snapshot_loaded_row_counter& row_counter );
 
          void initialize_account( const account_name& account, bool is_trx_transient );

--- a/libraries/chain/include/eosio/chain/snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot.hpp
@@ -423,4 +423,17 @@ namespace eosio { namespace chain {
       const size_t total = 0;
       time_t last_print = time(NULL);
    };
+
+   struct snapshot_written_row_counter {
+      snapshot_written_row_counter(const size_t total) : total(total) {}
+      void progress() {
+         if(++count % 50000 == 0 && time(NULL) - last_print >= 5) {
+            ilog("Snapshot creation ${pct}% complete", ("pct",std::min((unsigned)(((double)count/total)*100),100u)));
+            last_print = time(NULL);
+         }
+      }
+      size_t count = 0;
+      const size_t total = 0;
+      time_t last_print = time(NULL);
+   };
 }}

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -71,11 +71,20 @@ void resource_limits_manager::initialize_database() {
    }
 }
 
-void resource_limits_manager::add_to_snapshot( const snapshot_writer_ptr& snapshot ) const {
-   resource_index_set::walk_indices([this, &snapshot]( auto utils ){
-      snapshot->write_section<typename decltype(utils)::index_t::value_type>([this]( auto& section ){
-         decltype(utils)::walk(_db, [this, &section]( const auto &row ) {
+size_t resource_limits_manager::expected_snapshot_row_count() const {
+   size_t ret = 0;
+   resource_index_set::walk_indices([this, &ret]( auto utils ) {
+      ret += _db.get_index<typename decltype(utils)::index_t>().size();
+   });
+   return ret;
+}
+
+void resource_limits_manager::add_to_snapshot( const snapshot_writer_ptr& snapshot, snapshot_written_row_counter& row_counter ) const {
+   resource_index_set::walk_indices([this, &snapshot, &row_counter]( auto utils ){
+      snapshot->write_section<typename decltype(utils)::index_t::value_type>([this, &row_counter]( auto& section ){
+         decltype(utils)::walk(_db, [this, &section, &row_counter]( const auto &row ) {
             section.add_row(row, _db);
+            row_counter.progress();
          });
       });
    });

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -192,7 +192,7 @@ void snapshot_scheduler::create_snapshot(next_function<snapshot_information> nex
                     "Unable to finalize valid snapshot of block number ${bn}: [code: ${ec}] ${message}",
                     ("bn", head_block_num)("ec", ec.value())("message", ec.message()));
 
-         ilog("Snapshot creation at block ${bn} complete; snapshot named ${fn}", ("bn", head_block_num)("fn", snapshot_path.filename()));
+         ilog("Snapshot creation at block ${bn} complete; snapshot placed at ${fn}", ("bn", head_block_num)("fn", snapshot_path));
          next(snapshot_information{head_id, head_block_num, head_block_time, chain_snapshot_header::current_version, snapshot_path.generic_string()});
       }
       CATCH_AND_CALL(next);


### PR DESCRIPTION
Add status and progress logs during snapshot creation; can look something like
```
info  2024-08-01T16:18:01.831 nodeos    controller.cpp:3525           log_applied          ] Received block 84115323a9ceb11e... #386613117 @ 2024-08-01T16:18:02.000 signed by eoscannonchn [trxs: 20, lib: 386612788, net: 3016, cpu: 16896, elapsed: 2885, time: 6155, latency: -168 ms]
info  2024-08-01T16:18:01.976 nodeos    snapshot_scheduler.cpp:219    create_snapshot      ] Starting snapshot creation at block 386613117
info  2024-08-01T16:18:06.024 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 10% complete
info  2024-08-01T16:18:11.008 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 16% complete
info  2024-08-01T16:18:16.021 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 27% complete
info  2024-08-01T16:18:21.014 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 35% complete
info  2024-08-01T16:18:26.020 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 47% complete
info  2024-08-01T16:18:31.030 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 53% complete
info  2024-08-01T16:18:36.022 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 61% complete
info  2024-08-01T16:18:41.008 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 80% complete
info  2024-08-01T16:18:46.013 nodeos    snapshot.hpp:431              progress             ] Snapshot creation 87% complete
info  2024-08-01T16:18:49.210 nodeos    snapshot_scheduler.cpp:228    create_snapshot      ] Snapshot creation at block 386613117 complete; snapshot will be available once block becomes irreversible
info  2024-08-01T16:19:19.339 nodeos    controller.cpp:3525           log_applied          ] Received block dfc6827a3b3cec00... #386613118 @ 2024-08-01T16:18:02.500 signed by eoscannonchn [trxs: 15, lib: 386612788, net: 4408, cpu: 14767, elapsed: 5143, time: 12016, latency: 76839 ms]
...
info  2024-08-01T16:20:47.085 nodeos    controller.cpp:3525           log_applied          ] Received block 590e9cb5752b3afb... #386613448 @ 2024-08-01T16:20:47.500 signed by eoslaomaocom [trxs: 28, lib: 386613112, net: 6200, cpu: 15072, elapsed: 7637, time: 16368, latency: -414 ms]
info  2024-08-01T16:20:47.994 nodeos    pending_snapshot.hpp:54       finalize             ] Snapshot created at block 386613117 available at /mnt/eos.data/snapshots/snapshot-170b3f7d84115323a9ceb11efbe837517fb129bb019e1c0c2b131b7a1a041026.bin
info  2024-08-01T16:20:47.997 nodeos    controller.cpp:3525           log_applied          ] Received block 5421f3049893c12d... #386613449 @ 2024-08-01T16:20:48.000 signed by eosnationftw [trxs: 35, lib: 386613124, net: 8224, cpu: 9747, elapsed: 5038, time: 10782, latency: -2 ms]
```

Resolves AntelopeIO/leap#1166