### PR TITLE
[1.0 -> main] Add max_reversible_blocks_allowed(), use in net_plugin to limit sync-fetch-span

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1117,13 +1117,6 @@ struct controller_impl {
       return prev->block_num();
    }
 
-   // returns 0 for legacy
-   size_t fork_db_savanna_size() const {
-      return fork_db.apply_s<size_t>([&](const auto& forkdb) {
-         return forkdb.size();
-      });
-   }
-
    bool fork_db_block_exists( const block_id_type& id ) const {
       return fork_db.apply<bool>([&](const auto& forkdb) {
          return forkdb.block_exists(id);
@@ -4840,6 +4833,19 @@ struct controller_impl {
       return conf.block_validation_mode == validation_mode::LIGHT || conf.trusted_producers.count(producer);
    }
 
+   int32_t max_reversible_blocks_allowed() const {
+      if (conf.max_reversible_blocks == 0)
+         return std::numeric_limits<int32_t>::max();
+
+      return fork_db.apply<int32_t>(
+         [&](const fork_database_legacy_t& forkdb) {
+            return std::numeric_limits<int32_t>::max();
+         },
+         [&](const fork_database_if_t& forkdb) {
+            return conf.max_reversible_blocks - forkdb.size();
+         });
+   }
+
    bool should_terminate(block_num_type reversible_block_num) const {
       assert(reversible_block_num > 0);
       if (conf.terminate_at_block > 0 && conf.terminate_at_block <= reversible_block_num) {
@@ -4847,9 +4853,9 @@ struct controller_impl {
               ("n", reversible_block_num)("num", conf.terminate_at_block) );
          return true;
       }
-      if (conf.max_reversible_blocks > 0 && fork_db_savanna_size() >= conf.max_reversible_blocks) {
+      if (max_reversible_blocks_allowed() <= 0) {
          elog("Exceeded max reversible blocks allowed, fork db size ${s} >= max-reversible-blocks ${m}",
-              ("s", fork_db_savanna_size())("m", conf.max_reversible_blocks));
+              ("s", fork_db_size())("m", conf.max_reversible_blocks));
          return true;
       }
       return false;
@@ -5658,6 +5664,10 @@ validation_mode controller::get_validation_mode()const {
 
 bool controller::should_terminate() const {
    return my->should_terminate();
+}
+
+int32_t controller:: max_reversible_blocks_allowed() const {
+   return my->max_reversible_blocks_allowed();
 }
 
 const apply_handler* controller::find_apply_handler( account_name receiver, account_name scope, action_name act ) const

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -95,7 +95,7 @@ namespace eosio::chain {
             uint32_t                 sig_cpu_bill_pct       =  chain::config::default_sig_cpu_bill_pct;
             uint16_t                 chain_thread_pool_size =  chain::config::default_controller_thread_pool_size;
             uint16_t                 vote_thread_pool_size  =  0;
-            uint32_t                 max_reversible_blocks  =  chain::config::default_max_reversible_blocks;
+            int32_t                  max_reversible_blocks  =  chain::config::default_max_reversible_blocks;
             bool                     read_only              =  false;
             bool                     force_all_checks       =  false;
             bool                     disable_replay_opts    =  false;
@@ -395,6 +395,11 @@ namespace eosio::chain {
          /// @return true if terminate-at-block reached, or max-reversible-blocks reached
          /// not-thread-safe
          bool should_terminate() const;
+
+         /// Difference between max-reversible-blocks and fork database size.
+         /// Can return MAX_INT32 if disabled or pre-Savanna
+         /// @return the number of reversible blocks still allowed
+         int32_t max_reversible_blocks_allowed() const;
 
          void set_subjective_cpu_leeway(fc::microseconds leeway);
          std::optional<fc::microseconds> get_subjective_cpu_leeway() const;

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -263,9 +263,28 @@ namespace eosio::chain {
       }
 
       /// @param legacy_f the lambda to execute if in legacy mode
-      /// @param savanna_f the lambda to execute if in savanna instant-finality mode
+      /// @param savanna_f the lambda to execute if in savanna mode
       template <class R, class LegacyF, class SavannaF>
       R apply(const LegacyF& legacy_f, const SavannaF& savanna_f) {
+         if constexpr (std::is_same_v<void, R>) {
+            if (in_use.load() == in_use_t::legacy) {
+               legacy_f(fork_db_l);
+            } else {
+               savanna_f(fork_db_s);
+            }
+         } else {
+            if (in_use.load() == in_use_t::legacy) {
+               return legacy_f(fork_db_l);
+            } else {
+               return savanna_f(fork_db_s);
+            }
+         }
+      }
+
+      /// @param legacy_f the lambda to execute if in legacy mode
+      /// @param savanna_f the lambda to execute if in savanna mode
+      template <class R, class LegacyF, class SavannaF>
+      R apply(const LegacyF& legacy_f, const SavannaF& savanna_f) const {
          if constexpr (std::is_same_v<void, R>) {
             if (in_use.load() == in_use_t::legacy) {
                legacy_f(fork_db_l);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -361,7 +361,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "'none' - EOS VM OC tier-up is completely disabled.\n")
 #endif
          ("enable-account-queries", bpo::value<bool>()->default_value(false), "enable queries to find accounts by various metadata.")
-         ("max-reversible-blocks", bpo::value<uint32_t>()->default_value(config::default_max_reversible_blocks),
+         ("max-reversible-blocks", bpo::value<int32_t>()->default_value(config::default_max_reversible_blocks),
           "Approximate maximum allowed reversible blocks before shutdown. Will shut down if limit reached. Specify 0 to disable.")
          ("transaction-retry-max-storage-size-gb", bpo::value<uint64_t>(),
           "Maximum size (in GiB) allowed to be allocated for the Transaction Retry feature. Setting above 0 enables this feature.")
@@ -954,7 +954,11 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
       account_queries_enabled = options.at("enable-account-queries").as<bool>();
 
-      chain_config->max_reversible_blocks = options.at("max-reversible-blocks").as<uint32_t>();
+      chain_config->max_reversible_blocks = options.at("max-reversible-blocks").as<int32_t>();
+      if (chain_config->max_reversible_blocks == -1) // allow -1 or 0 for disable
+         chain_config->max_reversible_blocks = 0;
+      EOS_ASSERT(chain_config->max_reversible_blocks >= 0, plugin_config_exception,
+                 "max-reversible-blocks ${m} must be > 0", ("m", chain_config->max_reversible_blocks));
 
       chain_config->integrity_hash_on_start = options.at("integrity-hash-on-start").as<bool>();
       chain_config->integrity_hash_on_stop = options.at("integrity-hash-on-stop").as<bool>();

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -67,6 +67,8 @@ try:
     specificExtraNodeosArgs[pnodes+7] = f' --sync-fetch-span 1597 '
     specificExtraNodeosArgs[pnodes+8] = f' --sync-fetch-span 6765 '
     specificExtraNodeosArgs[pnodes+9] = f' --sync-fetch-span 28657 '
+    if not activateIF:
+        specificExtraNodeosArgs[pnodes+9] += " --max-reversible-blocks 2 " # should be ignored for pre-savanna blocks
     specificExtraNodeosArgs[pnodes+10] = f' --sync-fetch-span 89 --read-mode irreversible '
     specificExtraNodeosArgs[pnodes+11] = f' --sync-fetch-span 377 --read-mode irreversible '
     if cluster.launch(prodCount=prodCount, specificExtraNodeosArgs=specificExtraNodeosArgs, activateIF=activateIF, onlyBios=False,


### PR DESCRIPTION
Instead of `net_plugin` calculating how many reversible blocks are allowed to limit `sync-fetch-span`, call a method on `controller`. Now logic about which fork database to check is encapsulated to the controller.

Merges `release/1.0` into `main` including #609 

Resolves #608