### PR TITLE
swtich `__multi3` to `unsigned __int128` to avoid integer overflow UB

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -1928,7 +1928,7 @@ namespace webassembly {
          void __lshrti3(legacy_ptr<int128_t>, uint64_t, uint64_t, uint32_t) const;
          void __divti3(legacy_ptr<int128_t>, uint64_t, uint64_t, uint64_t, uint64_t) const;
          void __udivti3(legacy_ptr<uint128_t>, uint64_t, uint64_t, uint64_t, uint64_t) const;
-         void __multi3(legacy_ptr<int128_t>, uint64_t, uint64_t, uint64_t, uint64_t) const;
+         void __multi3(legacy_ptr<uint128_t>, uint64_t, uint64_t, uint64_t, uint64_t) const;
          void __modti3(legacy_ptr<int128_t>, uint64_t, uint64_t, uint64_t, uint64_t) const;
          void __umodti3(legacy_ptr<uint128_t>, uint64_t, uint64_t, uint64_t, uint64_t) const;
          void __addtf3(legacy_ptr<float128_t>, uint64_t, uint64_t, uint64_t, uint64_t) const;

--- a/libraries/chain/webassembly/compiler_builtins.cpp
+++ b/libraries/chain/webassembly/compiler_builtins.cpp
@@ -66,9 +66,9 @@ namespace eosio { namespace chain { namespace webassembly {
       *ret = lhs;
    }
 
-   void interface::__multi3(legacy_ptr<__int128> ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb) const {
-      __int128 lhs = ha;
-      __int128 rhs = hb;
+   void interface::__multi3(legacy_ptr<uint128_t> ret, uint64_t la, uint64_t ha, uint64_t lb, uint64_t hb) const {
+      uint128_t lhs = ha;
+      uint128_t rhs = hb;
 
       lhs <<= 64;
       lhs |=  la;


### PR DESCRIPTION
This is a pedantic fix to something in consensus touching code. risk/reward should be judged accordingly. I am reasonably comfortable with this change.

Overflowing a `__int128` is considered undefined behavior just like any other integer type. It turns out that contracts are calling `__multi3` with parameters that overflow which causes UBSAN failures when a node is run live on chain (we don't have any test that exercises `__multi3` in this manner).

My impression that from the standpoint of the compiler generating a call to `__multi3`, the call is agnostic to whether the parameters are signed or not because as long as there is no sign extension (that is, you're doing something like a 32-bit multiply to store in a 32-bit result) and as long as we're two's complement (realistically true; guaranteed in c++20) there is no need for the hardware to differentiate based on signedness and the result will be bit identical regardless of the signedness. A little bit of evidence to back this up is https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/README.txt#L73 where you can see it is not commented as being signed or unsigned.

For an illustrative example that signedness doesn't matter in producing bit identical output, consider multiplying two 16-bit numbers in to 16-bit result. `0x0002 * 0xffff`. If you treat these as signed, it's `2 * -1` and the result is `-2`, or `0xfffe`. If you treat these as unsigned, it's `2 * 65535` and the result is `131070` or `0x1fffe` which once truncated to the 16-bit result, _also_ `0xfffe`.

As a more empirical data point, consider that the generated assembly is identical for `__int128` and `unsigned __int128` across clang and gcc for both x86-64 with and without AVX; plus both ARM8 and ARM8.4,
https://godbolt.org/z/j1x4br45s