### PR TITLE
Update API docs for new get_finalizers_info_rpc

### DIFF
--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -174,14 +174,14 @@ paths:
                     items:
                       type: object
                       properties:
-                        public_key:
-                          type: string
-                          description: BLS Public Key for finalizer
-                          example: "PUB_BLS_PcJG7lYgwZcsFGe-i4WWYDw1GtP7r5vGWFcRe97TVcp5f5_h6RRRPRhZSGKtRF4CtdJxAP50VewH4VIhMIPfhsu9C4GGH4MgOzSwl51N3EK6XiAiRHQ_lcGvxggipYwIReHkhQ"
                         description:
                           type: string
                           description: Description of finalizer
                           example: finalizerone
+                        public_key:
+                          type: string
+                          description: BLS Public Key for finalizer
+                          example: "PUB_BLS_PcJG7lYgwZcsFGe-i4WWYDw1GtP7r5vGWFcRe97TVcp5f5_h6RRRPRhZSGKtRF4CtdJxAP50VewH4VIhMIPfhsu9C4GGH4MgOzSwl51N3EK6XiAiRHQ_lcGvxggipYwIReHkhQ"
                         is_vote_strong:
                           type: boolean
                           description: When true indicate strongly voted

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -93,65 +93,65 @@ paths:
     post:
       description: Returns information about finalizers
       operationId: get_finalizer_info_result
-        responses:
-          "200":
-            description: OK
-            content:
-              application/json:
-                schema:
-                  active_finalizer_policy:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                active_finalizer_policy:
+                  type: object
+                  description: List of current finalizers
+                    generation:
+                      type: integer
+                      description: version number of finalizers set
+                    threshold:
+                      type: integer
+                      description: total weight needed to advance finality
+                    finalizers:
+                      type: array
+                      items:
+                        ref: "#/components/schemas/Finalizer"
+                pending_finalizer_policy:
+                  type: object
+                  description: List of pending finalizers
+                    generation:
+                      type: integer
+                      description: version number of finalizers set
+                    threshold:
+                      type: integer
+                      description: total weight needed to advance finality
+                    finalizers:
+                      type: array
+                      items:
+                        ref: "#/components/schemas/Finalizer"
+                last_tracked_votes:
+                  type: array
+                  description: Record of last votes for top 21 finalizers
+                  items:
                     type: object
-                    description: List of current finalizers
-                      generation:
+                    properties:
+                      public_key:
+                        type: string
+                        description: BLS Public Key for finalizer
+                      description:
+                        type: string
+                        description: Description of finalizer
+                      is_vote_strong:
+                        type: boolean
+                        description: When true indicate strongly voted
+                      voted_policy_generation:
                         type: integer
-                        description: version number of finalizers set
-                      threshold:
+                        description: Policy Generation for vote
+                      voted_block_id:
+                        type: string
+                        description: Block id voted on
+                      voted_block_num:
                         type: integer
-                        description: total weight needed to advance finality
-                      finalizers:
-                        type: array
-                        items:
-                          ref: "#/components/schemas/Finalizer"
-                  pending_finalizer_policy:
-                    type: object
-                    description: List of pending finalizers
-                      generation:
-                        type: integer
-                        description: version number of finalizers set
-                      threshold:
-                        type: integer
-                        description: total weight needed to advance finality
-                      finalizers:
-                        type: array
-                        items:
-                          ref: "#/components/schemas/Finalizer"
-                  last_tracked_votes:
-                    type: array
-                    description: Record of last votes for top 21 finalizers
-                    items:
-                      type: object
-                      properties:
-                        public_key:
-                          type: string
-                          description: BLS Public Key for finalizer
-                        description:
-                          type: string
-                          description: Description of finalizer
-                        is_vote_strong:
-                          type: boolean
-                          description: When true indicate strongly voted
-                        voted_policy_generation:
-                          type: integer
-                          description: Policy Generation for vote
-                        voted_block_id:
-                          type: string
-                          description: Block id voted on
-                        voted_block_num:
-                          type: integer
-                          description: Block number voted on
-                        voted_block_timestamp:
-                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml"
-                          description: Timestamp for the voted on block
+                        description: Block number voted on
+                      voted_block_timestamp:
+                        $ref: "https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml"
+                        description: Timestamp for the voted on block
           "400":
             description: client error
             content:

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -102,6 +102,7 @@ paths:
                 active_finalizer_policy:
                   type: object
                   description: List of current finalizers
+                  properties:
                     generation:
                       type: integer
                       description: version number of finalizers set
@@ -115,6 +116,7 @@ paths:
                 pending_finalizer_policy:
                   type: object
                   description: List of pending finalizers
+                  properties:
                     generation:
                       type: integer
                       description: version number of finalizers set

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -1054,7 +1054,7 @@ components:
     Finalizer:
       type: object
       description: Description of a finalizer
-        description:
+        'description':
           type: string
           description: Name of finalizer, typicaly a producer acount
           example: finalizerone

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -1054,6 +1054,7 @@ components:
     Finalizer:
       type: object
       description: Description of a finalizer
+      properties:
         'description':
           type: string
           description: Name of finalizer, typicaly a producer acount

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -170,7 +170,7 @@ paths:
                               example: "PUB_BLS_PcJG7lYgwZcsFGe-i4WWYDw1GtP7r5vGWFcRe97TVcp5f5_h6RRRPRhZSGKtRF4CtdJxAP50VewH4VIhMIPfhsu9C4GGH4MgOzSwl51N3EK6XiAiRHQ_lcGvxggipYwIReHkhQ"
                   last_tracked_votes:
                     type: array
-                    description: Record of last votes for top 21 finalizers
+                    description: Record of last votes for the finalizers in current active finalizer policy and pending finalizer policy.
                     items:
                       type: object
                       properties:

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -114,7 +114,7 @@ paths:
                           ref: "#/components/schemas/Finalizer"
                   pending_finalizer_policy:
                     type: object
-                    description: List of current finalizers
+                    description: List of pending finalizers
                       generation:
                         type: integer
                         description: version number of finalizers set

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -100,15 +100,31 @@ paths:
               application/json:
                 schema:
                   active_finalizer_policy:
-                    type: array
-                    description: Variant type, an array of strings with the current finalizers
-                    items:
-                      type: string
+                    type: object
+                    description: List of current finalizers
+                      generation:
+                        type: integer
+                        description: version number of finalizers set
+                      threshold:
+                        type: integer
+                        description: total weight needed to advance finality
+                      finalizers:
+                        type: array
+                        items:
+                          ref: "#/components/schemas/Finalizer"
                   pending_finalizer_policy:
-                    type: array
-                    description: Variant type, an array of strings with the pending finalizers
-                    items:
-                      type: string
+                    type: object
+                    description: List of current finalizers
+                      generation:
+                        type: integer
+                        description: version number of finalizers set
+                      threshold:
+                        type: integer
+                        description: total weight needed to advance finality
+                      finalizers:
+                        type: array
+                        items:
+                          ref: "#/components/schemas/Finalizer"
                   last_tracked_votes:
                     type: array
                     description: Record of last votes for top 21 finalizers
@@ -1033,3 +1049,18 @@ components:
                     type: string
                     description: function executed when error occurred
                     example: parse_params
+    Finalizer:
+      type: object
+      description: Description of a finalizer
+        description:
+          type: string
+          description: Name of finalizer, typicaly a producer acount
+          example: finalizerone
+        weight:
+          type: integer
+          description: The weight of this finalizer used in determine when threshold of votes is reached
+          example: 1
+        public_key:
+          type: string
+          description: The BLS Public Key used by this finalizer
+          example: "PUB_BLS_PcJG7lYgwZcsFGe-i4WWYDw1GtP7r5vGWFcRe97TVcp5f5_h6RRRPRhZSGKtRF4CtdJxAP50VewH4VIhMIPfhsu9C4GGH4MgOzSwl51N3EK6XiAiRHQ_lcGvxggipYwIReHkhQ"

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -115,9 +115,11 @@ paths:
                       generation:
                         type: integer
                         description: version number of finalizers set
+                        example: 1
                       threshold:
                         type: integer
                         description: total weight needed to advance finality
+                        example: 15
                       finalizers:
                         type: array
                         items:
@@ -129,9 +131,11 @@ paths:
                       generation:
                         type: integer
                         description: version number of finalizers set
+                        example: 2
                       threshold:
                         type: integer
                         description: total weight needed to advance finality
+                        example: 15
                       finalizers:
                         type: array
                         items:
@@ -145,31 +149,36 @@ paths:
                         public_key:
                           type: string
                           description: BLS Public Key for finalizer
+                          example: "PUB_BLS_PcJG7lYgwZcsFGe-i4WWYDw1GtP7r5vGWFcRe97TVcp5f5_h6RRRPRhZSGKtRF4CtdJxAP50VewH4VIhMIPfhsu9C4GGH4MgOzSwl51N3EK6XiAiRHQ_lcGvxggipYwIReHkhQ"
                         description:
                           type: string
                           description: Description of finalizer
+                          example: finalizerone
                         is_vote_strong:
                           type: boolean
                           description: When true indicate strongly voted
                         voted_policy_generation:
                           type: integer
                           description: Policy Generation for vote
+                          example: 2
                         voted_block_id:
                           type: string
                           description: Block id voted on
+                          example: 1234
                         voted_block_num:
                           type: integer
                           description: Block number voted on
+                          example: "00003702056551dbabfab8ed499fb7d74850e92b9ac74d13b64ff2b161341c7a"
                         voted_block_timestamp:
                           $ref: "https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml"
                           description: Timestamp for the voted on block
 
-          "400":
-            description: client error
-            content:
-              application/json:
+        "400":
+          description: client error
+          content:
+            application/json:
               schema:
-              $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/Error"
   /get_info:
     post:
       description: Returns an object containing various details about the blockchain.
@@ -1009,9 +1018,6 @@ paths:
             application/json:
               schema:
                 description: Returns Nothing
-components:
-  securitySchemes: {}
-  schemas:
     Error:
       type: object
       properties:

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -93,67 +93,77 @@ paths:
     post:
       description: Returns information about finalizers
       operationId: get_finalizer_info_result
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              nullable: true
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                active_finalizer_policy:
-                  type: object
-                  description: List of current finalizers
-                  properties:
-                    generation:
-                      type: integer
-                      description: version number of finalizers set
-                    threshold:
-                      type: integer
-                      description: total weight needed to advance finality
-                    finalizers:
-                      type: array
-                      items:
-                        ref: "#/components/schemas/Finalizer"
-                pending_finalizer_policy:
-                  type: object
-                  description: List of pending finalizers
-                  properties:
-                    generation:
-                      type: integer
-                      description: version number of finalizers set
-                    threshold:
-                      type: integer
-                      description: total weight needed to advance finality
-                    finalizers:
-                      type: array
-                      items:
-                        ref: "#/components/schemas/Finalizer"
-                last_tracked_votes:
-                  type: array
-                  description: Record of last votes for top 21 finalizers
-                  items:
+                type: object
+                properties:
+                  active_finalizer_policy:
                     type: object
+                    description: List of current finalizers
                     properties:
-                      public_key:
-                        type: string
-                        description: BLS Public Key for finalizer
-                      description:
-                        type: string
-                        description: Description of finalizer
-                      is_vote_strong:
-                        type: boolean
-                        description: When true indicate strongly voted
-                      voted_policy_generation:
+                      generation:
                         type: integer
-                        description: Policy Generation for vote
-                      voted_block_id:
-                        type: string
-                        description: Block id voted on
-                      voted_block_num:
+                        description: version number of finalizers set
+                      threshold:
                         type: integer
-                        description: Block number voted on
-                      voted_block_timestamp:
-                        $ref: "https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml"
-                        description: Timestamp for the voted on block
+                        description: total weight needed to advance finality
+                      finalizers:
+                        type: array
+                        items:
+                          ref: "#/components/schemas/Finalizer"
+                  pending_finalizer_policy:
+                    type: object
+                    description: List of pending finalizers
+                    properties:
+                      generation:
+                        type: integer
+                        description: version number of finalizers set
+                      threshold:
+                        type: integer
+                        description: total weight needed to advance finality
+                      finalizers:
+                        type: array
+                        items:
+                          ref: "#/components/schemas/Finalizer"
+                  last_tracked_votes:
+                    type: array
+                    description: Record of last votes for top 21 finalizers
+                    items:
+                      type: object
+                      properties:
+                        public_key:
+                          type: string
+                          description: BLS Public Key for finalizer
+                        description:
+                          type: string
+                          description: Description of finalizer
+                        is_vote_strong:
+                          type: boolean
+                          description: When true indicate strongly voted
+                        voted_policy_generation:
+                          type: integer
+                          description: Policy Generation for vote
+                        voted_block_id:
+                          type: string
+                          description: Block id voted on
+                        voted_block_num:
+                          type: integer
+                          description: Block number voted on
+                        voted_block_timestamp:
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml"
+                          description: Timestamp for the voted on block
+
           "400":
             description: client error
             content:

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -89,6 +89,59 @@ paths:
             application/json:
               schema:
                 $ref: "https://eosio.github.io/schemata/v2.1/oas/BlockInfo.yaml"
+  /get_finalizer_info_result:
+    post:
+      description: Returns information about finalizers
+      operationId: get_finalizer_info_result
+        responses:
+          "200":
+            description: OK
+            content:
+              application/json:
+                schema:
+                  active_finalizer_policy:
+                    type: array
+                    description: Variant type, an array of strings with the current finalizers
+                    items:
+                      type: string
+                  pending_finalizer_policy:
+                    type: array
+                    description: Variant type, an array of strings with the pending finalizers
+                    items:
+                      type: string
+                  last_tracked_votes:
+                    type: array
+                    description: Record of last votes for top 21 finalizers
+                    items:
+                      type: object
+                      properties:
+                        public_key:
+                          type: string
+                          description: BLS Public Key for finalizer
+                        description:
+                          type: string
+                          description: Description of finalizer
+                        is_vote_strong:
+                          type: boolean
+                          description: When true indicate strongly voted
+                        voted_policy_generation:
+                          type: integer
+                          description: Policy Generation for vote
+                        voted_block_id:
+                          type: string
+                          description: Block id voted on
+                        voted_block_num:
+                          type: integer
+                          description: Block number voted on
+                        voted_block_timestamp:
+                          $ref: "https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml"
+                          description: Timestamp for the voted on block
+          "400":
+            description: client error
+            content:
+              application/json:
+              schema:
+              $ref: "#/components/schemas/Error"
   /get_info:
     post:
       description: Returns an object containing various details about the blockchain.
@@ -351,7 +404,7 @@ paths:
                     nullable: true
                     items:
                       $ref: "https://docs.eosnetwork.com/openapi/v2.0/Producer.yaml"
-                  total_producer_vote_weight: 
+                  total_producer_vote_weight:
                     type: string
                     description: The sum of all producer votes.
                   more:
@@ -727,7 +780,7 @@ paths:
               properties:
                 id:
                   type: string
-                  description: The transaction ID of the transaction to retrieve the status for. 
+                  description: The transaction ID of the transaction to retrieve the status for.
       responses:
         "200":
           description: OK
@@ -874,7 +927,7 @@ paths:
                 properties:
                   active:
                     description: A JSON object that encapsulates the list of active producers schedule and its version.
-                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/ProducerSchedule.yaml"                              
+                    $ref: "https://docs.eosnetwork.com/openapi/v2.0/ProducerSchedule.yaml"
                   pending:
                     description: A JSON object that encapsulates the list of pending producers schedule and its version.
                     $ref: "https://docs.eosnetwork.com/openapi/v2.0/ProducerSchedule.yaml"
@@ -928,3 +981,55 @@ paths:
             application/json:
               schema:
                 description: Returns Nothing
+components:
+  securitySchemes: {}
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: http return code
+          example: 400
+        message:
+          type: string
+          description: summary of error
+          example: Invalid Request
+        error:
+          type: object
+          description: details on the error
+          properties:
+            code:
+              type: integer
+              description: internal error code
+              example: 3200006
+            name:
+              type: string
+              description: name of error
+              example: invalid_http_request
+            what:
+              type: string
+              description: prettier version of error name
+              example: invalid http request
+            details:
+              type: array
+              description: list of additional information for debugging
+              items:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: debugging message
+                    example: Unable to parse valid input from POST body
+                  file:
+                    type: string
+                    description: file where error was thrown
+                    example: http_plugin.hpp
+                  line_number:
+                    type: integer
+                    description: line number in file where error was thrown
+                    example: 246
+                  method:
+                    type: string
+                    description: function executed when error occurred
+                    example: parse_params

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -123,7 +123,21 @@ paths:
                       finalizers:
                         type: array
                         items:
-                          ref: "#/components/schemas/Finalizer"
+                          type: object
+                          description: Description of a finalizer
+                          properties:
+                            'description':
+                              type: string
+                              description: Name of finalizer, typicaly a producer acount
+                              example: finalizerone
+                            weight:
+                              type: integer
+                              description: The weight of this finalizer used in determine when threshold of votes is reached
+                              example: 1
+                            public_key:
+                              type: string
+                              description: The BLS Public Key used by this finalizer
+                              example: "PUB_BLS_PcJG7lYgwZcsFGe-i4WWYDw1GtP7r5vGWFcRe97TVcp5f5_h6RRRPRhZSGKtRF4CtdJxAP50VewH4VIhMIPfhsu9C4GGH4MgOzSwl51N3EK6XiAiRHQ_lcGvxggipYwIReHkhQ"
                   pending_finalizer_policy:
                     type: object
                     description: List of pending finalizers
@@ -139,7 +153,21 @@ paths:
                       finalizers:
                         type: array
                         items:
-                          ref: "#/components/schemas/Finalizer"
+                          type: object
+                          description: Description of a finalizer
+                          properties:
+                            'description':
+                              type: string
+                              description: Name of finalizer, typicaly a producer acount
+                              example: finalizerone
+                            weight:
+                              type: integer
+                              description: The weight of this finalizer used in determine when threshold of votes is reached
+                              example: 1
+                            public_key:
+                              type: string
+                              description: The BLS Public Key used by this finalizer
+                              example: "PUB_BLS_PcJG7lYgwZcsFGe-i4WWYDw1GtP7r5vGWFcRe97TVcp5f5_h6RRRPRhZSGKtRF4CtdJxAP50VewH4VIhMIPfhsu9C4GGH4MgOzSwl51N3EK6XiAiRHQ_lcGvxggipYwIReHkhQ"
                   last_tracked_votes:
                     type: array
                     description: Record of last votes for top 21 finalizers
@@ -178,7 +206,54 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    description: http return code
+                    example: 400
+                  message:
+                    type: string
+                    description: summary of error
+                    example: Invalid Request
+                  error:
+                    type: object
+                    description: details on the error
+                    properties:
+                      code:
+                        type: integer
+                        description: internal error code
+                        example: 3200006
+                      name:
+                        type: string
+                        description: name of error
+                        example: invalid_http_request
+                      what:
+                        type: string
+                        description: prettier version of error name
+                        example: invalid http request
+                      details:
+                        type: array
+                        description: list of additional information for debugging
+                        items:
+                          type: object
+                          properties:
+                            message:
+                              type: string
+                              description: debugging message
+                              example: Unable to parse valid input from POST body
+                            file:
+                              type: string
+                              description: file where error was thrown
+                              example: http_plugin.hpp
+                            line_number:
+                              type: integer
+                              description: line number in file where error was thrown
+                              example: 246
+                            method:
+                              type: string
+                              description: function executed when error occurred
+                              example: parse_params
   /get_info:
     post:
       description: Returns an object containing various details about the blockchain.
@@ -1018,68 +1093,3 @@ paths:
             application/json:
               schema:
                 description: Returns Nothing
-    Error:
-      type: object
-      properties:
-        code:
-          type: integer
-          description: http return code
-          example: 400
-        message:
-          type: string
-          description: summary of error
-          example: Invalid Request
-        error:
-          type: object
-          description: details on the error
-          properties:
-            code:
-              type: integer
-              description: internal error code
-              example: 3200006
-            name:
-              type: string
-              description: name of error
-              example: invalid_http_request
-            what:
-              type: string
-              description: prettier version of error name
-              example: invalid http request
-            details:
-              type: array
-              description: list of additional information for debugging
-              items:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: debugging message
-                    example: Unable to parse valid input from POST body
-                  file:
-                    type: string
-                    description: file where error was thrown
-                    example: http_plugin.hpp
-                  line_number:
-                    type: integer
-                    description: line number in file where error was thrown
-                    example: 246
-                  method:
-                    type: string
-                    description: function executed when error occurred
-                    example: parse_params
-    Finalizer:
-      type: object
-      description: Description of a finalizer
-      properties:
-        'description':
-          type: string
-          description: Name of finalizer, typicaly a producer acount
-          example: finalizerone
-        weight:
-          type: integer
-          description: The weight of this finalizer used in determine when threshold of votes is reached
-          example: 1
-        public_key:
-          type: string
-          description: The BLS Public Key used by this finalizer
-          example: "PUB_BLS_PcJG7lYgwZcsFGe-i4WWYDw1GtP7r5vGWFcRe97TVcp5f5_h6RRRPRhZSGKtRF4CtdJxAP50VewH4VIhMIPfhsu9C4GGH4MgOzSwl51N3EK6XiAiRHQ_lcGvxggipYwIReHkhQ"

--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -89,10 +89,10 @@ paths:
             application/json:
               schema:
                 $ref: "https://eosio.github.io/schemata/v2.1/oas/BlockInfo.yaml"
-  /get_finalizer_info_result:
+  /get_finalizer_info:
     post:
       description: Returns information about finalizers
-      operationId: get_finalizer_info_result
+      operationId: get_finalizer_info
       requestBody:
         required: true
         content:
@@ -114,7 +114,7 @@ paths:
                     properties:
                       generation:
                         type: integer
-                        description: version number of finalizers set
+                        description: generation number of finalizer policy
                         example: 1
                       threshold:
                         type: integer
@@ -128,7 +128,7 @@ paths:
                           properties:
                             'description':
                               type: string
-                              description: Name of finalizer, typicaly a producer acount
+                              description: Name of finalizer, typically a producer account
                               example: finalizerone
                             weight:
                               type: integer
@@ -144,7 +144,7 @@ paths:
                     properties:
                       generation:
                         type: integer
-                        description: version number of finalizers set
+                        description: generation number of finalizer policy
                         example: 2
                       threshold:
                         type: integer
@@ -158,7 +158,7 @@ paths:
                           properties:
                             'description':
                               type: string
-                              description: Name of finalizer, typicaly a producer acount
+                              description: Name of finalizer, typically a producer account
                               example: finalizerone
                             weight:
                               type: integer
@@ -185,19 +185,19 @@ paths:
                         is_vote_strong:
                           type: boolean
                           description: When true indicate strongly voted
-                        voted_policy_generation:
+                        finalizer_policy_generation:
                           type: integer
                           description: Policy Generation for vote
                           example: 2
-                        voted_block_id:
+                        voted_for_block_id:
                           type: string
                           description: Block id voted on
-                          example: 1234
-                        voted_block_num:
+                          example: "00003702056551dbabfab8ed499fb7d74850e92b9ac74d13b64ff2b161341c7a"
+                        voted_for_block_num:
                           type: integer
                           description: Block number voted on
-                          example: "00003702056551dbabfab8ed499fb7d74850e92b9ac74d13b64ff2b161341c7a"
-                        voted_block_timestamp:
+                          example: 1234
+                        voted_for_block_timestamp:
                           $ref: "https://docs.eosnetwork.com/openapi/v2.0/DateTimeSeconds.yaml"
                           description: Timestamp for the voted on block
 


### PR DESCRIPTION
Adds description for return type of new `get_finalizers_info` endpoint in `chain_api` plugin