### PR TITLE
[1.0-beta4 -> main] Use our own hardware_destructive_interference_sz to avoid GCC warning

### DIFF
--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -109,7 +109,7 @@ namespace eosio::chain {
          friend struct fc::has_reflector_init<votes_t>;
          friend class aggregating_qc_sig_t;
          struct bit_processed {
-            alignas(hardware_destructive_interference_size)
+            alignas(hardware_destructive_interference_sz)
             std::atomic<bool> value;
          };
 

--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -12,15 +12,17 @@
 
 namespace eosio { namespace chain {
 
-   // should be defined for c++17, but clang++16 still has not implemented it
-#ifdef __cpp_lib_hardware_interference_size
-   using std::hardware_constructive_interference_size;
-   using std::hardware_destructive_interference_size;
-#else
+   // Avoid GCC warning:
+   // libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
+   //   28 |       alignas(hardware_destructive_interference_size)
+   //      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   // thread_utils.hpp:28:15: note: its value can vary between compiler versions or with different ‘-mtune’ or ‘-mcpu’ flags
+   // thread_utils.hpp:28:15: note: if this use is part of a public ABI, change it to instead use a constant variable you define
+   // thread_utils.hpp:28:15: note: the default value for the current CPU tuning is 64 bytes
+   // thread_utils.hpp:28:15: note: you can stabilize this value with ‘--param hardware_destructive_interference_size=64’, or disable this warning with ‘-Wno-interference-size’
+   //
    // 64 bytes on x86-64 │ L1_CACHE_BYTES │ L1_CACHE_SHIFT │ __cacheline_aligned │ ...
-   [[maybe_unused]] constexpr std::size_t hardware_constructive_interference_size = 64;
-   [[maybe_unused]] constexpr std::size_t hardware_destructive_interference_size  = 64;
-#endif
+   constexpr std::size_t hardware_destructive_interference_sz = 64;
 
    // Use instead of std::atomic when std::atomic does not support type
    template <typename T>

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -168,7 +168,7 @@ namespace eosio {
             >
       >;
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       mutable fc::mutex            unlinkable_blk_state_mtx;
       unlinkable_block_state_index unlinkable_blk_state GUARDED_BY(unlinkable_blk_state_mtx);
       // 30 should be plenty large enough as any unlinkable block that will be usable is likely to be usable
@@ -218,7 +218,7 @@ namespace eosio {
          in_sync
       };
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       fc::mutex      sync_mtx;
       uint32_t       sync_known_lib_num      GUARDED_BY(sync_mtx) {0};  // highest known lib num from currently connected peers
       uint32_t       sync_last_requested_num GUARDED_BY(sync_mtx) {0};  // end block number of the last requested range, inclusive
@@ -228,7 +228,7 @@ namespace eosio {
       const uint32_t sync_req_span {0};
       const uint32_t sync_peer_limit {0};
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       std::atomic<stages> sync_state{in_sync};
       std::atomic<uint32_t> sync_ordinal{0};
       // indicate that we have received blocks to catch us up to head, delay sending out handshakes until we have
@@ -270,11 +270,11 @@ namespace eosio {
    };
 
    class dispatch_manager {
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       mutable fc::mutex      blk_state_mtx;
       peer_block_state_index  blk_state GUARDED_BY(blk_state_mtx);
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       mutable fc::mutex      local_txns_mtx;
       node_transaction_index  local_txns GUARDED_BY(local_txns_mtx);
 
@@ -365,12 +365,12 @@ namespace eosio {
       >;
       enum class timer_type { check, stats };
    private:
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       mutable std::shared_mutex        connections_mtx;
       connection_details_index         connections;
       chain::flat_set<string>          supplied_peers;
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       fc::mutex                             connector_check_timer_mtx;
       unique_ptr<boost::asio::steady_timer> connector_check_timer GUARDED_BY(connector_check_timer_mtx);
       fc::mutex                             connection_stats_timer_mtx;
@@ -489,18 +489,18 @@ namespace eosio {
       bool                                  use_socket_read_watermark = false;
       /** @} */
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       fc::mutex                             expire_timer_mtx;
       boost::asio::steady_timer             expire_timer GUARDED_BY(expire_timer_mtx) {thread_pool.get_executor()};
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       fc::mutex                             keepalive_timer_mtx;
       boost::asio::steady_timer             keepalive_timer GUARDED_BY(keepalive_timer_mtx) {thread_pool.get_executor()};
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       std::atomic<bool>                     in_shutdown{false};
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       compat::channels::transaction_ack::channel_type::handle  incoming_transaction_ack_subscription;
 
       boost::asio::deadline_timer           accept_error_timer{thread_pool.get_executor()};
@@ -520,7 +520,7 @@ namespace eosio {
       std::function<void()> increment_dropped_trxs;
       
    private:
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       mutable fc::mutex             chain_info_mtx; // protects chain_info_t
       chain_info_t                  chain_info GUARDED_BY(chain_info_mtx);
 
@@ -783,7 +783,7 @@ namespace eosio {
          std::function<void( boost::system::error_code, std::size_t )> callback;
       };
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       mutable fc::mutex   _mtx;
       uint32_t            _write_queue_size GUARDED_BY(_mtx) {0};
       deque<queued_write> _write_queue      GUARDED_BY(_mtx);
@@ -887,7 +887,7 @@ namespace eosio {
 
       std::optional<peer_sync_state> peer_requested;  // this peer is requesting info from us
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       std::atomic<bool> socket_open{false};
 
       std::atomic<connection_state> conn_state{connection_state::connecting};
@@ -941,14 +941,14 @@ namespace eosio {
       // when syncing from a peer, the last block expected of the current range
       uint32_t                sync_last_requested_block{0};
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       std::atomic<uint32_t>   trx_in_progress_size{0};
 
       fc::time_point          last_dropped_trx_msg_time;
       const uint32_t          connection_id;
       int16_t                 sent_handshake_count = 0;
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       std::atomic<bool>       peer_syncing_from_us{false};
 
       std::atomic<uint16_t>   protocol_version = 0;
@@ -957,14 +957,14 @@ namespace eosio {
       std::atomic<bool>       is_bp_connection = false;
       block_status_monitor    block_status_monitor_;
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       fc::mutex                        sync_response_expected_timer_mtx;
       boost::asio::steady_timer        sync_response_expected_timer GUARDED_BY(sync_response_expected_timer_mtx);
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       std::atomic<go_away_reason>      no_retry{no_reason};
 
-      alignas(hardware_destructive_interference_size)
+      alignas(hardware_destructive_interference_sz)
       mutable fc::mutex                conn_mtx; //< mtx for last_handshake_recv .. remote_endpoint_ip
       handshake_message                last_handshake_recv GUARDED_BY(conn_mtx);
       handshake_message                last_handshake_sent GUARDED_BY(conn_mtx);


### PR DESCRIPTION
Avoid GCC warning:
```
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
   28 |       alignas(hardware_destructive_interference_size)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: its value can vary between compiler versions or with different ‘-mtune’ or ‘-mcpu’ flags
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: if this use is part of a public ABI, change it to instead use a constant variable you define
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: the default value for the current CPU tuning is 64 bytes
libraries/chain/include/eosio/chain/thread_utils.hpp:28:15: note: you can stabilize this value with ‘--param hardware_destructive_interference_size=64’, or disable this warning with ‘-Wno-interference-size’
```

Declare and use our own `hardware_destructive_interference_size` set to 64 which should be sufficient for our supported platforms. Rename to `hardware_destructive_interference_sz` to avoid confusing with `std::hardware_destructive_interference_size`.

See also #41 

Merges `release/1.0-beta4` into `main` including #474 