### PR TITLE
[1.0 -> main] Update max-reversible-blocks to only enforce savanna blocks

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1117,6 +1117,13 @@ struct controller_impl {
       return prev->block_num();
    }
 
+   // returns 0 for legacy
+   size_t fork_db_savanna_size() const {
+      return fork_db.apply_s<size_t>([&](const auto& forkdb) {
+         return forkdb.size();
+      });
+   }
+
    bool fork_db_block_exists( const block_id_type& id ) const {
       return fork_db.apply<bool>([&](const auto& forkdb) {
          return forkdb.block_exists(id);
@@ -4792,9 +4799,9 @@ struct controller_impl {
               ("n", reversible_block_num)("num", conf.terminate_at_block) );
          return true;
       }
-      if (conf.max_reversible_blocks > 0 && fork_db.size() >= conf.max_reversible_blocks) {
+      if (conf.max_reversible_blocks > 0 && fork_db_savanna_size() >= conf.max_reversible_blocks) {
          elog("Exceeded max reversible blocks allowed, fork db size ${s} >= max-reversible-blocks ${m}",
-              ("s", fork_db.size())("m", conf.max_reversible_blocks));
+              ("s", fork_db_savanna_size())("m", conf.max_reversible_blocks));
          return true;
       }
       return false;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3189,18 +3189,17 @@ struct controller_impl {
                 pbhs.prev_pending_schedule.schedule.producers.size() == 0 // ... and there was room for a new pending schedule prior to any possible promotion
                )
             {
-               // Promote proposed schedule to pending schedule.
-               if( !replaying ) {
-                  ilog( "promoting proposed schedule (set in block ${proposed_num}) to pending; current block: ${n} lib: ${lib} schedule: ${schedule} ",
-                        ("proposed_num", *gpo.proposed_schedule_block_num)("n", pbhs.block_num)
-                        ("lib", pbhs.dpos_irreversible_blocknum)
-                        ("schedule", bb_legacy.new_pending_producer_schedule ) );
-               }
-
                EOS_ASSERT( gpo.proposed_schedule.version == pbhs.active_schedule_version + 1,
                            producer_schedule_exception, "wrong producer schedule version specified" );
 
+               // Promote proposed schedule to pending schedule.
                bb_legacy.new_pending_producer_schedule = producer_authority_schedule::from_shared(gpo.proposed_schedule);
+
+               if( !replaying ) {
+                  ilog( "promoting proposed schedule (set in block ${proposed_num}) to pending; current block: ${n} lib: ${lib} schedule: ${schedule} ",
+                        ("proposed_num", *gpo.proposed_schedule_block_num)("n", pbhs.block_num)
+                        ("lib", pbhs.dpos_irreversible_blocknum)("schedule", bb_legacy.new_pending_producer_schedule ) );
+               }
 
                db.modify( gpo, [&]( auto& gp ) {
                   gp.proposed_schedule_block_num = std::optional<block_num_type>();

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -789,9 +789,12 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
                      "--snapshot is incompatible with --genesis-json as the snapshot contains genesis information");
 
          auto shared_mem_path = chain_config->state_dir / "shared_memory.bin";
-         EOS_ASSERT( !std::filesystem::is_regular_file(shared_mem_path),
-                 plugin_config_exception,
-                 "Snapshot can only be used to initialize an empty database." );
+         auto chain_head_path = chain_config->state_dir / chain_head_filename;
+         EOS_ASSERT(!std::filesystem::is_regular_file(shared_mem_path) &&
+                    !std::filesystem::is_regular_file(chain_head_path),
+                    plugin_config_exception,
+                    "Snapshot can only be used to initialize an empty database, remove directory: ${d}",
+                    ("d", chain_config->state_dir.generic_string()));
 
          auto block_log_chain_id = block_log::extract_chain_id(blocks_dir, retained_dir);
 


### PR DESCRIPTION
Update the `max-reversible-blocks` option to only be enforced for blocks after the Savanna transition.

Merges `release/1.0` into `main` including #587 

Resolves #579