### PR TITLE
[1.0 -> main] Normally process blocks from the forkdb on startup

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -104,6 +104,7 @@ namespace eosio::chain {
             uint32_t                 maximum_variable_signature_length = chain::config::default_max_variable_signature_length;
             bool                     disable_all_subjective_mitigations = false; //< for developer & testing purposes, can be configured using `disable-all-subjective-mitigations` when `EOSIO_DEVELOPER` build option is provided
             uint32_t                 terminate_at_block     = 0;
+            uint32_t                 num_configured_p2p_peers = 0;
             bool                     integrity_hash_on_start= false;
             bool                     integrity_hash_on_stop = false;
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -675,6 +675,8 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
       if( options.count( "terminate-at-block" ))
          chain_config->terminate_at_block = options.at( "terminate-at-block" ).as<uint32_t>();
 
+      chain_config->num_configured_p2p_peers = options.count( "p2p-peer-address" );
+
       // move fork_db to new location
       upgrade_from_reversible_to_fork_db( this );
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2224,6 +2224,8 @@ namespace eosio {
          set_state( lib_catchup );
          sync_last_requested_num = 0;
          sync_next_expected_num = chain_info.lib_num + 1;
+      } else if (sync_next_expected_num >= sync_last_requested_num) {
+         // break
       } else {
          peer_dlog(c, "already syncing, start sync ignored");
          return;

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -345,20 +345,25 @@ class Node(Transactions):
             if logStatus: Utils.Print(f'Determined node id {self.nodeId} (pid={pid}) is alive')
             return True
 
-    def rmFromCmd(self, matchValue: str):
-        '''Removes all instances of matchValue from cmd array and succeeding value if it's an option value string.'''
+    def rmFromCmd(self, matchValue: str) -> str:
+        '''Removes all instances of matchValue from cmd array and succeeding value if it's an option value string.
+           Returns the removed strings as a space-delimited string.'''
         if not self.cmd:
-            return
+            return ''
+
+        removed_items = []
 
         while True:
             try:
                 i = self.cmd.index(matchValue)
-                self.cmd.pop(i)
+                removed_items.append(self.cmd.pop(i))  # Store the matchValue
                 if len(self.cmd) > i:
-                    if self.cmd[i][0] != '-':
-                        self.cmd.pop(i)
+                    if self.cmd[i][0] != '-':  # Check if the next value isn't an option (doesn't start with '-')
+                        removed_items.append(self.cmd.pop(i))  # Store the succeeding value
             except ValueError:
                 break
+
+        return ' '.join(removed_items)  # Return the removed strings as a space-delimited string
 
     # pylint: disable=too-many-locals
     # If nodeosPath is equal to None, it will use the existing nodeos path

--- a/tests/nodeos_read_terminate_at_block_test.py
+++ b/tests/nodeos_read_terminate_at_block_test.py
@@ -43,7 +43,7 @@ dumpErrorDetails = args.dump_error_details
 def executeTest(cluster, testNodeId, testNodeArgs, resultMsgs):
     testNode = None
     testResult = False
-    resultDesc = "!!!BUG IS CONFIRMED ON TEST CASE #{} ({})".format(
+    resultDesc = "!!!BUG IS CONFIRMED ON TEST CASE #{}  ({})".format(
         testNodeId,
         testNodeArgs
     )
@@ -58,6 +58,7 @@ def executeTest(cluster, testNodeId, testNodeArgs, resultMsgs):
 
         testNode = cluster.getNode(testNodeId)
         assert not testNode.verifyAlive() # resets pid so reluanch works
+        peers = testNode.rmFromCmd('--p2p-peer-address')
         testNode.relaunch(addSwapFlags={"--terminate-at-block": "9999999"})
 
         # Wait for node to start up.
@@ -75,9 +76,9 @@ def executeTest(cluster, testNodeId, testNodeArgs, resultMsgs):
         checkReplay(testNode, testNodeArgs)
 
         # verify node can be restarted after a replay
-        checkRestart(testNode, "--replay-blockchain")
+        checkRestart(testNode, "--replay-blockchain", peers)
 
-        resultDesc = "!!!TEST CASE #{} ({}) IS SUCCESSFUL".format(
+        resultDesc = "!!!TEST CASE #{}  ({}) IS SUCCESSFUL".format(
             testNodeId,
             testNodeArgs
         )
@@ -144,12 +145,12 @@ def checkReplay(testNode, testNodeArgs):
     head, lib = getBlockNumInfo(testNode)
     assert head == termAtBlock, f"head {head} termAtBlock {termAtBlock}"
 
-def checkRestart(testNode, rmChainArgs):
+def checkRestart(testNode, rmChainArgs, peers):
     """Test restart of node continues"""
     if testNode and not testNode.killed:
         assert testNode.kill(signal.SIGTERM)
 
-    if not testNode.relaunch(rmArgs=rmChainArgs):
+    if not testNode.relaunch(chainArg=peers, rmArgs=rmChainArgs):
         Utils.errorExit(f"Unable to relaunch after {rmChainArgs}")
 
     assert testNode.verifyAlive(), f"relaunch failed after {rmChainArgs}"
@@ -201,7 +202,7 @@ def checkHeadOrSpeculative(head, lib):
 def executeSnapshotBlocklogTest(cluster, testNodeId, resultMsgs, nodeArgs, termAtBlock):
     testNode = cluster.getNode(testNodeId)
     testResult = False
-    resultDesc = "!!!BUG IS CONFIRMED ON TEST CASE #{} ({})".format(
+    resultDesc = "!!!BUG IS CONFIRMED ON TEST CASE #{}  ({})".format(
         testNodeId,
         f"replay block log, {nodeArgs} --terminate-at-block {termAtBlock}"
     )
@@ -221,7 +222,7 @@ def executeSnapshotBlocklogTest(cluster, testNodeId, resultMsgs, nodeArgs, termA
             m=re.search(r"Block ([\d]+) reached configured maximum block", line)
             if m:
                 assert int(m.group(1)) == termAtBlock, f"actual terminating block number {m.group(1)} not equal to expected termAtBlock {termAtBlock}"
-                resultDesc = f"!!!TEST CASE #{testNodeId} (replay block log, mode {nodeArgs} --terminate-at-block {termAtBlock}) IS SUCCESSFUL"
+                resultDesc = f"!!!TEST CASE #{testNodeId}  (replay block log, mode {nodeArgs} --terminate-at-block {termAtBlock}) IS SUCCESSFUL"
                 testResult = True
 
     Print(resultDesc)
@@ -266,10 +267,10 @@ try:
         0 : "--enable-stale-production"
     }
     regularNodeosArgs = {
-        1 : "--read-mode irreversible --terminate-at-block 75",
-        2 : "--read-mode head --terminate-at-block 100",
-        3 : "--read-mode speculative --terminate-at-block 125",
-        4 : "--read-mode irreversible --terminate-at-block 155"
+        1 : "--read-mode irreversible --terminate-at-block 100",
+        2 : "--read-mode head --terminate-at-block 125",
+        3 : "--read-mode speculative --terminate-at-block 150",
+        4 : "--read-mode irreversible --terminate-at-block 180"
     }
     replayNodeosArgs = {
         5 : "--read-mode irreversible",
@@ -344,6 +345,18 @@ try:
             )
             if not success:
                 break
+
+    # Test nodes can restart and advance lib
+    if not cluster.biosNode.relaunch():
+        Utils.errorExit("Unable to restart bios node")
+
+    if not producingNode.relaunch():
+        Utils.errorExit("Unable to restart producing node")
+
+    if success:
+        for nodeId, nodeArgs in {**regularNodeosArgs, **replayNodeosArgs}.items():
+            assert cluster.getNode(nodeId).relaunch(), f"Unable to relaunch {nodeId}"
+            assert cluster.getNode(nodeId).waitForLibToAdvance(), f"LIB did not advance for {nodeId}"
 
     testSuccessful = success
 


### PR DESCRIPTION
In Spring 1.0.0, unlike Leap, we process blocks into the fork database immediately. This can cause the fork database to grow very large when syncing and shutdown due to hitting the new `max-reversible-blocks` limit (before #545). When a node is shutdown, in Leap, it was assumed that when restarting a node if that node did not receive any blocks from the network it would be at the same height as when it was shutdown. The existing `tests/nodeos_read_terminate_at_block_test.py` integration test verifies this behavior.

However, if the node shutdown because of `max-reversible-blocks` you would like on restart for the node to process blocks out of the fork database potentially allowing LIB to progress and reversible blocks to be consumed and shrink in size. This is at odds with the expected behavior of a node starting up after a `terminate-at-block`. A user might find it very odd to terminate a node at a block, but find on restart that the node is actually beyond that block.

To fix the issue reported in #565, we would like to process blocks out of the fork database on restart. However, we want to maintain the existing expectations of starting a node after a shutdown via `terminate-at-block` being at the same block height on restart. 

Therefore, this PR modifies nodeos to normally process blocks out of the fork database on startup unless the node has no configured peers. The idea being that if a user has terminated a node with `terminate-at-block` and wants the node to remain at that block, they will restart the node without any `p2p-peer-address` configured. This is a bit of a hack until #570 can be added. Since #570 is a new feature, it will not come until a future release and will not be part of Spring 1.0.0.

Merges `release/1.0` into `main` including #572

Resolves #565 