### PR TITLE
[1.0 -> main] Fix logging of legacy proposer schedule

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3189,18 +3189,17 @@ struct controller_impl {
                 pbhs.prev_pending_schedule.schedule.producers.size() == 0 // ... and there was room for a new pending schedule prior to any possible promotion
                )
             {
-               // Promote proposed schedule to pending schedule.
-               if( !replaying ) {
-                  ilog( "promoting proposed schedule (set in block ${proposed_num}) to pending; current block: ${n} lib: ${lib} schedule: ${schedule} ",
-                        ("proposed_num", *gpo.proposed_schedule_block_num)("n", pbhs.block_num)
-                        ("lib", pbhs.dpos_irreversible_blocknum)
-                        ("schedule", bb_legacy.new_pending_producer_schedule ) );
-               }
-
                EOS_ASSERT( gpo.proposed_schedule.version == pbhs.active_schedule_version + 1,
                            producer_schedule_exception, "wrong producer schedule version specified" );
 
+               // Promote proposed schedule to pending schedule.
                bb_legacy.new_pending_producer_schedule = producer_authority_schedule::from_shared(gpo.proposed_schedule);
+
+               if( !replaying ) {
+                  ilog( "promoting proposed schedule (set in block ${proposed_num}) to pending; current block: ${n} lib: ${lib} schedule: ${schedule} ",
+                        ("proposed_num", *gpo.proposed_schedule_block_num)("n", pbhs.block_num)
+                        ("lib", pbhs.dpos_irreversible_blocknum)("schedule", bb_legacy.new_pending_producer_schedule ) );
+               }
 
                db.modify( gpo, [&]( auto& gp ) {
                   gp.proposed_schedule_block_num = std::optional<block_num_type>();


### PR DESCRIPTION
The new pending producer schedule was being logged before it was set.

```
info  2024-08-19T11:07:18.890 nodeos    controller.cpp:3201           operator()           ] promoting proposed schedule (set in block 69) to pending; current block: 70 lib: 69 schedule: {"version":1,"producers":[{"producer_name":"defproducera","authority":[0,{"threshold":1,"keys":[{"key":"EOS58B33q9S7oNkgeFfcoW3VJYu4obfDiqn5RHGE2ige6jVjUhymR","weight":1}]}]},{"producer_name":"defproducerb","authority":[0,{"threshold":1,"keys":[{"key":"EOS5CbcTDgbks2ptTxvyCbT9HFbzX7PDHUY2wN4DDnVBhhQr2ZNDE","weight":1}]}]},{"producer_name":"defproducerc","authority":[0,{"threshold":1,"keys":[{"key":"EOS6Tkpf8kcDfa32WA9B4nTcEJ64ZdDMSNioDcaL6rzdMwnpzaWJB","weight":1}]}]},{"producer_name":"defproducerd","authority":[0,{"threshold":1,"keys":[{"key":"EOS52ntDHqA2qj4xVo7KmxdezMRhvvBqpZBuKYJCsgihisxmywpAx","weight":1}]}]}]} 
```

Merges `release/1.0` into `main` including #580 

Resolves #567