### PR TITLE
[1.0] Normally process blocks from the forkdb on startup

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1766,10 +1766,18 @@ struct controller_impl {
          using BSP = std::decay_t<decltype(forkdb.root())>;
 
          auto pending_head = forkdb.head();
+         auto root = forkdb.root();
+         if( pending_head ) {
+            ilog("fork database size ${s} head ${hn} : ${h}, root ${rn} : ${r}",
+                 ("s", forkdb.size())("hn", pending_head->block_num())("h", pending_head->id())
+                 ("rn", root->block_num())("r", root->id()));
+         } else if (root) {
+            ilog("fork database has no pending blocks root ${rn} : ${r}",
+                 ("rn", root->block_num())("r", root->id()));
+         } else {
+            ilog("fork database empty, no pending or root");
+         }
          if( pending_head && blog_head && start_block_num <= blog_head->block_num() ) {
-            ilog("fork database head ${hn}:${h}, root ${rn}:${r}",
-                 ("hn", pending_head->block_num())("h", pending_head->id())
-                 ("rn", forkdb.root()->block_num())("r", forkdb.root()->id()));
             if( pending_head->block_num() < chain_head.block_num() || chain_head.block_num() < forkdb.root()->block_num() ) {
                ilog( "resetting fork database with new last irreversible block as the new root: ${id}", ("id", chain_head.id()) );
                fork_db_reset_root_to_chain_head();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -104,6 +104,7 @@ namespace eosio::chain {
             uint32_t                 maximum_variable_signature_length = chain::config::default_max_variable_signature_length;
             bool                     disable_all_subjective_mitigations = false; //< for developer & testing purposes, can be configured using `disable-all-subjective-mitigations` when `EOSIO_DEVELOPER` build option is provided
             uint32_t                 terminate_at_block     = 0;
+            uint32_t                 num_configured_p2p_peers = 0;
             bool                     integrity_hash_on_start= false;
             bool                     integrity_hash_on_stop = false;
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -675,6 +675,8 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
       if( options.count( "terminate-at-block" ))
          chain_config->terminate_at_block = options.at( "terminate-at-block" ).as<uint32_t>();
 
+      chain_config->num_configured_p2p_peers = options.count( "p2p-peer-address" );
+
       // move fork_db to new location
       upgrade_from_reversible_to_fork_db( this );
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2224,6 +2224,8 @@ namespace eosio {
          set_state( lib_catchup );
          sync_last_requested_num = 0;
          sync_next_expected_num = chain_info.lib_num + 1;
+      } else if (sync_next_expected_num >= sync_last_requested_num) {
+         // break
       } else {
          peer_dlog(c, "already syncing, start sync ignored");
          return;

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -345,20 +345,25 @@ class Node(Transactions):
             if logStatus: Utils.Print(f'Determined node id {self.nodeId} (pid={pid}) is alive')
             return True
 
-    def rmFromCmd(self, matchValue: str):
-        '''Removes all instances of matchValue from cmd array and succeeding value if it's an option value string.'''
+    def rmFromCmd(self, matchValue: str) -> str:
+        '''Removes all instances of matchValue from cmd array and succeeding value if it's an option value string.
+           Returns the removed strings as a space-delimited string.'''
         if not self.cmd:
-            return
+            return ''
+
+        removed_items = []
 
         while True:
             try:
                 i = self.cmd.index(matchValue)
-                self.cmd.pop(i)
+                removed_items.append(self.cmd.pop(i))  # Store the matchValue
                 if len(self.cmd) > i:
-                    if self.cmd[i][0] != '-':
-                        self.cmd.pop(i)
+                    if self.cmd[i][0] != '-':  # Check if the next value isn't an option (doesn't start with '-')
+                        removed_items.append(self.cmd.pop(i))  # Store the succeeding value
             except ValueError:
                 break
+
+        return ' '.join(removed_items)  # Return the removed strings as a space-delimited string
 
     # pylint: disable=too-many-locals
     # If nodeosPath is equal to None, it will use the existing nodeos path

--- a/tests/nodeos_read_terminate_at_block_test.py
+++ b/tests/nodeos_read_terminate_at_block_test.py
@@ -345,6 +345,18 @@ try:
             if not success:
                 break
 
+    # Test nodes can restart and advance lib
+    if not cluster.biosNode.relaunch():
+        Utils.errorExit("Unable to restart bios node")
+
+    if not producingNode.relaunch():
+        Utils.errorExit("Unable to restart producing node")
+
+    if success:
+        for nodeId, nodeArgs in {**regularNodeosArgs, **replayNodeosArgs}.items():
+            assert cluster.getNode(nodeId).relaunch(), f"Unable to relaunch {nodeId}"
+            assert cluster.getNode(nodeId).waitForLibToAdvance(), f"LIB did not advance for {nodeId}"
+
     testSuccessful = success
 
     Utils.Print("Script End ................................")


### PR DESCRIPTION
In Spring 1.0.0, unlike Leap, we process blocks into the fork database immediately. This can cause the fork database to grow very large when syncing and shutdown due to hitting the new `max-reversible-blocks` limit (before #545). When a node is shutdown, in Leap, it was assumed that when restarting a node if that node did not receive any blocks from the network it would be at the same height as when it was shutdown. The existing `tests/nodeos_read_terminate_at_block_test.py` integration test verifies this behavior.

However, if the node shutdown because of `max-reversible-blocks` you would like on restart for the node to process blocks out of the fork database potentially allowing LIB to progress and reversible blocks to be consumed and shrink in size. This is at odds with the expected behavior of a node starting up after a `terminate-at-block`. A user might find it very odd to terminate a node at a block, but find on restart that the node is actually beyond that block.

To fix the issue reported in #565, we would like to process blocks out of the fork database on restart. However, we want to maintain the existing expectations of starting a node after a shutdown via `terminate-at-block` being at the same block height on restart. 

Therefore, this PR modifies nodeos to normally process blocks out of the fork database on startup unless the node has no configured peers. The idea being that if a user has terminated a node with `terminate-at-block` and wants the node to remain at that block, they will restart the node without any `p2p-peer-address` configured. This is a bit of a hack until #570 can be added. Since #570 is a new feature, it will not come until a future release and will not be part of Spring 1.0.0.

Resolves #565 