### PR TITLE
[1.0 -> main] Better logging for aggregate_vote failure and add logging for proposer policy becoming active

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -338,9 +338,9 @@ void finish_next(const block_header_state& prev,
 
       if (next_header_state.active_finalizer_policy != prev.active_finalizer_policy) {
          const auto& act = next_header_state.active_finalizer_policy;
-         dlog("Finalizer policy generation change: ${old_gen} -> ${new_gen}",
+         ilog("Finalizer policy generation change: ${old_gen} -> ${new_gen}",
               ("old_gen", prev.active_finalizer_policy->generation)("new_gen",act->generation));
-         dlog("New finalizer policy becoming active in block ${n}:${id}: ${pol}",
+         ilog("New finalizer policy becoming active in block ${n}:${id}: ${pol}",
               ("n",block_header::num_from_id(id))("id", id)("pol", *act));
       }
 

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -344,7 +344,7 @@ void finish_next(const block_header_state& prev,
               ("n",block_header::num_from_id(id))("id", id)("pol", *act));
       }
 
-      if (next_header_state.active_proposer_policy != prev.active_proposer_policy) {
+      if (next_header_state.active_proposer_policy->proposer_schedule.version != prev.active_proposer_policy->proposer_schedule.version) {
          const auto& act = next_header_state.active_proposer_policy;
          dlog("Proposer policy version change: ${old_ver} -> ${new_ver}",
               ("old_ver", prev.active_proposer_policy->proposer_schedule.version)("new_ver",act->proposer_schedule.version));

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -338,9 +338,17 @@ void finish_next(const block_header_state& prev,
 
       if (next_header_state.active_finalizer_policy != prev.active_finalizer_policy) {
          const auto& act = next_header_state.active_finalizer_policy;
-         ilog("Finalizer policy generation change: ${old_gen} -> ${new_gen}",
+         dlog("Finalizer policy generation change: ${old_gen} -> ${new_gen}",
               ("old_gen", prev.active_finalizer_policy->generation)("new_gen",act->generation));
-         ilog("New finalizer policy becoming active in block ${n}:${id}: ${pol}",
+         dlog("New finalizer policy becoming active in block ${n}:${id}: ${pol}",
+              ("n",block_header::num_from_id(id))("id", id)("pol", *act));
+      }
+
+      if (next_header_state.active_proposer_policy != prev.active_proposer_policy) {
+         const auto& act = next_header_state.active_proposer_policy;
+         dlog("Proposer policy version change: ${old_ver} -> ${new_ver}",
+              ("old_ver", prev.active_proposer_policy->proposer_schedule.version)("new_ver",act->proposer_schedule.version));
+         dlog("New proposer policy becoming active in block ${n}:${id}: ${pol}",
               ("n",block_header::num_from_id(id))("id", id)("pol", *act));
       }
    }

--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -177,7 +177,7 @@ void block_state::set_trxs_metas( deque<transaction_metadata_ptr>&& trxs_metas, 
 // Called from vote threads
 aggregate_vote_result_t block_state::aggregate_vote(uint32_t connection_id, const vote_message& vote) {
    auto finalizer_digest = vote.strong ? strong_digest.to_uint8_span() : std::span<const uint8_t>(weak_digest);
-   return aggregating_qc.aggregate_vote(connection_id, vote, block_num(), finalizer_digest);
+   return aggregating_qc.aggregate_vote(connection_id, vote, block_id, finalizer_digest);
 }
 
 // Only used for testing

--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -258,7 +258,7 @@ namespace eosio::chain {
       bool set_received_qc(const qc_t& qc);
       bool received_qc_is_strong() const;
       aggregate_vote_result_t aggregate_vote(uint32_t connection_id, const vote_message& vote,
-                                             block_num_type block_num, std::span<const uint8_t> finalizer_digest);
+                                             const block_id_type& block_id, std::span<const uint8_t> finalizer_digest);
       vote_status_t has_voted(const bls_public_key& key) const;
       bool is_quorum_met() const;
 


### PR DESCRIPTION
* Log detailed information when verify_sig fails, including block ID, vote strong or weak.
* Add debug logging when  proposer policy becoming active
```
debug 2024-08-15T12:53:57.365 unit_test block_header_state.cpp:349    finish_next          ] Proposer  policy version change: 0 -> 2
debug 2024-08-15T12:53:57.365 unit_test block_header_state.cpp:351    finish_next          ] New       proposer policy becoming active in block 37:                                                           0000002553a993a7e5895478dd02d8b67716476ca7df7cd78cf221752787f233: {"proposal_time":"2020-  01-01T00:00:11.500","proposer_schedule":{"version":2,"producers":[{"producer_name":"bob",  "authority":[0,         {"threshold":1,"keys":[{"key":                                                                         "EOS5mF6KuJY8NgNqzKS4oUjoq2q6n3txkprAhtjLb1gyi7nJ7QZLD","weight":1}]}]}]}}
```