### PR TITLE
Add CLEOS support for get_finalizer_info RPC endpoint

### DIFF
--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -43,6 +43,7 @@ namespace eosio { namespace client { namespace http {
    const string get_raw_code_and_abi_func = chain_func_base + "/get_raw_code_and_abi";
    const string get_currency_balance_func = chain_func_base + "/get_currency_balance";
    const string get_currency_stats_func = chain_func_base + "/get_currency_stats";
+   const string get_finalizer_info_func = chain_func_base + "/get_finalizer_info";
    const string get_producers_func = chain_func_base + "/get_producers";
    const string get_schedule_func = chain_func_base + "/get_producer_schedule";
    const string get_required_keys = chain_func_base + "/get_required_keys";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2988,6 +2988,11 @@ int main( int argc, char** argv ) {
       std::cout << fc::json::to_pretty_string(get_info()) << std::endl;
    });
 
+   // get finalizer info
+   get->add_subcommand("finalizer_info", localized("Get current finalizer information"))->callback([] {
+      std::cout << fc::json::to_pretty_string(call(get_finalizer_info_func, fc::mutable_variant_object())) << std::endl;
+   });
+
    // get transaction status
    string status_transaction_id;
    auto getTransactionStatus = get->add_subcommand("transaction-status", localized("Get transaction status information"));


### PR DESCRIPTION
Resolves https://github.com/AntelopeIO/spring/issues/464

`cleos get` command output now looks like

```
./cleos get -h
Retrieve various items and information from the blockchain
Usage: bin/cleos get [OPTIONS] SUBCOMMAND

Options:
  -h,--help              Print this help message and exit
  --help-all             Show all help

Subcommands:
  info                   Get current blockchain information
  finalizer_info         Get current finalizer information
  transaction-status     Get transaction status information
  consensus_parameters   Get current blockchain consensus parameters
  block                  Retrieve a full block from the blockchain
 ...
```

Sample command output in Legacy:

```
./cleos get finalizer_info
{
  "active_finalizer_policy": null,
  "pending_finalizer_policy": null,
  "last_tracked_votes": []
}
```
Sample command output in Savanna:

```
./cleos get finalizer_info
{
  "active_finalizer_policy": {
    "generation": 1,
    "threshold": 3,
    "finalizers": [{
        "description": "finalizer #1",
        "weight": 1,
        "public_key": "PUB_BLS_B59vbf8hreKiI0-6pWvHs55VMPEGCwvcsnsfhLt-tmXnnakc7xDuEVDCwG6YAI0OHn2nydknjwA-et1tZHfckVGDNrffliKlcxoDHlmOuVWENwj300BLfdLmifuc2eIVms-V1w"
      },{
        "description": "finalizer #2",
        "weight": 1,
        "public_key": "PUB_BLS_aC9j4RbZ0mMixSwq2YeB-H7HzNGBCYYKRMTYD8JtPXgJnByhiEBV1Iudkxz6lJ8QzaPcko2mInz-ezMJpBc6PDN9BmHmME_ktESNId9AwuZkWmxB_dMBqdJbBC8m6nwRsHo4Qw"
      },{
        "description": "finalizer #3",
        "weight": 1,
        "public_key": "PUB_BLS_qacN8yy04oNE2keEue7oGEOqyBt2uDE61dorlRTA40I4Ftl4Gsh-fm2jpR_bbisKPnAHhK80sgfb8DSyUh7kNFlUIMxzYIQ9M9Ug3m2wnrBgs-1Aj8nP-vuhWvzihG4J5FFKGA"
      },{
        "description": "finalizer #4",
        "weight": 1,
        "public_key": "PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q"
      }
    ]
  },
  "pending_finalizer_policy": null,
  "last_tracked_votes": [{
      "description": "finalizer #1",
      "public_key": "PUB_BLS_B59vbf8hreKiI0-6pWvHs55VMPEGCwvcsnsfhLt-tmXnnakc7xDuEVDCwG6YAI0OHn2nydknjwA-et1tZHfckVGDNrffliKlcxoDHlmOuVWENwj300BLfdLmifuc2eIVms-V1w",
      "is_vote_strong": true,
      "finalizer_policy_generation": 1,
      "voted_for_block_id": "000000422dc57b4d1adc8a74c2c285fb2e8661afd440b7ff753e381fc9a8c58d",
      "voted_for_block_num": 66,
      "voted_for_block_timestamp": "2024-08-03T21:15:43.000"
    },{
      "description": "finalizer #2",
      "public_key": "PUB_BLS_aC9j4RbZ0mMixSwq2YeB-H7HzNGBCYYKRMTYD8JtPXgJnByhiEBV1Iudkxz6lJ8QzaPcko2mInz-ezMJpBc6PDN9BmHmME_ktESNId9AwuZkWmxB_dMBqdJbBC8m6nwRsHo4Qw",
      "is_vote_strong": true,
      "finalizer_policy_generation": 1,
      "voted_for_block_id": "000000422dc57b4d1adc8a74c2c285fb2e8661afd440b7ff753e381fc9a8c58d",
      "voted_for_block_num": 66,
      "voted_for_block_timestamp": "2024-08-03T21:15:43.000"
    },{
      "description": "finalizer #3",
      "public_key": "PUB_BLS_qacN8yy04oNE2keEue7oGEOqyBt2uDE61dorlRTA40I4Ftl4Gsh-fm2jpR_bbisKPnAHhK80sgfb8DSyUh7kNFlUIMxzYIQ9M9Ug3m2wnrBgs-1Aj8nP-vuhWvzihG4J5FFKGA",
      "is_vote_strong": true,
      "finalizer_policy_generation": 1,
      "voted_for_block_id": "000000422dc57b4d1adc8a74c2c285fb2e8661afd440b7ff753e381fc9a8c58d",
      "voted_for_block_num": 66,
      "voted_for_block_timestamp": "2024-08-03T21:15:43.000"
    },{
      "description": "finalizer #4",
      "public_key": "PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q",
      "is_vote_strong": true,
      "finalizer_policy_generation": 1,
      "voted_for_block_id": "000000422dc57b4d1adc8a74c2c285fb2e8661afd440b7ff753e381fc9a8c58d",
      "voted_for_block_num": 66,
      "voted_for_block_timestamp": "2024-08-03T21:15:43.000"
    }
  ]
}

```