### PR TITLE
[1.0] Additional debug output

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2388,11 +2388,12 @@ producer_plugin_impl::handle_push_result(const transaction_metadata_ptr&        
       if( exception_is_exhausted( *trace->except ) ) {
          if( in_producing_mode() ) {
             fc_dlog(trx->is_transient() ? _transient_trx_failed_trace_log : _trx_failed_trace_log,
-                    "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
-                    ("block_num", chain.head().block_num() + 1)("prod", get_pending_block_producer())("txid", trx->id()));
+                    "[TRX_TRACE] Block ${bn} for producer ${prod} COULD NOT FIT, elapsed ${e}us, tx: ${txid} RETRYING ",
+                    ("bn", chain.head().block_num() + 1)("e", trace->elapsed)("prod", get_pending_block_producer())("txid", trx->id()));
          } else {
             fc_dlog(trx->is_transient() ? _transient_trx_failed_trace_log : _trx_failed_trace_log,
-                    "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING", ("txid", trx->id()));
+                    "[TRX_TRACE] Speculative execution COULD NOT FIT, elapsed ${e}us, tx: ${txid} RETRYING",
+                    ("e", trace->elapsed)("txid", trx->id()));
          }
          if (!trx->is_read_only())
             pr.block_exhausted = block_is_exhausted(); // smaller trx might fit

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -308,7 +308,7 @@ class Utils:
     @staticmethod
     def runCmdArrReturnJson(cmdArr, trace=False, silentErrors=True):
         retStr=Utils.checkOutput(cmdArr)
-        return Utils.toJson(retStr)
+        return Utils.toJson(retStr, trace, silentErrors)
 
     @staticmethod
     def runCmdReturnStr(cmd, trace=False, ignoreError=False):

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -168,7 +168,7 @@ class Transactions(NodeosQueries):
             retries = retries + 1
             start=time.perf_counter()
             try:
-                trans=Utils.runCmdReturnJson(cmd, trace=False)
+                trans=Utils.runCmdReturnJson(cmd, trace=False, silentErrors=shouldFail)
                 self.trackCmdTransaction(trans)
                 if Utils.Debug:
                     end=time.perf_counter()


### PR DESCRIPTION
- In integration tests when `cleos set contract` fails, log the failure.
- Add `elapsed Xus` to `COULD NOT FIT` log.
```
debug 2024-08-24T19:34:53.979 nodeos    producer_plugin.cpp:2396      handle_push_result   ] [TRX_TRACE] Speculative execution COULD NOT FIT, elapsed 25165us, tx: 58e89df409f96e330c62caa2742e54f17c597918997eba7546647cb92941acc4 RETRYING
debug 2024-08-24T19:35:14.304 nodeos    producer_plugin.cpp:2392      handle_push_result   ] [TRX_TRACE] Block 85 for producer defproducern COULD NOT FIT, elapsed 80049us, tx: caab341eeed1d5f27cb41d566d7a58a0d7ca52e1c56a9035e98453acf9ba95a9 RETRYING
```

Related to #632 