### PR TITLE
[1.0-beta4] Watermark violation should create speculative block

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1879,6 +1879,17 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
       _pending_block_mode = pending_block_mode::speculating;
    }
 
+   if (in_speculating_mode()) {
+      static fc::time_point last_start_block_time = fc::time_point::maximum(); // always start with speculative block
+      // Determine if we are syncing: if we have recently started an old block then assume we are syncing
+      if (last_start_block_time < now + fc::microseconds(config::block_interval_us)) {
+         auto head_block_age = now - chain.head().block_time();
+         if (head_block_age > fc::seconds(5))
+            return start_block_result::waiting_for_block; // if syncing no need to create a block just to immediately abort it
+      }
+      last_start_block_time = now;
+   }
+
    if (in_producing_mode()) {
       // determine if our watermark excludes us from producing at this point
       if (auto current_watermark = _producer_watermarks.get_watermark(scheduled_producer.producer_name)) {
@@ -1895,17 +1906,6 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
             _pending_block_mode = pending_block_mode::speculating;
          }
       }
-   }
-
-   if (in_speculating_mode()) {
-      static fc::time_point last_start_block_time = fc::time_point::maximum(); // always start with speculative block
-      // Determine if we are syncing: if we have recently started an old block then assume we are syncing
-      if (last_start_block_time < now + fc::microseconds(config::block_interval_us)) {
-         auto head_block_age = now - chain.head().block_time();
-         if (head_block_age > fc::seconds(5))
-            return start_block_result::waiting_for_block; // if syncing no need to create a block just to immediately abort it
-      }
-      last_start_block_time = now;
    }
 
    if (in_producing_mode()) {


### PR DESCRIPTION
Failing watermark validation would cause node to go into tight spin:

```
error 2024-08-01T19:05:54.914 nodeos    producer_plugin.cpp:1893      start_block          ] Not producing block because "defproducerd" signed a block at the next block time or later (2024-08-01T19:05:55.000) than the pending block time (2024-08-01T19:05:55.000)
debug 2024-08-01T19:05:54.914 nodeos    producer_plugin.cpp:2554      schedule_production_ ] Waiting till another block is received and scheduling Speculative/Production Change
debug 2024-08-01T19:05:54.914 nodeos    producer_plugin.cpp:2628      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2024-08-01T19:05:54.887
... [snip over 2000 entries]
error 2024-08-01T19:05:54.999 nodeos    producer_plugin.cpp:1893      start_block          ] Not producing block because "defproducerd" signed a block at the next block time or later (2024-08-01T19:05:55.000) than the pending block time (2024-08-01T19:05:55.000)
debug 2024-08-01T19:05:54.999 nodeos    producer_plugin.cpp:2554      schedule_production_ ] Waiting till another block is received and scheduling Speculative/Production Change
debug 2024-08-01T19:05:55.000 nodeos    producer_plugin.cpp:2628      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2024-08-01T19:05:55.350
```

Move block time check in speculative mode above watermark check in production mode.

Reolves: https://github.com/AntelopeIO/leap/issues/2380