### PR TITLE
also add `BOOST_UNORDERED_DISABLE_NEON` for users of libtester

### DIFF
--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -35,6 +35,8 @@ else ( APPLE )
    set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -Wall")
 endif ( APPLE )
 
+add_compile_definitions(BOOST_UNORDERED_DISABLE_NEON)
+
 set( Boost_USE_MULTITHREADED      ON )
 set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 set( BOOST_EXCLUDE_LIBRARIES "mysql" )

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -32,6 +32,8 @@ else ( APPLE )
    set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -Wall")
 endif ( APPLE )
 
+add_compile_definitions(BOOST_UNORDERED_DISABLE_NEON)
+
 set( Boost_USE_MULTITHREADED      ON )
 set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 set( BOOST_EXCLUDE_LIBRARIES "mysql" )


### PR DESCRIPTION
Follow up to #519. I think we probably need to do this or run the risk of ODR violations (on ARM) if something else uses `boost::unordered` as part of the external test compilation. It's also possible it's already a ODR violation as-is since `apply_context.hpp` -- exposed as public libtester interface -- does a `#include <boost/unordered/unordered_flat_map.hpp>`. (I admit to not looking at `unordered`'s impl yet to know if this ODR violation theory is possible or not, but seems like this is right thing to do -- it's possible original reporter in #517 will need it anyways to compile their external tests)