### PR TITLE
[1.0] Add test case to demonstrate the weak masking issue

### DIFF
--- a/libraries/libfc/include/fc/scoped_exit.hpp
+++ b/libraries/libfc/include/fc/scoped_exit.hpp
@@ -36,4 +36,41 @@ namespace fc {
       return scoped_exit<Callback>( std::forward<Callback>(c) );
    }
 
+   // ---------------------------------------------------------------------------
+   // An object which assigns a value to a variable in its constructor, and resets
+   // to its previous value in its destructor
+   // ---------------------------------------------------------------------------
+   template <class T>
+   class scoped_set_value {
+   public:
+      template <class V>
+      [[nodiscard]] scoped_set_value(T& var, V&& val,
+                                     bool do_it = true) noexcept(std::is_nothrow_copy_constructible_v<T> &&
+                                                                 std::is_nothrow_move_assignable_v<T>)
+         : _v(var)
+         , _do_it(do_it) {
+         if (_do_it) {
+            _old_value = std::move(_v);
+            _v         = std::forward<V>(val);
+         }
+      }
+
+      ~scoped_set_value() {
+         if (_do_it)
+            _v = std::move(_old_value);
+      }
+
+      void dismiss() noexcept { _do_it = false; }
+
+      scoped_set_value(const scoped_set_value&)            = delete;
+      scoped_set_value& operator=(const scoped_set_value&) = delete;
+      scoped_set_value(scoped_set_value&&)                 = delete;
+      scoped_set_value& operator=(scoped_set_value&&)      = delete;
+      void*             operator new(std::size_t)          = delete;
+
+   private:
+      T&   _v;
+      T    _old_value;
+      bool _do_it;
+   };
 }

--- a/unittests/savanna_cluster.cpp
+++ b/unittests/savanna_cluster.cpp
@@ -14,8 +14,13 @@ node_t::node_t(size_t node_idx, cluster_t& cluster, setup_policy policy /* = set
       // to vote (and emit the `voted_block` signal) synchronously.
       // --------------------------------------------------------------------------------------
       vote_result_t status = std::get<1>(v);
-      if (status == vote_result_t::success)
-         cluster.dispatch_vote_to_peers(node_idx, skip_self_t::yes, std::get<2>(v));
+
+      if (status == vote_result_t::success) {
+         vote_message_ptr vote_msg = std::get<2>(v);
+         last_vote = vote_t(vote_msg);
+         if (propagate_votes)
+            cluster.dispatch_vote_to_peers(node_idx, skip_self_t::yes, std::get<2>(v));
+      }
    };
 
    // called on `commit_block`, for both blocks received from `push_block` and produced blocks

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -21,20 +21,20 @@ public:
    [[nodiscard]] scoped_set_value(T& var, V&& val,
                                   bool do_it = true) noexcept(std::is_nothrow_copy_constructible_v<T> &&
                                                               std::is_nothrow_move_assignable_v<T>)
-      : v_(var)
-      , do_it_(do_it) {
-      if (do_it_) {
-         old_value_ = std::move(v_);
-         v_         = std::forward<V>(val);
+      : _v(var)
+      , _do_it(do_it) {
+      if (_do_it) {
+         _old_value = std::move(_v);
+         _v         = std::forward<V>(val);
       }
    }
 
    ~scoped_set_value() {
-      if (do_it_)
-         v_ = std::move(old_value_);
+      if (_do_it)
+         _v = std::move(_old_value);
    }
 
-   void dismiss() noexcept { do_it_ = false; }
+   void dismiss() noexcept { _do_it = false; }
 
    scoped_set_value(const scoped_set_value&)            = delete;
    scoped_set_value& operator=(const scoped_set_value&) = delete;
@@ -42,9 +42,9 @@ public:
    scoped_set_value& operator=(scoped_set_value&&)      = delete;
    void*             operator new(std::size_t)          = delete;
 
-   T&   v_;
-   T    old_value_;
-   bool do_it_;
+   T&   _v;
+   T    _old_value;
+   bool _do_it;
 };
 
 namespace savanna_cluster {

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -508,6 +508,23 @@ namespace savanna_cluster {
 
       size_t num_nodes() const { return _num_nodes; }
 
+      qc_claim_t qc_claim(const signed_block_ptr& b) {
+         return b->extract_header_extension<finality_extension>().qc_claim;
+      }
+
+      std::optional<qc_t> qc(const signed_block_ptr& b) {
+         if (b->contains_extension(quorum_certificate_extension::extension_id()))
+             return b->extract_extension<quorum_certificate_extension>().qc;
+         return {};
+      }
+
+      // debugging utilities
+      // -------------------
+      static void print(const char* name, const signed_block_ptr& b) {
+         std::cout << name << " ts = " << b->timestamp.slot << ", id = " << b->calculate_id().str().substr(8, 16)
+                   << ", previous = " << b->previous.str().substr(8, 16) << '\n';
+      }
+
    public:
       std::vector<node_t>  _nodes;
       fin_keys_t           _fin_keys;

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -98,7 +98,7 @@ BOOST_FIXTURE_TEST_CASE(weak_masking_issue, savanna_cluster::cluster_t) try {
 
    signed_block_ptr b3;
    {
-      scoped_set_value tmp(B.propagate_votes, false);      // temporarily prevent B from broadcasting its votes)
+      fc::scoped_set_value tmp(B.propagate_votes, false);  // temporarily prevent B from broadcasting its votes)
                                                            // so A won't receive them and form a QC on b3
 
       b3 = A.produce_block(_block_interval_us * 2);        // A will see its own strong vote on b3, and C's weak vote

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -53,9 +53,9 @@ BOOST_FIXTURE_TEST_CASE(snapshot_startup_with_forkdb, savanna_cluster::cluster_t
                   +-----+  S   +-----+      S     +-----+   no   +-----+   W  +-----+  S  +-----+
 A produces   <----| b0  |<-----| b1  |<-----------|  b3 |<-------+ b4  |<-----| b5  |<----|  b6 |<-------
                   +-----+      +-----+            +-----+  claim +-----+      +-----+     +-----+
-                                   ^
-                                   |      +-----+
-D produces                         +------| b2  |
+                     ^
+                     |                    +-----+
+D produces           +--------------------| b2  |
                                      S    +-----+
 
 */

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -46,6 +46,19 @@ BOOST_FIXTURE_TEST_CASE(snapshot_startup_with_forkdb, savanna_cluster::cluster_t
 // Because the issue is fixed in spring https://github.com/AntelopeIO/spring/pull/537, test must pass
 // on all versions past that commit.
 // -----------------------------------------------------------------------------------------------------
+/*
+                                               S
+                                  +------------------------------+
+                                  V                              |
+                  +-----+  S   +-----+      S     +-----+   no   +-----+   W  +-----+  S  +-----+
+A produces   <----| b0  |<-----| b1  |<-----------|  b3 |<-------+ b4  |<-----| b5  |<----|  b6 |<-------
+                  +-----+      +-----+            +-----+  claim +-----+      +-----+     +-----+
+                                   ^
+                                   |      +-----+
+D produces                         +------| b2  |
+                                     S    +-----+
+
+*/
 BOOST_FIXTURE_TEST_CASE(weak_masking_issue, savanna_cluster::cluster_t) try {
    auto& A=_nodes[0]; auto& B=_nodes[1]; auto& C=_nodes[2]; auto& D=_nodes[3];
    using vote_t = savanna_cluster::node_t::vote_t;

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -5,6 +5,7 @@ using namespace eosio::testing;
 
 BOOST_AUTO_TEST_SUITE(savanna_misc_tests)
 
+// ------------------------------------------------------------------------------------
 // Verify that we can restart a node from a snapshot without state or blocks (reversible
 // or not)
 // ------------------------------------------------------------------------------------
@@ -21,6 +22,7 @@ BOOST_FIXTURE_TEST_CASE(snapshot_startup_without_forkdb, savanna_cluster::cluste
 
 } FC_LOG_AND_RETHROW()
 
+// ------------------------------------------------------------------------------------
 // Verify that we cannot restart a node from a snapshot without state and blocks log,
 // but with a fork database
 // ------------------------------------------------------------------------------------
@@ -39,5 +41,67 @@ BOOST_FIXTURE_TEST_CASE(snapshot_startup_with_forkdb, savanna_cluster::cluster_t
 } FC_LOG_AND_RETHROW()
 
 
+// -----------------------------------------------------------------------------------------------------
+// Test case demonstrating the weak masking issue (see https://github.com/AntelopeIO/spring/issues/534)
+// Because the issue is fixed in spring https://github.com/AntelopeIO/spring/pull/537, test must pass
+// on all versions past that commit.
+// -----------------------------------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(weak_masking_issue, savanna_cluster::cluster_t) try {
+   auto& A=_nodes[0]; auto& B=_nodes[1]; auto& C=_nodes[2]; auto& D=_nodes[3];
+   using vote_t = savanna_cluster::node_t::vote_t;
+
+   auto b0 = A.produce_blocks(2);                     // receive strong votes from all finalizers
+
+   // partition D out. D will be used to produce blocks on an alternative fork.
+   // We will have 3 finalizers voting which is enough to reach QCs
+   // -------------------------------------------------------------------------
+   const std::vector<size_t> partition {3};
+   set_partition(partition);
+
+   auto b1 = A.produce_block();                       // receives strong votes from 3 finalizers
+
+   auto b2 = D.produce_block(_block_interval_us * 2); // produce a `later` block on D
+   push_block(0, b2);                                 // push block to other partition, should receive weak votes
+   BOOST_REQUIRE_EQUAL(A.last_vote, vote_t(b2, false));
+   BOOST_REQUIRE_EQUAL(B.last_vote, vote_t(b2, false));
+
+   {
+      scoped_set_value tmp(B.propagate_votes, false); // temporarily prevent B from broadcasting its votes)
+                                                      // so A won't receive them and form a QC on b3
+
+      auto b3 = A.produce_block(_block_interval_us * 3); // b3 should receive 2 weak votes from A and C (not a quorum)
+                                                      // because B doesn't propagate and D is partitioned away
+      BOOST_REQUIRE_EQUAL(A.last_vote, vote_t(b3, false));
+      BOOST_REQUIRE_EQUAL(B.last_vote, vote_t(b3, false));
+   }
+
+   std::cout << "lib=" <<  B.lib_number << '\n';
+
+                                                      // Now B broadcasts its votes again, so
+   auto b4 = A.produce_block();                       // b4 should receive 3 weak votes from A, B and C
+                                                      // and should include a strong QC claim on b1 (repeated)
+                                                      // since we don't have enough votes to form a QC on b3
+   BOOST_REQUIRE_EQUAL(A.last_vote, vote_t(b4, false));
+   BOOST_REQUIRE_EQUAL(B.last_vote, vote_t(b4, false));
+
+
+   std::cout << "lib after b4=" <<  B.lib_number << '\n';
+   auto b5 = A.produce_block();                       // a weak QC was formed on b4 and is be included in b5
+                                                      // b5 should receive 3 strong votes (because it has a
+                                                      // weak QC on b4, which itself had a strong QC on b1.
+                                                      // Upon receiving a strong QC on b5, b1 will be final
+   BOOST_REQUIRE_EQUAL(A.last_vote, vote_t(b5, true));
+   BOOST_REQUIRE_EQUAL(B.last_vote, vote_t(b5, true));
+
+
+   std::cout << "lib after b5=" <<  B.lib_number << '\n';
+   auto b6 = A.produce_block();                       // should include strong QC on b5, b1 should be final
+
+   BOOST_REQUIRE_EQUAL(A.last_vote, vote_t(b6, true));
+   BOOST_REQUIRE_EQUAL(B.last_vote, vote_t(b6, true));
+
+   BOOST_REQUIRE_EQUAL(B.lib_number, b1->block_num());
+
+} FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Resolves #544.

Branch `gh_544_check`  created off commit 7beaa202 prior to PR #537 (implementing the FSI changes to avoid the issue) has the new test failing.