### PR TITLE
[1.0] Apply blocks from the forkdb on startup even if max-reversible-blocks reached

### DIFF
--- a/tests/terminate-scenarios-test.py
+++ b/tests/terminate-scenarios-test.py
@@ -98,6 +98,13 @@ try:
         errorExit("Failed to relaunch Eos instance")
     Print("nodeos instance relaunched.")
 
+    if maxReversibleBlocks > 0:
+        if not cluster.getNode(0).kill(killSignal):
+            errorExit("Failed to kill Node0")
+        # should immediately exit as max-reversible-blocks set to 2
+        if not cluster.getNode(0).relaunch(addSwapFlags={"--max-reversible-blocks":"2"}, waitForTerm=True):
+            errorExit("Failed to relaunch Node0 with --max-reversible-blocks 2")
+
     testSuccessful=True
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, dumpErrorDetails=dumpErrorDetails)

--- a/tests/terminate-scenarios-test.py
+++ b/tests/terminate-scenarios-test.py
@@ -101,7 +101,7 @@ try:
     if maxReversibleBlocks > 0:
         if not cluster.getNode(0).kill(killSignal):
             errorExit("Failed to kill Node0")
-        # should immediately exit as max-reversible-blocks set to 2
+        # should immediately exit as max-reversible-blocks set to 2, verifies node not stuck in infinite loop on startup
         if not cluster.getNode(0).relaunch(addSwapFlags={"--max-reversible-blocks":"2"}, waitForTerm=True):
             errorExit("Failed to relaunch Node0 with --max-reversible-blocks 2")
 


### PR DESCRIPTION
If a node is shutdown by hitting `max-reversible-blocks` or if `max-reversible-blocks` reduced to lower than the number of persisted blocks in the forkdb, allow the node to start and apply all blocks from the forkdb.

Resolves #634 