### PR TITLE
[1.0 -> main] Add changes required for updating to boost 1.86 - but without the boost upgrade

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -149,6 +149,7 @@ add_library( eosio_chain
 ## Boost::accumulators depends on Boost::numeric_ublas, which is still missing cmake support (see
 ## https://github.com/boostorg/cmake/issues/39). Until this is fixed, manually add Boost::numeric_ublas
 ## as an interface library
+##        ** Remove the two lines below when upgrading to Boost 1.86 or above **
 ## ----------------------------------------------------------------------------------------------------
 add_library(boost_numeric_ublas INTERFACE)
 add_library(Boost::numeric_ublas ALIAS boost_numeric_ublas)
@@ -156,7 +157,7 @@ add_library(Boost::numeric_ublas ALIAS boost_numeric_ublas)
 target_link_libraries( eosio_chain PUBLIC bn256 fc chainbase eosio_rapidjson Logging IR WAST WASM
                        softfloat builtins ${CHAIN_EOSVM_LIBRARIES} ${LLVM_LIBS} ${CHAIN_RT_LINKAGE}
                        Boost::signals2 Boost::hana Boost::property_tree Boost::multi_index Boost::asio Boost::lockfree
-                       Boost::assign Boost::accumulators
+                       Boost::assign Boost::accumulators Boost::rational
                      )
 target_include_directories( eosio_chain
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include"

--- a/plugins/net_plugin/include/eosio/net_plugin/net_utils.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <eosio/chain/exceptions.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 
 #include <string>
 #include <sstream>

--- a/programs/cleos/CMakeLists.txt
+++ b/programs/cleos/CMakeLists.txt
@@ -13,7 +13,7 @@ set(LOCALEDOMAIN ${CLI_CLIENT_EXECUTABLE_NAME})
 target_include_directories(${CLI_CLIENT_EXECUTABLE_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries( ${CLI_CLIENT_EXECUTABLE_NAME}
-                       PRIVATE appbase version spring-cli11 chain_api_plugin producer_plugin chain_plugin http_plugin eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} Boost::process Boost::dll )
+                       PRIVATE appbase version spring-cli11 chain_api_plugin producer_plugin chain_plugin http_plugin eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} Boost::process Boost::dll Boost::format )
 
 if (CURL_FOUND)
   target_sources(${CLI_CLIENT_EXECUTABLE_NAME} PRIVATE do_http_post_libcurl.cpp)

--- a/tests/trx_generator/http_client_async.hpp
+++ b/tests/trx_generator/http_client_async.hpp
@@ -104,7 +104,7 @@ class session : public std::enable_shared_from_this<session> {
       });
    }
 
-   void on_connect(beast::error_code ec, tcp::resolver::results_type::endpoint_type) {
+   void on_connect(beast::error_code ec, const auto&) {
       if (ec) {
          response_callback_(ec, {});
          return fail(ec, "connect");


### PR DESCRIPTION
Merge changes from `release/1.0` which allow to use newer boost versions.