### PR TITLE
[1.0] Replay from retained directory with no block log

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -956,7 +956,7 @@ namespace eosio { namespace chain {
             open(log_dir);
             const auto log_size = std::filesystem::file_size(block_file.get_file_path());
 
-            if (log_size == 0 && !catalog.empty()) {
+            if ((log_size == 0 || !head) && !catalog.empty()) {
                basic_block_log::reset(catalog.verifier.chain_id, catalog.last_block_num() + 1);
                update_head(read_block_by_num(catalog.last_block_num()));
             } else {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1583,93 +1583,104 @@ struct controller_impl {
 
    enum class startup_t { genesis, snapshot, existing_state };
 
-   std::exception_ptr replay_block_log() {
+   bool should_replay_block_log() const {
       auto blog_head = blog.head();
       if (!blog_head) {
          ilog( "no block log found" );
-         return {};
+         return false;
       }
+
+      auto start_block_num = chain_head.block_num() + 1;
+
+      bool should_replay = start_block_num <= blog_head->block_num();
+      if (!should_replay) {
+         ilog( "no irreversible blocks need to be replayed" );
+      }
+      return should_replay;
+   }
+
+   std::exception_ptr replay_block_log() {
+      auto blog_head = blog.head();
+      assert(blog_head);
 
       auto start_block_num = chain_head.block_num() + 1;
       auto start = fc::time_point::now();
 
-      std::exception_ptr except_ptr;
-      if( start_block_num <= blog_head->block_num() ) {
-         ilog( "existing block log, attempting to replay from ${s} to ${n} blocks", ("s", start_block_num)("n", blog_head->block_num()) );
-         try {
-            std::vector<block_state_legacy_ptr> legacy_branch; // for blocks that will need to be converted to IF blocks
-            while( auto next = blog.read_block_by_num( chain_head.block_num() + 1 ) ) {
-               block_handle_accessor::apply_l<void>(chain_head, [&](const auto& head) {
-                  if (next->is_proper_svnn_block()) {
-                     const bool skip_validate_signee = true; // validated already or not in replay_push_block according to conf.force_all_checks;
-                     assert(!legacy_branch.empty()); // should have started with a block_state chain_head or we transition during replay
-                     // transition to savanna
-                     block_state_ptr prev = chain_head_trans_svnn_block;
-                     bool replay_not_from_snapshot = !chain_head_trans_svnn_block;
-                     for (size_t i = 0; i < legacy_branch.size(); ++i) {
-                        if (i == 0 && replay_not_from_snapshot) {
-                           assert(!prev);
-                           prev = block_state::create_if_genesis_block(*legacy_branch[0]);
-                        } else {
-                           const auto& bspl = legacy_branch[i];
-                           assert(read_mode == db_read_mode::IRREVERSIBLE || bspl->action_mroot_savanna.has_value());
-                           auto new_bsp = block_state::create_transition_block(
-                                 *prev,
-                                 bspl->block,
-                                 protocol_features.get_protocol_feature_set(),
-                                 validator_t{}, skip_validate_signee,
-                                 bspl->action_mroot_savanna);
-                           prev = new_bsp;
-                        }
-                     }
-                     chain_head = block_handle{ prev }; // apply_l will not execute again after this
-                     {
-                        // If Leap started at a block prior to the IF transition, it needs to provide a default safety
-                        // information for those finalizers that don't already have one. This typically should be done when
-                        // we create the non-legacy fork_db, as from this point we may need to cast votes to participate
-                        // to the IF consensus. See https://github.com/AntelopeIO/leap/issues/2070#issuecomment-1941901836
-                        my_finalizers.set_default_safety_information(
-                           finalizer_safety_information{.last_vote                             = prev->make_block_ref(),
-                                                        .lock                                  = prev->make_block_ref(),
-                                                        .votes_forked_since_latest_strong_vote = false});
-                     }
-                  }
-               });
-               block_handle_accessor::apply<void>(chain_head, [&]<typename T>(const T&) {
-                  replay_push_block<T>( next, controller::block_status::irreversible );
-               });
-               block_handle_accessor::apply_l<void>(chain_head, [&](const auto& head) { // chain_head is updated via replay_push_block
-                  assert(!next->is_proper_svnn_block());
-                  if (next->contains_header_extension(finality_extension::extension_id())) {
-                     assert(legacy_branch.empty() || head->block->previous == legacy_branch.back()->block->calculate_id());
-                     legacy_branch.push_back(head);
-                     // note if is_proper_svnn_block is not reached then transistion will happen live
-                  }
-               });
-               if( check_shutdown() ) {  // needed on every loop for terminate-at-block
-                  ilog( "quitting from replay_block_log because of shutdown" );
-                  break;
-               }
-               if( next->block_num() % 500 == 0 ) {
-                  ilog( "${n} of ${head}", ("n", next->block_num())("head", blog_head->block_num()) );
-               }
-            }
-         } catch(  const database_guard_exception& e ) {
-            except_ptr = std::current_exception();
-         }
-         auto end = fc::time_point::now();
-         ilog( "${n} irreversible blocks replayed", ("n", 1 + chain_head.block_num() - start_block_num) );
-         ilog( "replayed ${n} blocks in ${duration} seconds, ${mspb} ms/block",
-               ("n", chain_head.block_num() + 1 - start_block_num)("duration", (end-start).count()/1000000)
-               ("mspb", ((end-start).count()/1000.0)/(chain_head.block_num()-start_block_num)) );
+      assert(start_block_num <= blog_head->block_num());
 
-         // if the irreverible log is played without undo sessions enabled, we need to sync the
-         // revision ordinal to the appropriate expected value here.
-         if( skip_db_sessions( controller::block_status::irreversible ) )
-            db.set_revision( chain_head.block_num() );
-      } else {
-         ilog( "no irreversible blocks need to be replayed" );
+      std::exception_ptr except_ptr;
+      ilog( "existing block log, attempting to replay from ${s} to ${n} blocks", ("s", start_block_num)("n", blog_head->block_num()) );
+      try {
+         std::vector<block_state_legacy_ptr> legacy_branch; // for blocks that will need to be converted to IF blocks
+         while( auto next = blog.read_block_by_num( chain_head.block_num() + 1 ) ) {
+            block_handle_accessor::apply_l<void>(chain_head, [&](const auto& head) {
+               if (next->is_proper_svnn_block()) {
+                  const bool skip_validate_signee = true; // validated already or not in replay_push_block according to conf.force_all_checks;
+                  assert(!legacy_branch.empty()); // should have started with a block_state chain_head or we transition during replay
+                  // transition to savanna
+                  block_state_ptr prev = chain_head_trans_svnn_block;
+                  bool replay_not_from_snapshot = !chain_head_trans_svnn_block;
+                  for (size_t i = 0; i < legacy_branch.size(); ++i) {
+                     if (i == 0 && replay_not_from_snapshot) {
+                        assert(!prev);
+                        prev = block_state::create_if_genesis_block(*legacy_branch[0]);
+                     } else {
+                        const auto& bspl = legacy_branch[i];
+                        assert(read_mode == db_read_mode::IRREVERSIBLE || bspl->action_mroot_savanna.has_value());
+                        auto new_bsp = block_state::create_transition_block(
+                              *prev,
+                              bspl->block,
+                              protocol_features.get_protocol_feature_set(),
+                              validator_t{}, skip_validate_signee,
+                              bspl->action_mroot_savanna);
+                        prev = new_bsp;
+                     }
+                  }
+                  chain_head = block_handle{ prev }; // apply_l will not execute again after this
+                  {
+                     // If Leap started at a block prior to the IF transition, it needs to provide a default safety
+                     // information for those finalizers that don't already have one. This typically should be done when
+                     // we create the non-legacy fork_db, as from this point we may need to cast votes to participate
+                     // to the IF consensus. See https://github.com/AntelopeIO/leap/issues/2070#issuecomment-1941901836
+                     my_finalizers.set_default_safety_information(
+                        finalizer_safety_information{.last_vote                             = prev->make_block_ref(),
+                                                     .lock                                  = prev->make_block_ref(),
+                                                     .votes_forked_since_latest_strong_vote = false});
+                  }
+               }
+            });
+            block_handle_accessor::apply<void>(chain_head, [&]<typename T>(const T&) {
+               replay_push_block<T>( next, controller::block_status::irreversible );
+            });
+            block_handle_accessor::apply_l<void>(chain_head, [&](const auto& head) { // chain_head is updated via replay_push_block
+               assert(!next->is_proper_svnn_block());
+               if (next->contains_header_extension(finality_extension::extension_id())) {
+                  assert(legacy_branch.empty() || head->block->previous == legacy_branch.back()->block->calculate_id());
+                  legacy_branch.push_back(head);
+                  // note if is_proper_svnn_block is not reached then transistion will happen live
+               }
+            });
+            if( check_shutdown() ) {  // needed on every loop for terminate-at-block
+               ilog( "quitting from replay_block_log because of shutdown" );
+               break;
+            }
+            if( next->block_num() % 500 == 0 ) {
+               ilog( "${n} of ${head}", ("n", next->block_num())("head", blog_head->block_num()) );
+            }
+         }
+      } catch(  const database_guard_exception& e ) {
+         except_ptr = std::current_exception();
       }
+      auto end = fc::time_point::now();
+      ilog( "${n} irreversible blocks replayed", ("n", 1 + chain_head.block_num() - start_block_num) );
+      ilog( "replayed ${n} blocks in ${duration} seconds, ${mspb} ms/block",
+            ("n", chain_head.block_num() + 1 - start_block_num)("duration", (end-start).count()/1000000)
+            ("mspb", ((end-start).count()/1000.0)/(chain_head.block_num()-start_block_num)) );
+
+      // if the irreverible log is played without undo sessions enabled, we need to sync the
+      // revision ordinal to the appropriate expected value here.
+      if( skip_db_sessions( controller::block_status::irreversible ) )
+         db.set_revision( chain_head.block_num() );
 
       return except_ptr;
    }
@@ -1677,15 +1688,14 @@ struct controller_impl {
    void replay(startup_t startup) {
       replaying = true;
 
+      bool replay_block_log_needed = should_replay_block_log();
+
       auto blog_head = blog.head();
       auto start_block_num = chain_head.block_num() + 1;
       std::exception_ptr except_ptr;
 
-      if (blog_head) {
+      if (replay_block_log_needed)
          except_ptr = replay_block_log();
-      } else {
-         ilog( "no block log found" );
-      }
 
       if( check_shutdown() ) {
          ilog( "quitting from replay because of shutdown" );
@@ -1699,38 +1709,40 @@ struct controller_impl {
       }
 
       if (startup == startup_t::existing_state) {
-         EOS_ASSERT(fork_db_has_root(), fork_database_exception,
-                    "No existing fork database despite existing chain state. Replay required." );
-         uint32_t lib_num = fork_db_root_block_num();
-         auto first_block_num = blog.first_block_num();
-         if(blog_head) {
-            EOS_ASSERT( first_block_num <= lib_num && lib_num <= blog_head->block_num(),
-                        block_log_exception,
-                        "block log (ranging from ${block_log_first_num} to ${block_log_last_num}) does not contain the last irreversible block (${fork_db_lib})",
-                        ("block_log_first_num", first_block_num)
-                        ("block_log_last_num", blog_head->block_num())
-                        ("fork_db_lib", lib_num)
-            );
-            lib_num = blog_head->block_num();
-         } else {
-            if( first_block_num != (lib_num + 1) ) {
-               blog.reset( chain_id, lib_num + 1 );
-            }
-         }
-
-         auto do_startup = [&](auto& forkdb) {
-            if( read_mode == db_read_mode::IRREVERSIBLE) {
-               auto root = forkdb.root();
-               if (root && chain_head.id() != root->id()) {
-                  chain_head = block_handle{forkdb.root()};
-                  // rollback db to LIB
-                  while( db.revision() > chain_head.block_num() ) {
-                     db.undo();
-                  }
+         if (!replay_block_log_needed) {
+            EOS_ASSERT(fork_db_has_root(), fork_database_exception,
+                       "No existing fork database despite existing chain state. Replay required." );
+            uint32_t lib_num = fork_db_root_block_num();
+            auto first_block_num = blog.first_block_num();
+            if(blog_head) {
+               EOS_ASSERT( first_block_num <= lib_num && lib_num <= blog_head->block_num(),
+                           block_log_exception,
+                           "block log (ranging from ${block_log_first_num} to ${block_log_last_num}) does not contain the last irreversible block (${fork_db_lib})",
+                           ("block_log_first_num", first_block_num)
+                           ("block_log_last_num", blog_head->block_num())
+                           ("fork_db_lib", lib_num)
+               );
+               lib_num = blog_head->block_num();
+            } else {
+               if( first_block_num != (lib_num + 1) ) {
+                  blog.reset( chain_id, lib_num + 1 );
                }
             }
-         };
-         fork_db.apply<void>(do_startup);
+
+            auto do_startup = [&](auto& forkdb) {
+               if( read_mode == db_read_mode::IRREVERSIBLE) {
+                  auto root = forkdb.root();
+                  if (root && chain_head.id() != root->id()) {
+                     chain_head = block_handle{forkdb.root()};
+                     // rollback db to LIB
+                     while( db.revision() > chain_head.block_num() ) {
+                        db.undo();
+                     }
+                  }
+               }
+            };
+            fork_db.apply<void>(do_startup);
+         }
       }
 
       auto fork_db_reset_root_to_chain_head = [&]() {

--- a/unittests/blocks_log_replay_tests.cpp
+++ b/unittests/blocks_log_replay_tests.cpp
@@ -88,13 +88,6 @@ struct blog_replay_fixture {
       eosio::testing::tester replay_chain_1(copied_config_1, *genesis, call_startup_t::no);
       replay_chain_1.control->startup( [](){}, []()->bool{ return false; } );
 
-      replay_chain_1.control->accepted_block().connect([&](const block_signal_params& t) {
-         const auto& [ block, id ] = t;
-         BOOST_TEST(block->block_num() > stop_at);
-         static uint32_t first = block->block_num();
-         BOOST_TEST(first == stop_at);
-      });
-
       // Make sure new chain contain the account created by original chain
       BOOST_REQUIRE_NO_THROW(replay_chain_1.get_account("replay1"_n));
       BOOST_REQUIRE_NO_THROW(replay_chain_1.get_account("replay2"_n));

--- a/unittests/partitioned_block_log_tests.cpp
+++ b/unittests/partitioned_block_log_tests.cpp
@@ -238,6 +238,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_split_log_util1, T, eosio::testing::testers 
    BOOST_CHECK(from_block_log_chain.fetch_block_by_number(100)->block_num() == 100u);
    BOOST_CHECK(from_block_log_chain.fetch_block_by_number(150)->block_num() == 150u);
 
+   from_block_log_chain.close();
+
    //
    // replay with no blocks.log, but blocks in retained_dir
    //

--- a/unittests/partitioned_block_log_tests.cpp
+++ b/unittests/partitioned_block_log_tests.cpp
@@ -5,13 +5,14 @@
 #include <eosio/chain/snapshot.hpp>
 #include <eosio/testing/tester.hpp>
 
-// #include <boost/mpl/list.hpp>
-#include <boost/test/unit_test.hpp>
+#include <snapshot_suites.hpp>
+#include <snapshot_tester.hpp>
 
+#include <boost/test/unit_test.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <contracts.hpp>
 #include <fc/io/cfile.hpp>
-#include <snapshots.hpp>
+
 
 BOOST_AUTO_TEST_SUITE(partitioned_block_log_tests)
 
@@ -200,8 +201,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_split_log_util1, T, eosio::testing::testers 
 
    chain.close();
 
+   fc::temp_directory temp_dir;
    auto blocks_dir   = chain.get_config().blocks_dir;
-   auto retained_dir = blocks_dir / "retained";
+   auto retained_dir = temp_dir.path() / "retained";
    eosio::chain::block_log::split_blocklog(blocks_dir, retained_dir, 50);
 
    BOOST_CHECK(std::filesystem::exists(retained_dir / "blocks-1-50.log"));
@@ -235,6 +237,86 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_split_log_util1, T, eosio::testing::testers 
    BOOST_CHECK(from_block_log_chain.fetch_block_by_number(75)->block_num() == 75u);
    BOOST_CHECK(from_block_log_chain.fetch_block_by_number(100)->block_num() == 100u);
    BOOST_CHECK(from_block_log_chain.fetch_block_by_number(150)->block_num() == 150u);
+
+   //
+   // replay with no blocks.log, but blocks in retained_dir
+   //
+
+   // remove the state files to make sure we are starting from block log
+   remove_existing_states(copied_config);
+   // we need to remove all blocks but what is in retained
+   std::filesystem::remove(blocks_dir / "blocks.log");
+   std::filesystem::remove(blocks_dir / "blocks.index");
+
+   // Create a replay chain without starting it
+   eosio::testing::tester replay_chain(copied_config, *genesis, eosio::testing::call_startup_t::no);
+   // no fork db head yet
+   BOOST_REQUIRE(!replay_chain.fork_db_head().is_valid());
+   // works because it pulls from retain dir
+   BOOST_CHECK(replay_chain.fetch_block_by_number(42)->block_num() == 42u);
+
+   // Simulate shutdown by CTRL-C
+   bool is_quiting = false;
+   auto check_shutdown = [&is_quiting](){ return is_quiting; };
+   uint32_t stop_at = 25;
+   // Set up shutdown at a particular block number
+   replay_chain.control->irreversible_block().connect([&](const eosio::chain::block_signal_params& t) {
+      const auto& [ block, id ] = t;
+      // Stop replay at block `stop_at`
+      if (block->block_num() == stop_at) {
+         is_quiting = true;
+      }
+   });
+   // Start replay and stop at block `stop_at`
+   replay_chain.control->startup( [](){}, check_shutdown, *genesis );
+
+   // create snapshot at stop_at block
+   replay_chain.control->abort_block();
+   auto writer = variant_snapshot_suite::get_writer();
+   replay_chain.control->write_snapshot(writer);
+   auto snapshot = variant_snapshot_suite::finalize(writer);
+
+   BOOST_REQUIRE(replay_chain.head().is_valid());
+   BOOST_CHECK(replay_chain.head().block_num() == stop_at);
+   // no fork db head yet
+   BOOST_CHECK(!replay_chain.fork_db_head().is_valid());
+
+   replay_chain.close();
+
+   // replay chain from stop_at with no blocks in block_log, pulls from retained dir
+   eosio::testing::tester replay_chain_1(copied_config, *genesis, eosio::testing::call_startup_t::no);
+   replay_chain_1.control->startup( [](){}, []()->bool{ return false; } );
+
+   BOOST_REQUIRE(replay_chain_1.fork_db_head().is_valid());
+   BOOST_CHECK(replay_chain_1.fork_db_head().block_num() == 150u);
+
+   BOOST_CHECK(replay_chain_1.fetch_block_by_number(1)->block_num() == 1u);
+   BOOST_CHECK(replay_chain_1.fetch_block_by_number(75)->block_num() == 75u);
+   BOOST_CHECK(replay_chain_1.fetch_block_by_number(100)->block_num() == 100u);
+   BOOST_CHECK(replay_chain_1.fetch_block_by_number(150)->block_num() == 150u);
+
+   replay_chain_1.close();
+
+   //
+   // start chain from snapshot at stop_at with no blocks in block_log, pulls from retained dir
+   //
+
+   // remove the state files to make sure we are starting from block log
+   remove_existing_states(copied_config);
+   // we need to remove all blocks but what is in retained
+   std::filesystem::remove(blocks_dir / "blocks.log");
+   std::filesystem::remove(blocks_dir / "blocks.index");
+
+   int ordinal = 0;
+   snapshotted_tester replay_chain_2(copied_config, variant_snapshot_suite::get_reader(snapshot), ++ordinal);
+
+   BOOST_REQUIRE(replay_chain_2.fork_db_head().is_valid());
+   BOOST_CHECK(replay_chain_2.fork_db_head().block_num() == 150u);
+
+   BOOST_CHECK(replay_chain_2.fetch_block_by_number(1)->block_num() == 1u);
+   BOOST_CHECK(replay_chain_2.fetch_block_by_number(75)->block_num() == 75u);
+   BOOST_CHECK(replay_chain_2.fetch_block_by_number(100)->block_num() == 100u);
+   BOOST_CHECK(replay_chain_2.fetch_block_by_number(150)->block_num() == 150u);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( test_split_log_no_archive, T, eosio::testing::testers ) {

--- a/unittests/snapshot_tester.hpp
+++ b/unittests/snapshot_tester.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <eosio/chain/block_log.hpp>
+#include <eosio/chain/snapshot.hpp>
+#include <eosio/testing/tester.hpp>
+
+
+inline std::filesystem::path get_parent_path(std::filesystem::path blocks_dir, int ordinal) {
+   std::filesystem::path leaf_dir = blocks_dir.filename();
+   if (leaf_dir.generic_string() == std::string("blocks")) {
+      blocks_dir = blocks_dir.parent_path();
+      leaf_dir = blocks_dir.filename();
+      try {
+         boost::lexical_cast<int>(leaf_dir.generic_string());
+         blocks_dir = blocks_dir.parent_path();
+      }
+      catch(const boost::bad_lexical_cast& ) {
+         // no extra ordinal directory added to path
+      }
+   }
+   return blocks_dir / std::to_string(ordinal);
+}
+
+inline controller::config copy_config(const controller::config& config, int ordinal) {
+   controller::config copied_config = config;
+   auto parent_path = get_parent_path(config.blocks_dir, ordinal);
+   copied_config.finalizers_dir   = parent_path / config.finalizers_dir.filename().generic_string();;
+   copied_config.blocks_dir = parent_path / config.blocks_dir.filename().generic_string();
+   copied_config.state_dir  = parent_path / config.state_dir.filename().generic_string();
+   return copied_config;
+}
+
+inline controller::config copy_config_and_files(const controller::config& config, int ordinal) {
+   controller::config copied_config = copy_config(config, ordinal);
+   std::filesystem::create_directories(copied_config.blocks_dir);
+   std::filesystem::copy_file(config.blocks_dir / "blocks.log", copied_config.blocks_dir / "blocks.log", std::filesystem::copy_options::none);
+   std::filesystem::copy_file(config.blocks_dir / "blocks.index", copied_config.blocks_dir / "blocks.index", std::filesystem::copy_options::none);
+   return copied_config;
+}
+
+class snapshotted_tester : public base_tester {
+public:
+   enum config_file_handling { dont_copy_config_files, copy_config_files };
+   snapshotted_tester(const controller::config& config, const snapshot_reader_ptr& snapshot, int ordinal,
+           config_file_handling copy_files_from_config = config_file_handling::dont_copy_config_files) {
+      FC_ASSERT(config.blocks_dir.filename().generic_string() != "."
+                && config.state_dir.filename().generic_string() != ".", "invalid path names in controller::config");
+
+      controller::config copied_config = (copy_files_from_config == copy_config_files)
+                                         ? copy_config_and_files(config, ordinal) : copy_config(config, ordinal);
+
+      BOOST_CHECK_GT(snapshot->total_row_count(), 0u);
+      init(copied_config, snapshot);
+   }
+
+   produce_block_result_t produce_block_ex( fc::microseconds skip_time = default_skip_time, bool no_throw = false )override {
+      return _produce_block(skip_time, false, no_throw);
+   }
+
+   signed_block_ptr produce_block( fc::microseconds skip_time = default_skip_time, bool no_throw = false )override {
+      return produce_block_ex(skip_time, no_throw).block;
+   }
+
+   signed_block_ptr produce_empty_block( fc::microseconds skip_time = default_skip_time )override {
+      control->abort_block();
+      return _produce_block(skip_time, true);
+   }
+
+   signed_block_ptr finish_block()override {
+      return _finish_block();
+   }
+
+   bool validate() { return true; }
+};

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -5,85 +5,17 @@
 #include <eosio/chain/snapshot.hpp>
 #include <eosio/testing/tester.hpp>
 #include "snapshot_suites.hpp"
+#include <snapshots.hpp>
+#include <snapshot_tester.hpp>
 
-#include <boost/mpl/list.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <test_contracts.hpp>
-#include <snapshots.hpp>
 #include "test_wasts.hpp"
 
 using namespace eosio;
 using namespace testing;
 using namespace chain;
-
-std::filesystem::path get_parent_path(std::filesystem::path blocks_dir, int ordinal) {
-   std::filesystem::path leaf_dir = blocks_dir.filename();
-   if (leaf_dir.generic_string() == std::string("blocks")) {
-      blocks_dir = blocks_dir.parent_path();
-      leaf_dir = blocks_dir.filename();
-      try {
-         boost::lexical_cast<int>(leaf_dir.generic_string());
-         blocks_dir = blocks_dir.parent_path();
-      }
-      catch(const boost::bad_lexical_cast& ) {
-         // no extra ordinal directory added to path
-      }
-   }
-   return blocks_dir / std::to_string(ordinal);
-}
-
-controller::config copy_config(const controller::config& config, int ordinal) {
-   controller::config copied_config = config;
-   auto parent_path = get_parent_path(config.blocks_dir, ordinal);
-   copied_config.finalizers_dir   = parent_path / config.finalizers_dir.filename().generic_string();;
-   copied_config.blocks_dir = parent_path / config.blocks_dir.filename().generic_string();
-   copied_config.state_dir  = parent_path / config.state_dir.filename().generic_string();
-   return copied_config;
-}
-
-controller::config copy_config_and_files(const controller::config& config, int ordinal) {
-   controller::config copied_config = copy_config(config, ordinal);
-   std::filesystem::create_directories(copied_config.blocks_dir);
-   std::filesystem::copy_file(config.blocks_dir / "blocks.log", copied_config.blocks_dir / "blocks.log", std::filesystem::copy_options::none);
-   std::filesystem::copy_file(config.blocks_dir / "blocks.index", copied_config.blocks_dir / "blocks.index", std::filesystem::copy_options::none);
-   return copied_config;
-}
-
-class snapshotted_tester : public base_tester {
-public:
-   enum config_file_handling { dont_copy_config_files, copy_config_files };
-   snapshotted_tester(const controller::config& config, const snapshot_reader_ptr& snapshot, int ordinal,
-           config_file_handling copy_files_from_config = config_file_handling::dont_copy_config_files) {
-      FC_ASSERT(config.blocks_dir.filename().generic_string() != "."
-                && config.state_dir.filename().generic_string() != ".", "invalid path names in controller::config");
-
-      controller::config copied_config = (copy_files_from_config == copy_config_files)
-                                         ? copy_config_and_files(config, ordinal) : copy_config(config, ordinal);
-
-      BOOST_CHECK_GT(snapshot->total_row_count(), 0u);
-      init(copied_config, snapshot);
-   }
-
-   produce_block_result_t produce_block_ex( fc::microseconds skip_time = default_skip_time, bool no_throw = false )override {
-      return _produce_block(skip_time, false, no_throw);
-   }
-
-   signed_block_ptr produce_block( fc::microseconds skip_time = default_skip_time, bool no_throw = false )override {
-      return produce_block_ex(skip_time, no_throw).block;
-   }
-
-   signed_block_ptr produce_empty_block( fc::microseconds skip_time = default_skip_time )override {
-      control->abort_block();
-      return _produce_block(skip_time, true);
-   }
-
-   signed_block_ptr finish_block()override {
-      return _finish_block();
-   }
-
-   bool validate() { return true; }
-};
 
 BOOST_AUTO_TEST_SUITE(snapshot_tests)
 


### PR DESCRIPTION
PR fixes two issues:
- Replaying from a snapshot with no block log, but blocks in the retained directory, issue #586
  - Before this PR, block log head would be nullptr and no blocks would be replayed from the retained directory.
- Interrupting replay of block log (from blocks or retained directory) via ctrl-c, restarting replay when no fork database.
  - Before this PR, would fail by throwing an error that no fork database exists.

Resolves #586