### PR TITLE
Do not log "no votes" for non-savanna blocks

### DIFF
--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -28,6 +28,8 @@ namespace eosio::chain_apis {
       // QC in the block and store it in last_votes.
       void on_accepted_block( const chain::signed_block_ptr& block, const chain::block_id_type& id ) {
          try {
+            if (!block->is_proper_svnn_block())
+               return;
             if (!tracking_enabled && !chain::vote_logger.is_enabled(fc::log_level::info))
                return;
 


### PR DESCRIPTION
No need to track votes for legacy blocks.

Resolves #539 