### PR TITLE
Disable `NEON` on arm in boost `unordered`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,10 @@ set(CMAKE_DISABLE_FIND_PACKAGE_OpenSSL On)
 # is effectively --catch_system_errors=no broadly across all tests
 add_compile_definitions(BOOST_TEST_DEFAULTS_TO_CORE_DUMP)
 
+# Unless this is set, some boost unordered headers include `arm_neon.h` when building on ARM processors,
+# which includes a definition for `float16_t` conflicting with the one in `libraries/softfloat`.
+add_compile_definitions(BOOST_UNORDERED_DISABLE_NEON)
+
 add_subdirectory( libraries )
 add_subdirectory( plugins )
 add_subdirectory( programs )

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -5,6 +5,8 @@
 
 #include <eosio/testing/tester.hpp>
 #include <ranges>
+
+#define BOOST_UNORDERED_DISABLE_NEON  // because of conflicting declaration for float16_t in softfloat (issue #517)
 #include <boost/unordered/unordered_flat_map.hpp>
 
 #include "snapshot_suites.hpp"

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -6,7 +6,6 @@
 #include <eosio/testing/tester.hpp>
 #include <ranges>
 
-#define BOOST_UNORDERED_DISABLE_NEON  // because of conflicting declaration for float16_t in softfloat (issue #517)
 #include <boost/unordered/unordered_flat_map.hpp>
 
 #include "snapshot_suites.hpp"


### PR DESCRIPTION
Disable `NEON` on arm in boost `unordered` because of conflicting declaration for `float16_t` in softfloat library.

Resolves #517.