### PR TITLE
[1.0-beta4] P2P: Fix sync stopping making progress

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2549,9 +2549,6 @@ namespace eosio {
       } else { // in_sync
          if (blk_applied) {
             send_handshakes_if_synced(blk_latency);
-         } else {
-            peer_dlog(c, "in_sync, cancel_sync_wait");
-            c->cancel_sync_wait();
          }
       }
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2137,8 +2137,6 @@ namespace eosio {
       bool request_sent = false;
       if( sync_last_requested_num != sync_known_lib_num ) {
          uint32_t start = sync_next_expected_num;
-         if (sync_req_span > 1)
-            start = std::min(start, chain_info.lib_num+1);
          uint32_t end = start + sync_req_span - 1;
          if( end > sync_known_lib_num )
             end = sync_known_lib_num;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2478,7 +2478,8 @@ namespace eosio {
          return;
       }
       c->latest_blk_time = std::chrono::system_clock::now();
-      c->block_status_monitor_.accepted();
+      if (blk_applied)
+         c->block_status_monitor_.accepted();
       if (blk_latency.count() < config::block_interval_us && c->peer_syncing_from_us) {
          // a peer will not send us a recent block unless it is synced
          c->peer_syncing_from_us = false;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2158,7 +2158,7 @@ namespace eosio {
        */
       connection_ptr new_sync_source = (conn && conn->current()) ? conn : find_next_sync_node();
 
-      auto reset_on_failure = [&]() {
+      auto reset_on_failure = [&]() REQUIRES(sync_mtx) {
          sync_source.reset();
          sync_known_lib_num = chain_info.lib_num;
          sync_last_requested_num = 0;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2146,7 +2146,9 @@ namespace eosio {
 
       bool request_sent = false;
       if( sync_last_requested_num != sync_known_lib_num ) {
-         uint32_t start = std::min(sync_next_expected_num, chain_info.lib_num+1);
+         uint32_t start = sync_next_expected_num;
+         if (sync_req_span > 1)
+            start = std::min(start, chain_info.lib_num+1);
          uint32_t end = start + sync_req_span - 1;
          if( end > sync_known_lib_num )
             end = sync_known_lib_num;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2191,12 +2191,11 @@ namespace eosio {
          return;
       }
 
-      if( sync_state != lib_catchup ) {
+      if( sync_state != lib_catchup || !sync_source ) {
          set_state( lib_catchup );
          sync_next_expected_num = chain_info.lib_num + 1;
       } else {
          peer_dlog(c, "already syncing, start sync ignored");
-         c->sync_wait();
          return;
       }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2136,7 +2136,7 @@ namespace eosio {
 
       bool request_sent = false;
       if( sync_last_requested_num != sync_known_lib_num ) {
-         uint32_t start = sync_next_expected_num;
+         uint32_t start = std::max(sync_next_expected_num, chain_info.lib_num+1);
          uint32_t end = start + sync_req_span - 1;
          if( end > sync_known_lib_num )
             end = sync_known_lib_num;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2215,6 +2215,7 @@ namespace eosio {
          auto lib = my_impl->get_chain_lib_num();
          sync_last_requested_num = 0;
          sync_next_expected_num = std::max(sync_next_expected_num, lib + 1);
+         sync_source.reset();
          request_next_chunk();
       }
    }
@@ -2499,6 +2500,7 @@ namespace eosio {
                if (blk_num >= c->sync_last_requested_block) {
                   peer_dlog(c, "calling cancel_sync_wait, block ${b}, sync_last_requested_block ${lrb}",
                             ("b", blk_num)("lrb", c->sync_last_requested_block));
+                  sync_source.reset();
                   c->cancel_sync_wait();
                } else {
                   peer_dlog(c, "calling sync_wait, block ${b}", ("b", blk_num));

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2550,22 +2550,22 @@ namespace eosio {
                   }
                }
                if (blk_num >= sync_known_lib_num) {
-                  peer_dlog(c, "received non-applied block ${bn} > ${kn}, will send handshakes when caught up",
+                  peer_dlog(c, "received non-applied block ${bn} >= ${kn}, will send handshakes when caught up",
                             ("bn", blk_num)("kn", sync_known_lib_num));
                   send_handshakes_when_synced = true;
-               }
-
-               // use chain head instead of fork head so we do not get too far ahead of applied blocks
-               uint32_t head = my_impl->get_chain_head_num();
-               // do not allow to get too far ahead (one sync_req_span) of chain head
-               if (blk_num >= sync_last_requested_num && blk_num < head + sync_req_span) {
-                  // block was not applied, possibly because we already have the block
-                  fc_dlog(logger, "Requesting blocks ahead, head: ${h} fhead ${fh} blk_num: ${bn} sync_next_expected_num ${nen} "
-                                  "sync_last_requested_num: ${lrn}, sync_last_requested_block: ${lrb}",
-                          ("h", my_impl->get_chain_head_num())("fh", my_impl->get_fork_head_num())
-                          ("bn", blk_num)("nen", sync_next_expected_num)
-                          ("lrn", sync_last_requested_num)("lrb", c->sync_last_requested_block));
-                  request_next_chunk();
+               } else {
+                  // use chain head instead of fork head so we do not get too far ahead of applied blocks
+                  uint32_t head = my_impl->get_chain_head_num();
+                  // do not allow to get too far ahead (one sync_req_span) of chain head
+                  if (blk_num >= sync_last_requested_num && blk_num < head + sync_req_span) {
+                     // block was not applied, possibly because we already have the block
+                     fc_dlog(logger, "Requesting blocks ahead, head: ${h} fhead ${fh} blk_num: ${bn} sync_next_expected_num ${nen} "
+                                     "sync_last_requested_num: ${lrn}, sync_last_requested_block: ${lrb}",
+                             ("h", my_impl->get_chain_head_num())("fh", my_impl->get_fork_head_num())
+                             ("bn", blk_num)("nen", sync_next_expected_num)
+                             ("lrn", sync_last_requested_num)("lrb", c->sync_last_requested_block));
+                     request_next_chunk();
+                  }
                }
             } else { // blk_applied
                if (blk_num >= sync_last_requested_num) {

--- a/tests/p2p_sync_throttle_test.py
+++ b/tests/p2p_sync_throttle_test.py
@@ -205,7 +205,7 @@ try:
                                                          'block_sync_bytes_sent',
                                                          response)
     Print(f'End sync throttling bytes sent: {endSyncThrottlingBytesSent}')
-    assert throttledNode.waitForBlock(beginLargeBlocksHeadBlock, timeout=90), f'Wait for begin block {beginLargeBlocksHeadBlock} on throttled sync node timed out'
+    assert throttledNode.waitForBlock(beginLargeBlocksHeadBlock, timeout=120), f'Wait for begin block {beginLargeBlocksHeadBlock} on throttled sync node timed out'
     # Throttled node is connecting to a listen port with a block sync throttle applied so it will receive
     # blocks more slowly during syncing than an unthrottled node.
     wasThrottled = False
@@ -218,7 +218,7 @@ try:
         if throttledState:
             wasThrottled = True
             break
-    assert throttledNode.waitForBlock(endLargeBlocksHeadBlock, timeout=90), f'Wait for block {endLargeBlocksHeadBlock} on sync node timed out'
+    assert throttledNode.waitForBlock(endLargeBlocksHeadBlock, timeout=120), f'Wait for block {endLargeBlocksHeadBlock} on sync node timed out'
     endThrottledSync = time.time()
     response = throttledNode.processUrllibRequest('prometheus', 'metrics', exitOnError=True, returnType=ReturnType.raw, printReturnLimit=16).decode()
     Print('Throttled Node End State')


### PR DESCRIPTION
When all blocks of a requested range were received before any of them had been applied, the `sync_next_expected_num` would not make progress. This caused the node to not ever request the next range of blocks.

- Sync timer was always being canceled in `recv_block` making it effectively useless if any block at all was received
- Existing `p2p_sync_throttle_test.py` is a good test for the sync timer as it does not sync fast enough and the timer fires.
  - Increased timeout in test because sync timer now works correctly and causes the test to close connection and reconnect.
- Fixes for reset on failure in `request_next_chuck()`
  - Was not clearing out all sync variables
  - This also fixes #462
- Fix for calling sync manager for block received before LIB
  - Allows sync manager to properly account for the received block
- Includes removal of unused `last_req` and simplification of sync timer.

Resolves #459 
Resolves #462

Still investigating, but may also resolve #436