### PR TITLE
[1.0] add `BOOST_TEST_DEFAULTS_TO_CORE_DUMP` to libtester users

### DIFF
--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -35,6 +35,7 @@ else ( APPLE )
    set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -Wall")
 endif ( APPLE )
 
+add_compile_definitions(BOOST_TEST_DEFAULTS_TO_CORE_DUMP)
 add_compile_definitions(BOOST_UNORDERED_DISABLE_NEON)
 
 set( Boost_USE_MULTITHREADED      ON )

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -32,6 +32,7 @@ else ( APPLE )
    set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -Wall")
 endif ( APPLE )
 
+add_compile_definitions(BOOST_TEST_DEFAULTS_TO_CORE_DUMP)
 add_compile_definitions(BOOST_UNORDERED_DISABLE_NEON)
 
 set( Boost_USE_MULTITHREADED      ON )


### PR DESCRIPTION
EOS VM within libtester needs to handle `SIGSEGV`. It's fine if other code using libtester chains their own SEGV handlers as well, but boost test by default completely takes over `SIGSEGV` and this prevents proper operation of EOS VM within libtester.

Previously inside of leap/spring we added `--catch_system_errors=no` to all `ctest` invocations of a boost unit test. This works but is a bit annoying because when running the test manually you need to also remember to manually pass `--catch_system_errors=no` or can experience problems. So instead AntelopeIO/leap#1849 does this globally by setting `BOOST_TEST_DEFAULTS_TO_CORE_DUMP`

But that doesn't change behavior for users of libtester and their native contract unit tests. They still would need to know to pass `--catch_system_errors=no` to get proper behavior from libtester and EOS VM. Oftentimes this doesn't matter because generally users of libtester aren't banging on wasm memory faults, but EOS EVM's tests did stumble on this problem recently. So let's add `BOOST_TEST_DEFAULTS_TO_CORE_DUMP` to any users of libtester so they do not need to know to `--catch_system_errors=no`.

Sending to 1.0 because of EOS EVM struggles here.