### PR TITLE
Implement last three  Savanna unittests modeled after the fast testnet wave tests. 

### DIFF
--- a/unittests/savanna_cluster.cpp
+++ b/unittests/savanna_cluster.cpp
@@ -27,10 +27,11 @@ node_t::node_t(size_t node_idx, cluster_t& cluster, setup_policy policy /* = set
       }
    };
 
-   auto node_initialization_fn = [&]() {
+   auto node_initialization_fn = [&, node_idx]() {
       [[maybe_unused]] auto _a = control->voted_block().connect(voted_block_cb);
       [[maybe_unused]] auto _b = control->accepted_block().connect(accepted_block_cb);
       tester::set_node_finalizers(node_finalizers);
+      cluster.get_new_blocks_from_peers(node_idx);
    };
 
    node_initialization_fn();                  // initialize the node when it is first created

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -59,6 +59,7 @@ namespace savanna_cluster {
 
       std::function<void(const block_signal_params&)> accepted_block_cb;
       std::function<void(const vote_signal_params&)>  voted_block_cb;
+
    public:
       std::vector<account_name> node_finalizers;
 
@@ -141,10 +142,12 @@ namespace savanna_cluster {
       }
 
       void push_block(const signed_block_ptr& b) {
-         assert(!pushing_a_block);
-         pushing_a_block = true;
-         auto reset_pending_on_exit = fc::make_scoped_exit([this]{ pushing_a_block = false; });
-         tester::push_block(b);
+         if (is_open() && !fetch_block_by_id(b->calculate_id())) {
+            assert(!pushing_a_block);
+            pushing_a_block = true;
+            auto reset_pending_on_exit = fc::make_scoped_exit([this]{ pushing_a_block = false; });
+            tester::push_block(b);
+         }
       }
 
       template <class Node>
@@ -419,7 +422,7 @@ namespace savanna_cluster {
       // -----------------------------------------------------------------------------
       void push_blocks(size_t src_idx, size_t dst_idx, uint32_t start_block_num) {
          auto& src = _nodes[src_idx];
-         assert(src.is_open() &&  _nodes[dst_idx].is_open());
+         assert(src.is_open() && _nodes[dst_idx].is_open());
 
          auto end_block_num   = src.fork_db_head().block_num();
 
@@ -464,26 +467,35 @@ namespace savanna_cluster {
       void dispatch_vote_to_peers(size_t node_idx, skip_self_t skip_self, const vote_message_ptr& msg) {
          static uint32_t connection_id = 0;
          for_each_peer(node_idx, skip_self, [&](node_t& n) {
-            n.control->process_vote_message(++connection_id, msg);
+            if (n.is_open())
+               n.control->process_vote_message(++connection_id, msg);
          });
       }
 
       void push_block_to_peers(size_t node_idx, skip_self_t skip_self, const signed_block_ptr& b) {
          for_each_peer(node_idx, skip_self, [&](node_t& n) {
-            if (!n.fetch_block_by_id(b->calculate_id()))
-               n.push_block(b);
+            n.push_block(b);
+         });
+      }
+
+      // when a node restarts, simulate receiving newly produced blocks from peers
+      void get_new_blocks_from_peers(size_t node_idx) {
+         assert(_nodes[node_idx].is_open());
+         for_each_peer(node_idx, skip_self_t::yes, [&](node_t& n) {
+            if (n.is_open())
+               n.push_blocks_to(_nodes[node_idx]);
          });
       }
 
       template<class CB>
       void for_each_peer(size_t node_idx, skip_self_t skip_self, const CB& cb) {
-         if (_shutting_down)
+         if (_shutting_down || _peers.empty())
             return;
          assert(_peers.find(node_idx) != _peers.end());
          const auto& peers = _peers[node_idx];
          for (auto i : peers) {
             bool dont_skip = skip_self == skip_self_t::no || i != node_idx;
-            if (dont_skip && _nodes[i].is_open())
+            if (dont_skip)
                cb(_nodes[i]);
          }
       }

--- a/unittests/savanna_cluster_tests.cpp
+++ b/unittests/savanna_cluster_tests.cpp
@@ -54,7 +54,7 @@ BOOST_FIXTURE_TEST_CASE(simple_test, savanna_cluster::cluster_t) { try {
       // all 4 blocks produced by _nodes[0] will have the same `latest_qc_claim_block_num`, which is node0_lib+2
 
       set_partition({});                                    // Reunite the two partitions
-      push_blocks(0, partition);                            // Push the blocks that _nodes[0] produced to the other
+      propagate_heads();                                    // Push the blocks that _nodes[0] produced to the other
                                                             // nodes which will vote
       _nodes[0].produce_block();                            // Produce one block so the newly produced QC propagates.
                                                             // this is needed because we don't advance lib when

--- a/unittests/savanna_finalizer_policy_tests.cpp
+++ b/unittests/savanna_finalizer_policy_tests.cpp
@@ -32,7 +32,7 @@ BOOST_FIXTURE_TEST_CASE(policy_change, savanna_cluster::cluster_t) try {
       A.produce_block();
       ++num_to_pending;
    } while (!A.head_pending_finalizer_policy());
-   BOOST_REQUIRE_EQUAL(num_to_pending, num_chains_to_final); // becames pending when proposed block is final
+   BOOST_REQUIRE_EQUAL(num_to_pending, num_chains_to_final); // becomes pending when proposed block is final
 
    // now that the new policy is pending, we need B to vote on it for finality to advance, as C is down.
    // --------------------------------------------------------------------------------------------------
@@ -96,7 +96,7 @@ BOOST_FIXTURE_TEST_CASE(policy_change_including_weight_and_threshold, savanna_cl
       A.produce_block();
       ++num_to_pending;
    } while (!A.head_pending_finalizer_policy());
-   BOOST_REQUIRE_EQUAL(num_to_pending, num_chains_to_final); // becames pending when proposed block is final
+   BOOST_REQUIRE_EQUAL(num_to_pending, num_chains_to_final); // becomes pending when proposed block is final
 
    // verify that lib stops advancing (because C is down so we can't get a QC on the pending policy
    // which needs three C votes)
@@ -170,7 +170,7 @@ BOOST_FIXTURE_TEST_CASE(policy_change_reduce_threshold_replace_all_keys, savanna
       A.produce_block();
       ++num_to_pending;
    } while (!A.head_pending_finalizer_policy());
-   BOOST_REQUIRE_EQUAL(num_to_pending, num_chains_to_final); // becames pending when proposed block is final
+   BOOST_REQUIRE_EQUAL(num_to_pending, num_chains_to_final); // becomes pending when proposed block is final
 
    // produce blocks on A, waiting for the new policy to become final
    // ---------------------------------------------------------------

--- a/unittests/savanna_finalizer_policy_tests.cpp
+++ b/unittests/savanna_finalizer_policy_tests.cpp
@@ -6,7 +6,7 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_SUITE(savanna_finalizer_policy)
 
 // ---------------------------------------------------------------------------------------------------
-//
+//     Policy change - new key on one node - node shutdown and restarted while policy pending
 // ---------------------------------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(policy_change, savanna_cluster::cluster_t) try {
    auto& A=_nodes[0]; auto& B=_nodes[1]; auto& C=_nodes[2];
@@ -66,6 +66,72 @@ BOOST_FIXTURE_TEST_CASE(policy_change, savanna_cluster::cluster_t) try {
    // --------------------------------------
    BOOST_REQUIRE_EQUAL(3u, A.lib_advances_by([&]() { A.produce_blocks(3); }));
 } FC_LOG_AND_RETHROW()
+
+// ---------------------------------------------------------------------------------------------------
+//                           Policy change including weight and threshold
+// ---------------------------------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(policy_change_including_weight_and_threshold, savanna_cluster::cluster_t) try {
+   auto& A=_nodes[0]; auto& B=_nodes[1]; auto& C=_nodes[2]; auto& D=_nodes[3];
+   auto initial_gen = A.head_active_finalizer_policy()->generation;
+
+   C.close();
+
+   // verify that lib still advances (since threshold is 3)
+   // -----------------------------------------------------
+   BOOST_REQUIRE_EQUAL(2u, A.lib_advances_by([&]() { A.produce_blocks(2); }));
+
+   // update finalizer_policy, so that C's weight is 3, B and D are removed, and the threshold is 4
+   // ---------------------------------------------------------------------------------------------
+   base_tester::finalizer_policy_input input;
+   input.finalizers.emplace_back(_fin_keys[0], 1);
+   input.finalizers.emplace_back(_fin_keys[2], 3);
+   input.threshold = 4;
+   A.set_finalizers(input);
+   A.produce_block();                                   // so the block with `set_finalizers` is `head`
+
+   // produce blocks on A, waiting for the new policy to become pending
+   // -----------------------------------------------------------------
+   BOOST_REQUIRE(!A.head_pending_finalizer_policy());     // we shouldn't have a pending policy
+   size_t num_to_pending = 0;
+   do {
+      A.produce_block();
+      ++num_to_pending;
+   } while (!A.head_pending_finalizer_policy());
+   BOOST_REQUIRE_EQUAL(num_to_pending, num_chains_to_final); // becames pending when proposed block is final
+
+   // verify that lib stops advancing (because C is down so we can't get a QC on the pending policy
+   // which needs three C votes)
+   // ---------------------------------------------------------------------------------------------
+   BOOST_REQUIRE_EQUAL(0u, A.lib_advances_by([&]() { A.produce_blocks(2); }));
+
+   // restart C.
+   // ---------
+   C.open();
+   A.push_blocks_to(C);
+
+   // produce blocks on A, waiting for transition to complete (until the updated policy is active on A's head)
+   // --------------------------------------------------------------------------------------------------------
+   auto finpol = A.head_active_finalizer_policy();
+   size_t num_to_active = 0;
+   do {
+      A.produce_block();
+      finpol = A.head_active_finalizer_policy();
+      ++num_to_active;
+   } while (finpol->generation != initial_gen+1);
+   BOOST_REQUIRE_EQUAL(num_to_active, num_chains_to_final); // becomes active when "pending" block is final
+
+   BOOST_REQUIRE_EQUAL(2u, A.lib_advances_by([&]() { A.produce_blocks(2); }));
+
+   // shutdown B and D which are not used in new policy.
+   // A produces 2 blocks, verify that *lib* advances by 2
+   // ----------------------------------------------------
+   B.close();
+   D.close();
+   BOOST_REQUIRE_EQUAL(2u, A.lib_advances_by([&]() { A.produce_blocks(2); }));
+
+} FC_LOG_AND_RETHROW()
+
+
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/savanna_finalizer_policy_tests.cpp
+++ b/unittests/savanna_finalizer_policy_tests.cpp
@@ -106,7 +106,6 @@ BOOST_FIXTURE_TEST_CASE(policy_change_including_weight_and_threshold, savanna_cl
    // restart C.
    // ---------
    C.open();
-   A.push_blocks_to(C);
 
    // produce blocks on A, waiting for transition to complete (until the updated policy is active on A's head)
    // --------------------------------------------------------------------------------------------------------
@@ -251,7 +250,6 @@ BOOST_FIXTURE_TEST_CASE(policy_change_restart_from_snapshot, savanna_cluster::cl
    // restart C from the snapshot
    // ---------------------------
    C.open_from_snapshot(snapshot_C);
-   A.push_blocks_to(C);
 
    // A produces 4 blocks, verify that the new policy is active and *lib* starts advancing again
    // ------------------------------------------------------------------------------------------

--- a/unittests/savanna_transition_tests.cpp
+++ b/unittests/savanna_transition_tests.cpp
@@ -151,7 +151,6 @@ BOOST_FIXTURE_TEST_CASE(restart_from_snapshot_at_beginning_of_transition_while_p
 
    for (auto& N : failing_nodes) {
       N->open_from_snapshot(snapshot_C);
-      A.push_blocks_to(*N);
    }
 
    // A produces blocks until we reach the critical block (i.e. until lib advances past the genesis block)
@@ -253,7 +252,6 @@ BOOST_FIXTURE_TEST_CASE(restart_from_snapshot_at_end_of_transition_while_preserv
 
    for (auto& N : failing_nodes) {
       N->open_from_snapshot(snapshot_C);
-      A.push_blocks_to(*N);
    }
 
    // with partition gone, transition to Savanna will complete and lib will start advancing again
@@ -331,7 +329,6 @@ BOOST_FIXTURE_TEST_CASE(restart_from_snapshot_at_beginning_of_transition_with_lo
 
    for (auto& N : failing_nodes) {
       N->open_from_snapshot(snapshot_C);
-      A.push_blocks_to(*N);
    }
 
    // A produces blocks until we reach the critical block (i.e. until lib advances past the genesis block)


### PR DESCRIPTION
Resolves #380.

This PR implements the last three Savanna unittests modeled after the fast testnet wave tests (the finalizer transition tests). Merging this PR will finally close issue #380.

It also updates the `savanna_cluster` test class to automatically get new blocks from connected peers on node startup, which alleviates the need to call `push_block_to()` in tests after restarting a node.