### PR TITLE
update to libsecp256k1 0.5.1 for small signing performance improvement

### DIFF
--- a/libraries/libfc/secp256k1/CMakeLists.txt
+++ b/libraries/libfc/secp256k1/CMakeLists.txt
@@ -5,8 +5,7 @@ add_library(secp256k1-internal INTERFACE)
 target_include_directories(secp256k1-internal INTERFACE secp256k1/src)
 
 target_compile_definitions(secp256k1-internal INTERFACE ENABLE_MODULE_RECOVERY=1
-                                                        ENABLE_MODULE_EXTRAKEYS=1
-                                                        COMB_BLOCKS=11
+                                                        COMB_BLOCKS=43
                                                         COMB_TEETH=6
                                                         ECMULT_WINDOW_SIZE=15
                                                         SECP256K1_STATIC=1)


### PR DESCRIPTION
Bump libsecp256k1 to v0.5.1.

v0.5.1 changes the default pre computed table size used for signing. The default was changed to match what Bitcoin Core is using (the highest configuration; i.e. largest table). So, change our configuration to match the new default. It seems entirely reasonable to use the same configuration Bitcoin Core does.

On a i7-12700K this improves signing time from about 17.4µs to 16.8µs on a gcc14 build. A 3% improvement at the cost of the secp256k1 context growing by 64KB (inconsequential growth).