### PR TITLE
expose chainbase's new "reclaimable" memory in `db_size_api`

### DIFF
--- a/docs/01_nodeos/03_plugins/db_size_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/db_size_api_plugin/index.md
@@ -4,6 +4,7 @@ The `db_size_api_plugin` retrieves analytics about the blockchain.
 
 * free_bytes
 * used_bytes
+* reclaimable_bytes
 * size
 * indices
 

--- a/plugins/db_size_api_plugin/db_size_api_plugin.cpp
+++ b/plugins/db_size_api_plugin/db_size_api_plugin.cpp
@@ -39,6 +39,7 @@ db_size_stats db_size_api_plugin::get() {
    ret.free_bytes = db.get_segment_manager()->get_free_memory();
    ret.size = db.get_segment_manager()->get_size();
    ret.used_bytes = ret.size - ret.free_bytes;
+   ret.reclaimable_bytes = db.get_reclaimable_memory();
 
    chainbase::database::database_index_row_count_multiset indices = db.row_count_per_index();
    for(const auto& i : indices)

--- a/plugins/db_size_api_plugin/include/eosio/db_size_api_plugin/db_size_api_plugin.hpp
+++ b/plugins/db_size_api_plugin/include/eosio/db_size_api_plugin/db_size_api_plugin.hpp
@@ -17,6 +17,7 @@ struct db_size_index_count {
 struct db_size_stats {
    uint64_t                    free_bytes = 0;
    uint64_t                    used_bytes = 0;
+   uint64_t                    reclaimable_bytes = 0;
    uint64_t                    size = 0;
    vector<db_size_index_count> indices;
 };
@@ -45,4 +46,4 @@ private:
 }
 
 FC_REFLECT( eosio::db_size_index_count, (index)(row_count) )
-FC_REFLECT( eosio::db_size_stats, (free_bytes)(used_bytes)(size)(indices) )
+FC_REFLECT( eosio::db_size_stats, (free_bytes)(used_bytes)(reclaimable_bytes)(size)(indices) )


### PR DESCRIPTION
As of Leap 3.1, chainbase has not just the boost interprocess allocator (`segment_manager`) but also `chainbase_node_allocator` was is layered on top of the `segment_manager`. Both of these allocators maintain their own free list. But since `chainbase_node_allocator` sits on top of `segment_manager`, the memory tied up in `chainbase_node_allocator`'s free list is considered used memory from the perspective of `segment_manager`.

The `chainbase_node_allocator` isn't used for everything, for example it's not used for the CoW strings. So various bits of code interface with the top layer but then other bits of code the bottom layer.

And the `db_size_api` is looking at free memory in the bottom layer. That is, when `db_size_api` reports the free bytes it's reporting from the perspective of the bottom allocator even though the top allocator may have an extensive free list that would be used first for allocations against it. This can create some confusing and/or deceptive reports of memory usage.

To help provide some visibility to this "used from perspective of bottom layer but free from perspective of top layer" memory, add a new field to `db_size_api`'s response which is the total amount of memory in the top layer's free list. I've called this 'reclaimable' memory as a differentiator.

Some other options I considered:

Don't have a new field in`db_size_api`'s response but instead consider the top allocator's free list as part of the existing `free`/`used` counts. The problem with this is that the bottom allocator's free memory is what governs nodeos falling over. So it would be deceptive to return, in an extreme example, 4GB of free memory but really only 256MB of that is free from the perspective of the bottom allocator (since some allocations do go directly to the bottom allocator).

Don't allow `chainbase_node_allocator`'s free list to grow limitless as it can now. This was my first preference. However `chainbase_node_allocator` allocates chunks of 64 items from the bottom allocator which means those chunks would need to be freed as a whole. Pretty much impossible. So instead `chainbase_node_allocator` would need to allocate 1-by-1 from the bottom allocator, but I'm unsure the time and space penalty for doing that. Without further research it would not be a change I'd blindly make.

Needs AntelopeIO/chainbase#51