### PR TITLE
[1.0 -> main] Remove unnecessary code that cannot be executed.Gh 534 2 main

### DIFF
--- a/libraries/chain/finality/finalizer.cpp
+++ b/libraries/chain/finality/finalizer.cpp
@@ -32,16 +32,13 @@ finalizer::vote_result finalizer::decide_vote(const block_state_ptr& bsp) {
       // This allows restoration of liveness if a replica is locked on a stale proposal
       // -------------------------------------------------------------------------------
       res.liveness_check = bsp->core.latest_qc_block_timestamp() > fsi.lock.timestamp;
-      if (!res.liveness_check) {
-         // might be locked on an old timestamp if finalizer was active in the past and is now active again
-         res.liveness_check = bsp->core.last_final_block_timestamp() >= fsi.lock.timestamp;
-      }
 
       if (!res.liveness_check) {
          fc_ilog(vote_logger, "liveness check failed, block ${bn} ${id}: ${c} <= ${l}, fsi.lock ${lbn} ${lid}, latest_qc_claim: ${qc}",
                  ("bn", bsp->block_num())("id", bsp->id())("c", bsp->core.latest_qc_block_timestamp())("l", fsi.lock.timestamp)
                  ("lbn", fsi.lock.block_num())("lid", fsi.lock.block_id)
                  ("qc", bsp->core.latest_qc_claim()));
+
          // Safety check : check if this proposal extends the proposal we're locked on
          res.safety_check = bsp->core.extends(fsi.lock.block_id);
          if (!res.safety_check) {


### PR DESCRIPTION
As described in issue https://github.com/AntelopeIO/spring/issues/534 (3rd `small things` at the end), we have a small test that cannot possibly be true, so this PR removes that dead code.