### PR TITLE
Mask out only the private key when logging signature-provider

### DIFF
--- a/plugins/signature_provider_plugin/include/eosio/signature_provider_plugin/signature_provider_plugin.hpp
+++ b/plugins/signature_provider_plugin/include/eosio/signature_provider_plugin/signature_provider_plugin.hpp
@@ -23,6 +23,11 @@ public:
 
    const char* const signature_provider_help_text() const;
 
+   ///               public_key   spec_type    spec_data
+   /// Note: spec_data is private_key if spec_type is KEY
+   static std::tuple<std::string, std::string, std::string> parse_signature_provider_spec(const std::string& spec);
+
+
    using signature_provider_type = std::function<chain::signature_type(chain::digest_type)>;
 
    // @return empty optional for BLS specs


### PR DESCRIPTION
On startup and shutdown when logging the `signature-provider`, log the public key but mask out the private key. Before the public and private key were both masked out.

Example output:
`signature-provider = EOS7GQpG7KWgw7FaFDnkua1LadP71nF1kVqAXZ5uD8apE3gUoCxX4=KEY:***`

```
info  2024-08-08T18:46:44.214 nodeos    main.cpp:69                   log_non_default_opti ] Non-default options: data-dir = spring-testnet4-validator-data, config-dir = spring-testnet4, genesis-json = spring-testnet4-validator/genesis.json, plugin = eosio::chain_api_plugin, plugin = eosio::net_api_plugin, http-server-address = 127.0.0.1:7799, p2p-listen-endpoint = 0.0.0.0:9799, chain-state-db-size-mb = 32000, database-map-mode = mapped_private, http-server-address = 127.0.0.1:8899, p2p-listen-endpoint = 0.0.0.0:9899:0, signature-provider = EOS7GQpG7KWgw7FaFDnkua1LadP71nF1kVqAXZ5uD8apE3gUoCxX4=KEY:***, signature-provider = PUB_BLS_MEiD85FQ_7-WMBno5xit7-kHcCaJak7UVtcFQayDfneJCQT1mleNd-FQ9kBRHL4A_kHg41rEjhHXlfiH0GWqB2PP6mRUBR_wiFwOsO8lKUtDa_mBjtGSUVIo2sQWKDMGjEGASA=KEY:***, producer-name = zombiezombie, p2p-peer-address = p2p.spring-beta4.jungletestnet.io:9898, p2p-peer-address = 3.227.1.63:1444, p2p-peer-address = savanna.genereos.io:9876, p2p-peer-address = jungleb4.maroonspoon.com:9876, p2p-peer-address = p2p.spring-beta.jungletestnet.io:9898
```

Resolves #461