### PR TITLE
P2P: Fix net_plugin requesting same range repeatedly

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2198,7 +2198,7 @@ namespace eosio {
          return;
       }
 
-      if( sync_state != lib_catchup || !sync_source ) {
+      if( sync_state != lib_catchup ) {
          set_state( lib_catchup );
          sync_last_requested_num = 0;
          sync_next_expected_num = chain_info.lib_num + 1;
@@ -2518,8 +2518,6 @@ namespace eosio {
                } else {
                   if (blk_num == sync_next_expected_num) {
                      ++sync_next_expected_num;
-                  } else if (blk_num < sync_next_expected_num) {
-                     sync_next_expected_num = blk_num + 1;
                   }
                }
                if (blk_num >= sync_known_lib_num) {
@@ -2542,8 +2540,7 @@ namespace eosio {
                }
             } else { // blk_applied
                if (blk_num >= sync_last_requested_num) {
-                  // should not reach as should have hit the above when the block was received but not applied, but
-                  // if we do then request blocks as we are still in lib_catchup
+                  // Did not request blocks ahead, likely because too far ahead of head
                   fc_dlog(logger, "Requesting blocks, head: ${h} fhead ${fh} blk_num: ${bn} sync_next_expected_num ${nen} "
                                   "sync_last_requested_num: ${lrn}, sync_last_requested_block: ${lrb}",
                           ("h", my_impl->get_chain_head_num())("fh", my_impl->get_fork_head_num())


### PR DESCRIPTION
PR #472 Added additional unneeded check for `!sync_source` in `start_sync` to know if a sync was not already in progress. However, if the last request had received all the blocks from the previous request then `sync_source` would already be reset. This sets up a race condition such that many `start_sync` calls can kick off a new sync instead of continuing the current one.

Also with #472 there is no need to reset `sync_next_expected_num` back to received block when receiving a block already received. This just causes additional requests for blocks already received.

Resolves #499


