### PR TITLE
[1.0 -> main] Verify chain_head.dat does not exist on snapshot load

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -789,9 +789,12 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
                      "--snapshot is incompatible with --genesis-json as the snapshot contains genesis information");
 
          auto shared_mem_path = chain_config->state_dir / "shared_memory.bin";
-         EOS_ASSERT( !std::filesystem::is_regular_file(shared_mem_path),
-                 plugin_config_exception,
-                 "Snapshot can only be used to initialize an empty database." );
+         auto chain_head_path = chain_config->state_dir / chain_head_filename;
+         EOS_ASSERT(!std::filesystem::is_regular_file(shared_mem_path) &&
+                    !std::filesystem::is_regular_file(chain_head_path),
+                    plugin_config_exception,
+                    "Snapshot can only be used to initialize an empty database, remove directory: ${d}",
+                    ("d", chain_config->state_dir.generic_string()));
 
          auto block_log_chain_id = block_log::extract_chain_id(blocks_dir, retained_dir);
 


### PR DESCRIPTION
Spring verifies that `shared_memory.bin` does not exist when loading a snapshot. Also verify `chain_head.dat` does not exist when loading a snapshot.

```
warn  2024-08-19T11:32:37.908 nodeos    chain_plugin.cpp:1111         plugin_initialize    ] 3110006 plugin_config_exception: Incorrect plugin configuration
Snapshot can only be used to initialize an empty database, remove directory: /home/heifner/ext/leap/cmake-build-debug/bin/spring-testnet4-data/state
    {"d":"/home/heifner/ext/leap/cmake-build-debug/bin/spring-testnet4-data/state"}
    nodeos  chain_plugin.cpp:797 plugin_initialize

appbase: exception thrown during plugin "eosio::chain_plugin" initialization.
Incorrect plugin configuration
info  2024-08-19T11:32:37.909 nodeos    main.cpp:165                  operator()           ] nodeos version v1.0.0-rc1 v1.0.0-rc1-4c48ac7de86201d4b25a1e0e2d24cdb4c741efbb-dirty
info  2024-08-19T11:32:37.909 nodeos    main.cpp:69                   log_non_default_opti ] Non-default options: data-dir = spring-testnet4-data, config-dir = spring-testnet4, snapshot = snapshot-spring-8543320-2024-26-07_06-00.bin, chain-state-db-size-mb = 32000, http-server-address = 127.0.0.1:8899, p2p-listen-endpoint = 0.0.0.0:9899:0, signature-provider = EOS7GQpG7KWgw7FaFDnkua1LadP71nF1kVqAXZ5uD8apE3gUoCxX4=KEY:***, signature-provider = PUB_BLS_MEiD85FQ_7-WMBno5xit7-kHcCaJak7UVtcFQayDfneJCQT1mleNd-FQ9kBRHL4A_kHg41rEjhHXlfiH0GWqB2PP6mRUBR_wiFwOsO8lKUtDa_mBjtGSUVIo2sQWKDMGjEGASA=KEY:***, producer-name = zombiezombie, p2p-peer-address = p2p.spring-beta4.jungletestnet.io:9898, p2p-peer-address = 3.227.1.63:1444, p2p-peer-address = savanna.genereos.io:9876, p2p-peer-address = jungleb4.maroonspoon.com:9876, p2p-peer-address = p2p.spring-beta.jungletestnet.io:9898
error 2024-08-19T11:32:37.909 nodeos    main.cpp:224                  main                 ] 3110006 plugin_config_exception: Incorrect plugin configuration
Snapshot can only be used to initialize an empty database, remove directory: /home/heifner/ext/leap/cmake-build-debug/bin/spring-testnet4-data/state
    {"d":"/home/heifner/ext/leap/cmake-build-debug/bin/spring-testnet4-data/state"}
    nodeos  chain_plugin.cpp:797 plugin_initialize
rethrow
    {}
    nodeos  chain_plugin.cpp:1111 plugin_initialize
```

Merges `release/1.0` into `main` including #581 

Resolves #559 