### PR TITLE
[5.0 -> main] compute_transaction should return failure trace

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2601,7 +2601,7 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
 }
 
 void read_only::compute_transaction(compute_transaction_params params, next_function<compute_transaction_results> next) {
-   send_transaction_params_t gen_params { .return_failure_trace = false,
+   send_transaction_params_t gen_params { .return_failure_trace = true,
                                           .retry_trx            = false,
                                           .retry_trx_num_blocks = std::nullopt,
                                           .trx_type             = transaction_metadata::trx_type::dry_run,


### PR DESCRIPTION
`/v1/chain/compute_transaction` API endpoint should return a failure trace. 
This was accidently changed to false when refactoring send_transaction in 5.0.

See 4.0 impl: https://github.com/AntelopeIO/leap/blob/01dab51ac00aed6730700b82943c30ccfd854fce/plugins/chain_plugin/chain_plugin.cpp#L2562-L2562

Merges `release/5.0` into `main` including https://github.com/AntelopeIO/leap/pull/2400

Resolves [#2281](https://github.com/AntelopeIO/leap/issues/2281)