### PR TITLE
Provide 500ms for speculative blocks

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1868,14 +1868,15 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    _pending_block_deadline = block_timing_util::calculate_producing_block_deadline(_produce_block_cpu_effort, block_time);
    if (in_speculating_mode()) { // if we are producing, then produce block even if deadline has passed
       // speculative block, no reason to start a block that will immediately be re-started, set deadline in the future
-      // a block should come in during this time, if not then just keep creating the block every produce_block_cpu_effort
-      if (now + fc::milliseconds(config::block_interval_ms/10) > _pending_block_deadline) {
-         _pending_block_deadline = now + _produce_block_cpu_effort;
+      // a block should come in during this time, if not then just keep creating the block every block_interval_ms
+      if (now + fc::milliseconds(config::block_interval_ms) > _pending_block_deadline) {
+         _pending_block_deadline = now + fc::milliseconds(config::block_interval_ms);
       }
    }
    const auto& preprocess_deadline = _pending_block_deadline;
 
-   fc_dlog(_log, "Starting block #${n} ${bt} producer ${p}", ("n", pending_block_num)("bt", block_time)("p", scheduled_producer.producer_name));
+   fc_dlog(_log, "Starting block #${n} ${bt} producer ${p}, deadline ${d}",
+           ("n", pending_block_num)("bt", block_time)("p", scheduled_producer.producer_name)("d", _pending_block_deadline));
 
    try {
 


### PR DESCRIPTION
Since https://github.com/AntelopeIO/leap/pull/1481 speculative blocks honor block deadlines so that "Start speculative blocks every block interval but not more often". However, since 50ms threshold was use it could set a deadline that would be hit before another block came causing a needless restart of a transaction and restart of a block.

For example:
```
info  2024-08-12T15:18:22.511 nodeos    controller.cpp:3525           log_applied          ] Received block ebede3ba155c0f61... #2154995 @ 2024-08-12T15:18:22.500 signed by lioninjungle [trxs: 2, lib: 2154993, net: 432, cpu: 351, elapsed: 619, time: 1966, latency: 11 ms]
debug 2024-08-12T15:18:22.511 nodeos    producer_plugin.cpp:2005      start_block          ] Starting block #2154996 2024-08-12T15:18:23.000 producer lioninjungle
debug 2024-08-12T15:18:22.511 nodeos    producer_plugin.cpp:2162      remove_expired_trxs  ] Processed 0 expired transactions of the 1 transactions in the unapplied queue.
debug 2024-08-12T15:18:22.511 nodeos    producer_plugin.cpp:2643      schedule_production_ ] Speculative Block Created; Scheduling Speculative/Production Change
debug 2024-08-12T15:18:22.511 nodeos    producer_plugin.cpp:2699      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2024-08-12T15:18:47.500
debug 2024-08-12T15:18:22.685 nodeos    producer_plugin.cpp:869       restart_speculative_ ] Restarting exhausted speculative block #2154996
debug 2024-08-12T15:18:22.685 nodeos    producer_plugin.cpp:309       report               ] Block #2154996 lioninjungle trx idle: 173057us out of 173987us, success: 0, 0us, fail: 0, 0us, transient: 0, 0us, other: 930us
debug 2024-08-12T15:18:22.685 nodeos    producer_plugin.cpp:2005      start_block          ] Starting block #2154996 2024-08-12T15:18:23.000 producer lioninjungle
debug 2024-08-12T15:18:22.685 nodeos    producer_plugin.cpp:2162      remove_expired_trxs  ] Processed 0 expired transactions of the 2 transactions in the unapplied queue.
debug 2024-08-12T15:18:22.685 nodeos    producer_plugin.cpp:2553      process_incoming_trx ] Processing 1 pending transactions
debug 2024-08-12T15:18:22.685 nodeos    producer_plugin.cpp:2579      process_incoming_trx ] Processed 1 pending transactions, 0 left
debug 2024-08-12T15:18:22.685 nodeos    producer_plugin.cpp:2643      schedule_production_ ] Speculative Block Created; Scheduling Speculative/Production Change
debug 2024-08-12T15:18:22.685 nodeos    producer_plugin.cpp:2699      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2024-08-12T15:18:47.500
debug 2024-08-12T15:18:22.971 nodeos    producer_plugin.cpp:783       on_incoming_block    ] received incoming block 2154996 0020e1f42cb0c29fb64575c9b3ed4a4135a43180eab3a0a950aa15c3bf189567
debug 2024-08-12T15:18:22.971 nodeos    producer_plugin.cpp:309       report               ] Block #2154996 lioninjungle trx idle: 284523us out of 286360us, success: 3, 1161us, fail: 0, 0us, transient: 0, 0us, other: 676us
debug 2024-08-12T15:18:22.973 nodeos    producer_plugin.cpp:666       on_block             ] Removed applied transactions before: 3, after: 1
info  2024-08-12T15:18:22.973 nodeos    controller.cpp:3525           log_applied          ] Received block 2cb0c29fb64575c9... #2154996 @ 2024-08-12T15:18:23.000 signed by lioninjungle [trxs: 2, lib: 2154994, net: 432, cpu: 251, elapsed: 641, time: 2026, latency: -26 ms]
```

Instead give a speculative block a full block interval (500ms) before considering it exhausted.