### PR TITLE
P2P: Provide better log message when unable to resolve host

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2791,7 +2791,8 @@ namespace eosio {
                   c->send_time();
                }
             } else {
-               fc_ilog( logger, "connection failed to ${a}, ${error}", ("a", c->peer_address())( "error", err.message()));
+               fc_ilog(logger, "connection failed to ${a}, ${e}", ("a", c->peer_address())
+                       ("e", err == boost::asio::error::not_found ? "Unable to resolve endpoint" : err.message()));
                c->close( false );
                if (my_impl->increment_failed_p2p_connections) {
                   my_impl->increment_failed_p2p_connections();


### PR DESCRIPTION
Before:
```
info  2024-08-12T16:20:02.907 net-1     net_plugin.cpp:2794           operator()           ] connection failed to p2p.spring-beta.jungletestnet.io:9898, Element not found
```
After
```
info  2024-08-12T16:24:02.571 net-2     net_plugin.cpp:2795           operator()           ] connection failed to p2p.spring-beta.jungletestnet.io:9898, Unable to resolve endpoint
```