### PR TITLE
[1.0-beta4 -> main] P2P: Fix sync stopping making progress

### DIFF
--- a/tests/p2p_sync_throttle_test.py
+++ b/tests/p2p_sync_throttle_test.py
@@ -205,7 +205,7 @@ try:
                                                          'block_sync_bytes_sent',
                                                          response)
     Print(f'End sync throttling bytes sent: {endSyncThrottlingBytesSent}')
-    assert throttledNode.waitForBlock(beginLargeBlocksHeadBlock, timeout=90), f'Wait for begin block {beginLargeBlocksHeadBlock} on throttled sync node timed out'
+    assert throttledNode.waitForBlock(beginLargeBlocksHeadBlock, timeout=120), f'Wait for begin block {beginLargeBlocksHeadBlock} on throttled sync node timed out'
     # Throttled node is connecting to a listen port with a block sync throttle applied so it will receive
     # blocks more slowly during syncing than an unthrottled node.
     wasThrottled = False
@@ -218,7 +218,7 @@ try:
         if throttledState:
             wasThrottled = True
             break
-    assert throttledNode.waitForBlock(endLargeBlocksHeadBlock, timeout=90), f'Wait for block {endLargeBlocksHeadBlock} on sync node timed out'
+    assert throttledNode.waitForBlock(endLargeBlocksHeadBlock, timeout=120), f'Wait for block {endLargeBlocksHeadBlock} on sync node timed out'
     endThrottledSync = time.time()
     response = throttledNode.processUrllibRequest('prometheus', 'metrics', exitOnError=True, returnType=ReturnType.raw, printReturnLimit=16).decode()
     Print('Throttled Node End State')


### PR DESCRIPTION
When all blocks of a requested range were received before any of them had been applied, the `sync_next_expected_num` would not make progress. This caused the node to not ever request the next range of blocks.

- Sync timer was always being canceled in `recv_block` making it effectively useless if any block at all was received
- Existing `p2p_sync_throttle_test.py` is a good test for the sync timer as it does not sync fast enough and the timer fires.
  - Increased timeout in test because sync timer now works correctly and causes the test to close connection and reconnect.
- Fixes for reset on failure in `request_next_chuck()`
  - Was not clearing out all sync variables
  - This also fixes #462
- Fix for calling sync manager for block received before LIB
  - Allows sync manager to properly account for the received block
- Includes removal of unused `last_req` and simplification of sync timer.

Merges `release/1.0-beta4` into `main` including #469 

Resolves #459 
Resolves #462

Still investigating, but may also resolve #436