### PR TITLE
Fix some incorrect extension lookups using `lower_bound` 

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -635,8 +635,8 @@ namespace eosio { namespace chain {
    }
 
    void impl::abi_to_variant::add_block_header_finality_extension( mutable_variant_object& mvo, const header_extension_multimap& header_exts ) {
-      if (header_exts.count(finality_extension::extension_id())) {
-         const auto& f_ext = std::get<finality_extension>(header_exts.lower_bound(finality_extension::extension_id())->second);
+      if (auto it = header_exts.find(finality_extension::extension_id()); it != header_exts.end()) {
+         const auto& f_ext = std::get<finality_extension>(it->second);
          mvo("finality_extension", f_ext);
       }
    }

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -438,7 +438,7 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
    if( control.is_builtin_activated( builtin_protocol_feature_t::no_duplicate_deferred_id ) ) {
       auto exts = trx.validate_and_extract_extensions();
       if( exts.size() > 0 ) {
-         auto itr = exts.lower_bound( deferred_transaction_generation_context::extension_id() );
+         auto itr = exts.find( deferred_transaction_generation_context::extension_id() );
 
          EOS_ASSERT( exts.size() == 1 && itr != exts.end(), invalid_transaction_extension,
                      "only the deferred_transaction_generation_context extension is currently supported for deferred transactions"

--- a/libraries/chain/block_header.cpp
+++ b/libraries/chain/block_header.cpp
@@ -28,7 +28,7 @@ namespace eosio { namespace chain {
    header_extension_multimap block_header::validate_and_extract_header_extensions()const {
       using decompose_t = block_header_extension_types::decompose_t;
 
-      flat_multimap<uint16_t, block_header_extension> results;
+      header_extension_multimap results;
 
       uint16_t id_type_lower_bound = 0;
 

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -369,8 +369,7 @@ block_header_state block_header_state::next(const signed_block_header& h, valida
    // retrieve protocol_feature_activation from incoming block header extension
    // -------------------------------------------------------------------------
    vector<digest_type> new_protocol_feature_activations;
-   if( exts.count(protocol_feature_activation::extension_id() > 0) ) {
-      auto  pfa_entry = exts.lower_bound(protocol_feature_activation::extension_id());
+   if (auto  pfa_entry = exts.find(protocol_feature_activation::extension_id()); pfa_entry != exts.end()) {
       auto& pfa_ext   = std::get<protocol_feature_activation>(pfa_entry->second);
       new_protocol_feature_activations = pfa_ext.protocol_features;
       validator( timestamp(), activated_protocol_features->protocol_features, new_protocol_feature_activations );
@@ -378,9 +377,9 @@ block_header_state block_header_state::next(const signed_block_header& h, valida
 
    // retrieve finality_extension data from block header extension
    // --------------------------------------------------------------------
-   EOS_ASSERT(exts.count(finality_extension::extension_id()) > 0, invalid_block_header_extension,
+   auto  f_entry = exts.find(finality_extension::extension_id());
+   EOS_ASSERT(f_entry != exts.end(), invalid_block_header_extension,
               "Instant Finality Extension is expected to be present in all block headers after switch to IF");
-   auto  f_entry     = exts.lower_bound(finality_extension::extension_id());
    const auto& f_ext = std::get<finality_extension>(f_entry->second);
 
    if (h.is_proper_svnn_block()) {

--- a/libraries/chain/block_header_state_legacy.cpp
+++ b/libraries/chain/block_header_state_legacy.cpp
@@ -156,8 +156,8 @@ namespace eosio::chain {
          result.producer_to_last_implied_irb[proauth.producer_name] = dpos_proposed_irreversible_blocknum;
       }
 
-      if (header_exts.count(finality_extension::extension_id())) { // transition to savanna has started
-         const auto& f_ext = std::get<finality_extension>(header_exts.lower_bound(finality_extension::extension_id())->second);
+      if (auto it = header_exts.find(finality_extension::extension_id()); it != header_exts.end()) { // transition to savanna has started
+         const auto& f_ext = std::get<finality_extension>(it->second);
          // copy over qc_claim from IF Genesis Block
          result.qc_claim = f_ext.qc_claim;
       }
@@ -275,11 +275,11 @@ namespace eosio::chain {
          maybe_new_producer_schedule.emplace(new_producers);
       }
 
-      if ( exts.count(producer_schedule_change_extension::extension_id()) > 0 ) {
+      if (auto it = exts.find(producer_schedule_change_extension::extension_id()); it != exts.end()) {
          EOS_ASSERT(wtmsig_enabled, producer_schedule_exception, "Block header producer_schedule_change_extension before activation of WTMsig Block Signatures" );
          EOS_ASSERT( !was_pending_promoted, producer_schedule_exception, "cannot set pending producer schedule in the same block in which pending was promoted to active" );
 
-         const auto& new_producer_schedule = std::get<producer_schedule_change_extension>(exts.lower_bound(producer_schedule_change_extension::extension_id())->second);
+         const auto& new_producer_schedule = std::get<producer_schedule_change_extension>(it->second);
 
          EOS_ASSERT( new_producer_schedule.version == active_schedule.version + 1, producer_schedule_exception, "wrong producer schedule version specified" );
          EOS_ASSERT( prev_pending_schedule.schedule.producers.empty(), producer_schedule_exception,
@@ -290,9 +290,9 @@ namespace eosio::chain {
       }
 
       protocol_feature_activation_set_ptr new_activated_protocol_features;
-      { // handle protocol_feature_activation
-         if( exts.count(protocol_feature_activation::extension_id() > 0) ) {
-            const auto& new_protocol_features = std::get<protocol_feature_activation>(exts.lower_bound(protocol_feature_activation::extension_id())->second).protocol_features;
+      {  // handle protocol_feature_activation
+         if (auto it = exts.find(protocol_feature_activation::extension_id()); it != exts.end()) {
+            const auto& new_protocol_features = std::get<protocol_feature_activation>(it->second).protocol_features;
             validator( timestamp, prev_activated_protocol_features->protocol_features, new_protocol_features );
 
             new_activated_protocol_features =   std::make_shared<protocol_feature_activation_set>(

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -194,11 +194,9 @@ void block_state::verify_qc(const qc_t& qc) const {
 }
 
 qc_claim_t block_state::extract_qc_claim() const {
-   auto itr = header_exts.lower_bound(finality_extension::extension_id());
-   if (itr == header_exts.end())
-      return {};
-   const auto& f_ext = std::get<finality_extension>(itr->second);
-   return f_ext.qc_claim;
+   if (auto itr = header_exts.find(finality_extension::extension_id()); itr != header_exts.end())
+      return std::get<finality_extension>(itr->second).qc_claim;
+   return {};
 }
 
 valid_t block_state::new_valid(const block_header_state& next_bhs, const digest_type& action_mroot, const digest_type& strong_digest) const {

--- a/libraries/chain/block_state_legacy.cpp
+++ b/libraries/chain/block_state_legacy.cpp
@@ -86,7 +86,7 @@ namespace eosio::chain {
    }
 
    std::optional<block_num_type> block_state_legacy::savanna_genesis_block_num() const {
-      if (auto itr = header_exts.lower_bound(finality_extension::extension_id()); itr != header_exts.end()) {
+      if (auto itr = header_exts.find(finality_extension::extension_id()); itr != header_exts.end()) {
          const auto& f_ext = std::get<finality_extension>(itr->second);
          return std::optional<block_num_type>{f_ext.qc_claim.block_num};
       }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3480,14 +3480,14 @@ struct controller_impl {
       EOS_REPORT( "header_extensions", b.header_extensions, ab.header_extensions )
 
       if (b.header_extensions != ab.header_extensions) {
-         flat_multimap<uint16_t, block_header_extension> bheader_exts = b.validate_and_extract_header_extensions();
-         if (bheader_exts.count(finality_extension::extension_id())) {
-            const auto& f_ext = std::get<finality_extension>(bheader_exts.lower_bound(finality_extension::extension_id())->second);
+         header_extension_multimap bheader_exts = b.validate_and_extract_header_extensions();
+         if (auto it = bheader_exts.find(finality_extension::extension_id()); it != bheader_exts.end()) {
+            const auto& f_ext = std::get<finality_extension>(it->second);
             elog("b  if: ${i}", ("i", f_ext));
          }
-         flat_multimap<uint16_t, block_header_extension> abheader_exts = ab.validate_and_extract_header_extensions();
-         if (abheader_exts.count(finality_extension::extension_id())) {
-            const auto& f_ext = std::get<finality_extension>(abheader_exts.lower_bound(finality_extension::extension_id())->second);
+         header_extension_multimap abheader_exts = ab.validate_and_extract_header_extensions();
+         if (auto it = abheader_exts.lower_bound(finality_extension::extension_id()); it != abheader_exts.end()) {
+            const auto& f_ext = std::get<finality_extension>(it->second);
             elog("ab if: ${i}", ("i", f_ext));
          }
       }
@@ -3498,12 +3498,12 @@ struct controller_impl {
    static std::optional<qc_data_t> extract_qc_data(const signed_block_ptr& b) {
       std::optional<qc_data_t> qc_data;
       auto hexts = b->validate_and_extract_header_extensions();
-      if (auto f_entry = hexts.lower_bound(finality_extension::extension_id()); f_entry != hexts.end()) {
+      if (auto f_entry = hexts.find(finality_extension::extension_id()); f_entry != hexts.end()) {
          auto& f_ext   = std::get<finality_extension>(f_entry->second);
 
          // get the matching qc extension if present
          auto exts = b->validate_and_extract_extensions();
-         if (auto entry = exts.lower_bound(quorum_certificate_extension::extension_id()); entry != exts.end()) {
+         if (auto entry = exts.find(quorum_certificate_extension::extension_id()); entry != exts.end()) {
             auto& qc_ext = std::get<quorum_certificate_extension>(entry->second);
             return qc_data_t{ std::move(qc_ext.qc), f_ext.qc_claim };
          }
@@ -3870,7 +3870,7 @@ struct controller_impl {
                   invalid_qc_claim,
                   "Block #${b} is making a new finality claim, but doesn't include a qc to justify this claim", ("b", block_num) );
 
-      const auto& qc_ext   = std::get<quorum_certificate_extension>(block_exts.lower_bound(qc_ext_id)->second);
+      const auto& qc_ext   = std::get<quorum_certificate_extension>(block_exts.find(qc_ext_id)->second);
       const auto& qc_proof = qc_ext.qc;
 
       // Check QC information in header extension and block extension match

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3486,7 +3486,7 @@ struct controller_impl {
             elog("b  if: ${i}", ("i", f_ext));
          }
          header_extension_multimap abheader_exts = ab.validate_and_extract_header_extensions();
-         if (auto it = abheader_exts.lower_bound(finality_extension::extension_id()); it != abheader_exts.end()) {
+         if (auto it = abheader_exts.find(finality_extension::extension_id()); it != abheader_exts.end()) {
             const auto& f_ext = std::get<finality_extension>(it->second);
             elog("ab if: ${i}", ("i", f_ext));
          }

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -270,9 +270,8 @@ namespace eosio::chain {
          try {
             const auto& exts = n->header_exts;
 
-            if (exts.count(protocol_feature_activation::extension_id()) > 0) {
-               const auto& pfa = exts.lower_bound(protocol_feature_activation::extension_id())->second;
-               const auto& new_protocol_features = std::get<protocol_feature_activation>(pfa).protocol_features;
+            if (auto it = exts.find(protocol_feature_activation::extension_id()); it != exts.end()) {
+               const auto& new_protocol_features = std::get<protocol_feature_activation>(it->second).protocol_features;
                validator(n->timestamp(), prev_bh->get_activated_protocol_features()->protocol_features, new_protocol_features);
             }
          }

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -629,8 +629,8 @@ namespace impl {
 
          // process contents of block.transaction_extensions
          auto exts = trx.validate_and_extract_extensions();
-         if (exts.count(deferred_transaction_generation_context::extension_id()) > 0) {
-            const auto& deferred_transaction_generation = std::get<deferred_transaction_generation_context>(exts.lower_bound(deferred_transaction_generation_context::extension_id())->second);
+         if (auto it = exts.find(deferred_transaction_generation_context::extension_id()); it != exts.end()) {
+            const auto& deferred_transaction_generation = std::get<deferred_transaction_generation_context>(it->second);
             mvo("deferred_transaction_generation", deferred_transaction_generation);
          }
 
@@ -662,9 +662,9 @@ namespace impl {
 
          // process contents of block.header_extensions
          flat_multimap<uint16_t, block_header_extension> header_exts = block.validate_and_extract_header_extensions();
-         if ( header_exts.count(protocol_feature_activation::extension_id() > 0) ) {
+         if (auto it = header_exts.find(protocol_feature_activation::extension_id()); it != header_exts.end()) {
             const auto& new_protocol_features =
-                  std::get<protocol_feature_activation>(header_exts.lower_bound(protocol_feature_activation::extension_id())->second).protocol_features;
+                  std::get<protocol_feature_activation>(it->second).protocol_features;
             vector<fc::variant> pf_array;
             pf_array.reserve(new_protocol_features.size());
             for (auto feature : new_protocol_features) {
@@ -674,9 +674,8 @@ namespace impl {
             }
             mvo("new_protocol_features", pf_array);
          }
-         if ( header_exts.count(producer_schedule_change_extension::extension_id())) {
-            const auto& new_producer_schedule =
-                  std::get<producer_schedule_change_extension>(header_exts.lower_bound(producer_schedule_change_extension::extension_id())->second);
+         if (auto it = header_exts.find(producer_schedule_change_extension::extension_id()); it != header_exts.end()) {
+            const auto& new_producer_schedule = std::get<producer_schedule_change_extension>(it->second);
             mvo("new_producer_schedule", new_producer_schedule);
          }
          add_block_header_finality_extension(mvo, header_exts);
@@ -686,15 +685,12 @@ namespace impl {
 
          // process contents of block.block_extensions
          auto block_exts = block.validate_and_extract_extensions();
-         if ( block_exts.count(additional_block_signatures_extension::extension_id()) > 0) {
-            const auto& additional_signatures =
-                  std::get<additional_block_signatures_extension>(block_exts.lower_bound(additional_block_signatures_extension::extension_id())->second);
+         if (auto it = block_exts.find(additional_block_signatures_extension::extension_id()); it != block_exts.end()) {
+            const auto& additional_signatures = std::get<additional_block_signatures_extension>(it->second);
             mvo("additional_signatures", additional_signatures);
          }
-         auto qc_extension_count = block_exts.count(quorum_certificate_extension::extension_id());
-         if ( qc_extension_count > 0) {
-            const auto& qc_extension =
-                  std::get<quorum_certificate_extension>(block_exts.lower_bound(quorum_certificate_extension::extension_id())->second);
+         if (auto it = block_exts.find(quorum_certificate_extension::extension_id()); it != block_exts.end()) {
+            const auto& qc_extension = std::get<quorum_certificate_extension>(it->second);
             mvo("qc_extension", qc_extension);
          }
 

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -663,8 +663,7 @@ namespace impl {
          // process contents of block.header_extensions
          flat_multimap<uint16_t, block_header_extension> header_exts = block.validate_and_extract_header_extensions();
          if (auto it = header_exts.find(protocol_feature_activation::extension_id()); it != header_exts.end()) {
-            const auto& new_protocol_features =
-                  std::get<protocol_feature_activation>(it->second).protocol_features;
+            const auto& new_protocol_features = std::get<protocol_feature_activation>(it->second).protocol_features;
             vector<fc::variant> pf_array;
             pf_array.reserve(new_protocol_features.size());
             for (auto feature : new_protocol_features) {

--- a/libraries/chain/include/eosio/chain/block_header_state_utils.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state_utils.hpp
@@ -37,8 +37,8 @@ namespace eosio::chain::detail {
    inline vector<signature_type> extract_additional_signatures(const signed_block_ptr& b) {
       auto exts = b->validate_and_extract_extensions();
 
-      if (exts.count(additional_sigs_eid) > 0) {
-         auto& additional_sigs = std::get<additional_block_signatures_extension>(exts.lower_bound(additional_sigs_eid)->second);
+      if (auto it = exts.find(additional_sigs_eid); it != exts.end()) {
+         auto& additional_sigs = std::get<additional_block_signatures_extension>(it->second);
          return std::move(additional_sigs.signatures);
       }
 
@@ -51,10 +51,10 @@ namespace eosio::chain::detail {
    inline const vector<digest_type>& get_new_protocol_feature_activations(const header_extension_multimap& header_exts) {
       static const vector<digest_type> no_activations{};
 
-      if( header_exts.count(protocol_feature_activation::extension_id()) == 0 )
-         return no_activations;
+      if (auto it = header_exts.find(protocol_feature_activation::extension_id()); it != header_exts.end())
+         return std::get<protocol_feature_activation>(it->second).protocol_features;
 
-      return std::get<protocol_feature_activation>(header_exts.lower_bound(protocol_feature_activation::extension_id())->second).protocol_features;
+      return no_activations;
    }
 
 } /// namespace eosio::chain

--- a/unittests/finality_proof.hpp
+++ b/unittests/finality_proof.hpp
@@ -73,12 +73,12 @@ namespace finality_proof {
    static qc_data_t extract_qc_data(const signed_block_ptr& b) {
       assert(b);
       auto hexts = b->validate_and_extract_header_extensions();
-      if (auto f_entry = hexts.lower_bound(finality_extension::extension_id()); f_entry != hexts.end()) {
+      if (auto f_entry = hexts.find(finality_extension::extension_id()); f_entry != hexts.end()) {
          auto& f_ext   = std::get<finality_extension>(f_entry->second);
 
          // get the matching qc extension if present
          auto exts = b->validate_and_extract_extensions();
-         if (auto entry = exts.lower_bound(quorum_certificate_extension::extension_id()); entry != exts.end()) {
+         if (auto entry = exts.find(quorum_certificate_extension::extension_id()); entry != exts.end()) {
             auto& qc_ext = std::get<quorum_certificate_extension>(entry->second);
             return qc_data_t{ std::move(qc_ext.qc), f_ext.qc_claim };
          }


### PR DESCRIPTION
We typically use the map `lower_bound()` api to retrieve an iterator to an extension we are interested in. However this api returns the first entry in the map that is *not less* than the key we are looking for. If the key we are looking for is not present, it could return a different, greater key.

Foe example, see:

https://github.com/AntelopeIO/spring/blob/b58cbbcdc532f430e87a430ed1209bc9c9fce3e2/libraries/chain/block_state.cpp#L197-L201

This doesn't cause an issue right now because `finality_extension` is the last of the header extensions, and `quorum_certificate_extension` is the last of the block extensions (so they have the highest ids), but it is quite fragile.

A common pattern is to do a `count()` to check if the extension is present, followed by a `lower_bound()` to retrieve an iterator to it. I guess it could make sense in cases where we can have multiple extensions of a given type, but for *unique* extensions, I feel that doing a single lookup using `find()` instead of two lookups is better.

This PR updates the extension lookups to use `find()` instead of `lower_bound()`