### PR TITLE
[1.0-beta4] P2P: Fix fork check on connection

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2349,6 +2349,10 @@ namespace eosio {
             std::optional<block_id_type> fork_head_id = cc.fork_block_id_for_num( msg.fork_head_num ); // thread-safe
             if (fork_head_id) { // possible for LIB to move and fork_head_num not be found if running with no block-log
                on_fork = fork_head_id != msg.fork_head_id;
+               if (on_fork) {
+                  peer_dlog(c, "Sending catch_up request_message sync 4, fhead ${fh} != msg.fhead ${mfh}",
+                            ("fh", *fork_head_id)("mfh", msg.fork_head_id));
+               }
             }
          } catch( ... ) {}
          if( on_fork ) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1532,7 +1532,7 @@ namespace eosio {
             unknown_block = !my_id;
             on_fork = my_id != msg_head_id;
          } catch( ... ) {
-            on_fork = true;
+            unknown_block = true;
          }
       }
       if( unknown_block ) {
@@ -2350,7 +2350,7 @@ namespace eosio {
             if (fork_head_id) { // possible for LIB to move and fork_head_num not be found if running with no block-log
                on_fork = fork_head_id != msg.fork_head_id;
             }
-         } catch( ... ) { on_fork = true; }
+         } catch( ... ) {}
          if( on_fork ) {
             request_message req;
             req.req_blocks.mode = catch_up;
@@ -3528,7 +3528,6 @@ namespace eosio {
                }
             } catch( ... ) {
                peer_wlog( this, "caught an exception getting block id for ${pl}", ("pl", peer_lib) );
-               on_fork = true;
             }
             if( on_fork ) {
                peer_wlog( this, "Peer chain is forked, sending: forked go away" );


### PR DESCRIPTION
If running without a block log or with a truncated block log, it is possible that trying to retrieve a block by number will fail because the block is not available in the block log. Modify on-fork check on first handshake to allow for the block not to be found. Also allow for block not to be found on sync check in case LIB moves during sync check.

Resolves #456 