### PR TITLE
P2P: Add last_vote_received to connection status

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -18,6 +18,7 @@ namespace eosio {
       bool              is_socket_open       = false;
       bool              is_blocks_only       = false;
       bool              is_transactions_only = false;
+      time_point        last_vote_received;
       handshake_message last_handshake;
    };
 
@@ -99,4 +100,6 @@ namespace eosio {
 
 }
 
-FC_REFLECT( eosio::connection_status, (peer)(remote_ip)(remote_port)(connecting)(syncing)(is_bp_peer)(is_socket_open)(is_blocks_only)(is_transactions_only)(last_handshake) )
+FC_REFLECT( eosio::connection_status, (peer)(remote_ip)(remote_port)(connecting)(syncing)
+                                      (is_bp_peer)(is_socket_open)(is_blocks_only)(is_transactions_only)
+                                      (last_vote_received)(last_handshake) )

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1376,7 +1376,6 @@ namespace eosio {
       stat.is_socket_open = socket_is_open();
       stat.is_blocks_only = is_blocks_only_connection();
       stat.is_transactions_only = is_transactions_only_connection();
-      elog("last vote ${v}", ("v", last_vote_received.load()));
       stat.last_vote_received = last_vote_received;
       fc::lock_guard g( conn_mtx );
       stat.peer = peer_addr;


### PR DESCRIPTION
Add `last_vote_received` timestamp to connection status
```
  {
    "peer": "p2p.spring-beta4.jungletestnet.io:9898",
    "remote_ip": "136.243.79.230",
    "remote_port": "9898",
    "connecting": false,
    "syncing": false,
    "is_bp_peer": false,
    "is_socket_open": true,
    "is_blocks_only": false,
    "is_transactions_only": false,
    "last_vote_received": "2024-08-08T16:58:08.714",
    "last_handshake": {
      "network_version": 1214,
      "chain_id": "3eade55e76244083238a944a905517e8827c0da033304f6461108d69c1045e90",
      "node_id": "5c2c510673f56fdc44d3ed0bbbe4baaa8ce8e91ab86e91e57f0b128f0993beb1",
      "key": "EOS1111111111111111111111111111111114T1Anm",
      "time": "1723136044079711000",
      "token": "0000000000000000000000000000000000000000000000000000000000000000",
      "sig": "SIG_K1_111111111111111111111111111111111111111111111111111111111111111116uk5ne",
      "p2p_address": "p2p.spring-beta4.jungletestnet.io:9898 - 5c2c510",
      "last_irreversible_block_num": 1485709,
      "last_irreversible_block_id": "0016ab8c5598f0d3b4bd02941e09dc581db3018704b500630fce8bb62f46821f",
      "fork_head_num": 1485712,
      "fork_head_id": "0016ab8e83791607d413fe9b3b56eaddef411cfcd2db545c9a696354c1c30b83",
      "os": "linux",
      "agent": "api01_b2",
      "generation": 1
    }
  }
```

Resolves #489