### PR TITLE
[1.0] Add max_reversible_blocks_allowed(), use in net_plugin to limit sync-fetch-span

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -396,6 +396,11 @@ namespace eosio::chain {
          /// not-thread-safe
          bool should_terminate() const;
 
+         /// Difference between max-reversible-blocks and fork database size.
+         /// Can return MAX_INT32 if disabled or pre-Savanna
+         /// @return the number of reversible blocks still allowed
+         int32_t max_reversible_blocks_allowed() const;
+
          void set_subjective_cpu_leeway(fc::microseconds leeway);
          std::optional<fc::microseconds> get_subjective_cpu_leeway() const;
          void set_greylist_limit( uint32_t limit );

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -95,7 +95,7 @@ namespace eosio::chain {
             uint32_t                 sig_cpu_bill_pct       =  chain::config::default_sig_cpu_bill_pct;
             uint16_t                 chain_thread_pool_size =  chain::config::default_controller_thread_pool_size;
             uint16_t                 vote_thread_pool_size  =  0;
-            uint32_t                 max_reversible_blocks  =  chain::config::default_max_reversible_blocks;
+            int32_t                  max_reversible_blocks  =  chain::config::default_max_reversible_blocks;
             bool                     read_only              =  false;
             bool                     force_all_checks       =  false;
             bool                     disable_replay_opts    =  false;

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -263,9 +263,28 @@ namespace eosio::chain {
       }
 
       /// @param legacy_f the lambda to execute if in legacy mode
-      /// @param savanna_f the lambda to execute if in savanna instant-finality mode
+      /// @param savanna_f the lambda to execute if in savanna mode
       template <class R, class LegacyF, class SavannaF>
       R apply(const LegacyF& legacy_f, const SavannaF& savanna_f) {
+         if constexpr (std::is_same_v<void, R>) {
+            if (in_use.load() == in_use_t::legacy) {
+               legacy_f(fork_db_l);
+            } else {
+               savanna_f(fork_db_s);
+            }
+         } else {
+            if (in_use.load() == in_use_t::legacy) {
+               return legacy_f(fork_db_l);
+            } else {
+               return savanna_f(fork_db_s);
+            }
+         }
+      }
+
+      /// @param legacy_f the lambda to execute if in legacy mode
+      /// @param savanna_f the lambda to execute if in savanna mode
+      template <class R, class LegacyF, class SavannaF>
+      R apply(const LegacyF& legacy_f, const SavannaF& savanna_f) const {
          if constexpr (std::is_same_v<void, R>) {
             if (in_use.load() == in_use_t::legacy) {
                legacy_f(fork_db_l);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -361,7 +361,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "'none' - EOS VM OC tier-up is completely disabled.\n")
 #endif
          ("enable-account-queries", bpo::value<bool>()->default_value(false), "enable queries to find accounts by various metadata.")
-         ("max-reversible-blocks", bpo::value<uint32_t>()->default_value(config::default_max_reversible_blocks),
+         ("max-reversible-blocks", bpo::value<int32_t>()->default_value(config::default_max_reversible_blocks),
           "Approximate maximum allowed reversible blocks before shutdown. Will shut down if limit reached. Specify 0 to disable.")
          ("transaction-retry-max-storage-size-gb", bpo::value<uint64_t>(),
           "Maximum size (in GiB) allowed to be allocated for the Transaction Retry feature. Setting above 0 enables this feature.")
@@ -954,7 +954,11 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
       account_queries_enabled = options.at("enable-account-queries").as<bool>();
 
-      chain_config->max_reversible_blocks = options.at("max-reversible-blocks").as<uint32_t>();
+      chain_config->max_reversible_blocks = options.at("max-reversible-blocks").as<int32_t>();
+      if (chain_config->max_reversible_blocks == -1) // allow -1 or 0 for disable
+         chain_config->max_reversible_blocks = 0;
+      EOS_ASSERT(chain_config->max_reversible_blocks >= 0, plugin_config_exception,
+                 "max-reversible-blocks ${m} must be > 0", ("m", chain_config->max_reversible_blocks));
 
       chain_config->integrity_hash_on_start = options.at("integrity-hash-on-start").as<bool>();
       chain_config->integrity_hash_on_stop = options.at("integrity-hash-on-stop").as<bool>();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2004,8 +2004,8 @@ namespace eosio {
       int32_t reversible_remaining = my_impl->chain_plug->chain().max_reversible_blocks_allowed();
       if (reversible_remaining <= 0) {
          auto fork_db_size = my_impl->chain_plug->chain().fork_db_size();
-         fc_wlog(logger, "max-reversible-blocks exceeded, remaining ${r}, fork_db_size ${fs}",
-                 ("r", reversible_remaining)("fs", fork_db_size));
+         fc_wlog(logger, "max-reversible-blocks exceeded by ${ex}, fork_db_size ${fs}",
+                 ("ex", -reversible_remaining)("fs", fork_db_size));
          reversible_remaining = 0;
       }
       if (reversible_remaining < sync_fetch_span) {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -227,7 +227,6 @@ namespace eosio {
 
       const uint32_t sync_fetch_span {0};
       const uint32_t sync_peer_limit {0};
-      const size_t   max_reversible_blocks {0};
 
       alignas(hardware_destructive_interference_sz)
       std::atomic<stages> sync_state{in_sync};
@@ -259,7 +258,7 @@ namespace eosio {
          immediately,  // closing connection immediately
          handshake     // sending handshake message
       };
-      explicit sync_manager( uint32_t span, uint32_t sync_peer_limit, size_t max_reversible_blocks, uint32_t min_blocks_distance );
+      explicit sync_manager( uint32_t span, uint32_t sync_peer_limit, uint32_t min_blocks_distance );
       static void send_handshakes();
       bool syncing_from_peer() const { return sync_state == lib_catchup; }
       bool is_in_sync() const { return sync_state == in_sync; }
@@ -1989,30 +1988,30 @@ namespace eosio {
    }
    //-----------------------------------------------------------
 
-    sync_manager::sync_manager( uint32_t span, uint32_t sync_peer_limit, size_t max_reversible_blocks, uint32_t min_blocks_distance )
+    sync_manager::sync_manager( uint32_t span, uint32_t sync_peer_limit, uint32_t min_blocks_distance )
       :sync_known_lib_num( 0 )
       ,sync_last_requested_num( 0 )
       ,sync_next_expected_num( 1 )
       ,sync_source()
       ,sync_fetch_span( span )
       ,sync_peer_limit( sync_peer_limit )
-      ,max_reversible_blocks(max_reversible_blocks)
       ,sync_state(in_sync)
       ,min_blocks_distance(min_blocks_distance)
    {
    }
 
    uint32_t sync_manager::active_sync_fetch_span() const {
-      auto fork_db_size = my_impl->chain_plug->chain().fork_db_size();
-      int32_t reversible_remaining = max_reversible_blocks - fork_db_size - 1;
+      int32_t reversible_remaining = my_impl->chain_plug->chain().max_reversible_blocks_allowed();
       if (reversible_remaining <= 0) {
-         fc_wlog(logger, "max-reversible-blocks ${m} exceeded, remaining ${r}, fork_db_size ${fs}",
-                 ("m", max_reversible_blocks)("r", reversible_remaining)("fs", fork_db_size));
+         auto fork_db_size = my_impl->chain_plug->chain().fork_db_size();
+         fc_wlog(logger, "max-reversible-blocks exceeded, remaining ${r}, fork_db_size ${fs}",
+                 ("r", reversible_remaining)("fs", fork_db_size));
          reversible_remaining = 0;
       }
       if (reversible_remaining < sync_fetch_span) {
-         fc_wlog(logger, "sync-fetch-span ${sfs} restricted to ${r} by max-reversible-blocks ${m}, fork_db_size ${fs}",
-                 ("sfs", sync_fetch_span)("r", reversible_remaining)("m", max_reversible_blocks)("fs", fork_db_size));
+         auto fork_db_size = my_impl->chain_plug->chain().fork_db_size();
+         fc_wlog(logger, "sync-fetch-span ${sfs} restricted to ${r} by max-reversible-blocks, fork_db_size ${fs}",
+                 ("sfs", sync_fetch_span)("r", reversible_remaining)("fs", fork_db_size));
          return reversible_remaining;
       }
       return sync_fetch_span;
@@ -4297,7 +4296,6 @@ namespace eosio {
          sync_master = std::make_unique<sync_manager>(
              options.at( "sync-fetch-span" ).as<uint32_t>(),
              options.at( "sync-peer-limit" ).as<uint32_t>(),
-             chain_plug->chain_config().max_reversible_blocks,
              min_blocks_distance);
 
          connections.init( std::chrono::milliseconds( options.at("p2p-keepalive-interval-ms").as<int>() * 2 ),

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -67,6 +67,8 @@ try:
     specificExtraNodeosArgs[pnodes+7] = f' --sync-fetch-span 1597 '
     specificExtraNodeosArgs[pnodes+8] = f' --sync-fetch-span 6765 '
     specificExtraNodeosArgs[pnodes+9] = f' --sync-fetch-span 28657 '
+    if not activateIF:
+        specificExtraNodeosArgs[pnodes+9] += " --max-reversible-blocks 2 " # should be ignored for pre-savanna blocks
     specificExtraNodeosArgs[pnodes+10] = f' --sync-fetch-span 89 --read-mode irreversible '
     specificExtraNodeosArgs[pnodes+11] = f' --sync-fetch-span 377 --read-mode irreversible '
     if cluster.launch(prodCount=prodCount, specificExtraNodeosArgs=specificExtraNodeosArgs, activateIF=activateIF, onlyBios=False,


### PR DESCRIPTION
Instead of `net_plugin` calculating how many reversible blocks are allowed to limit `sync-fetch-span`, call a method on `controller`. Now logic about which fork database to check is encapsulated to the controller.

Resolves #608