### PR TITLE
explicitly handle inputs in `__divti3` and `__modti3` that result in UB overflow

### DIFF
--- a/libraries/chain/webassembly/compiler_builtins.cpp
+++ b/libraries/chain/webassembly/compiler_builtins.cpp
@@ -45,6 +45,12 @@ namespace eosio { namespace chain { namespace webassembly {
 
       EOS_ASSERT(rhs != 0, arithmetic_exception, "divide by zero");
 
+      //force integer overflow to return dividend unchanged
+      if(lhs == std::numeric_limits<__int128>::min() && rhs == -1) {
+         *ret = lhs;
+         return;
+      }
+
       lhs /= rhs;
 
       *ret = lhs;
@@ -91,6 +97,12 @@ namespace eosio { namespace chain { namespace webassembly {
       rhs |=  lb;
 
       EOS_ASSERT(rhs != 0, arithmetic_exception, "divide by zero");
+
+      //force undefined behavior (due to lhs/rhs being an overflow) to return zero
+      if(lhs == std::numeric_limits<__int128>::min() && rhs == -1) {
+         *ret = 0;
+         return;
+      }
 
       lhs %= rhs;
       *ret = lhs;

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -39,6 +39,7 @@
 
 #include <contracts.hpp>
 #include <test_contracts.hpp>
+#include <test_wasts.hpp>
 #include "test_cfd_transaction.hpp"
 
 
@@ -1486,6 +1487,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(compiler_builtins_tests, T, validating_testers) tr
 
    // test test_ashrti3
    CALL_TEST_FUNCTION( chain, "test_compiler_builtins", "test_ashrti3", {});
+
+   chain.produce_block();
+   chain.set_code( "testapi"_n, divmod_host_function_overflow_wast );
+   chain.produce_block();
+   CALL_TEST_FUNCTION( chain, "test_compiler_builtins", "", {}); //divmod_host_function_overflow_wast ignores action name
 
    BOOST_REQUIRE_EQUAL( chain.validate(), true );
 } FC_LOG_AND_RETHROW()

--- a/unittests/contracts/test_wasts.hpp
+++ b/unittests/contracts/test_wasts.hpp
@@ -1002,3 +1002,39 @@ static const char set_jumbo_row_wast[] = R"=====(
    )
 )
 )=====";
+
+static const char divmod_host_function_overflow_wast[] = R"=====(
+(module
+   (import "env" "__divti3" (func $__divti3 (param $ret_ptr i32) (param $la i64) (param $ha i64) (param $lb i64) (param $hb i64)))
+   (import "env" "__modti3" (func $__modti3 (param $ret_ptr i32) (param $la i64) (param $ha i64) (param $lb i64) (param $hb i64)))
+
+   (memory $0 1)
+   (export "apply" (func $apply))
+
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (call $__divti3 (i32.const 8)
+         (i64.const 0)                  (i64.const 0x8000000000000000)   ;; bytes: 0x00000000000000000000000000000080 (INT128_MIN)
+         (i64.const 0xffffffffffffffff) (i64.const 0xffffffffffffffff)   ;; -1
+      )
+      ;;should still be bytes 00000000000000000000000000000080
+      (if (i64.ne (i64.load (i32.const 8)) (i64.const 0)) (then
+         (unreachable)
+      ))
+      (if (i64.ne (i64.load (i32.const 16)) (i64.const 0x8000000000000000)) (then
+         (unreachable)
+      ))
+
+      (call $__modti3 (i32.const 8)
+         (i64.const 0)                  (i64.const 0x8000000000000000)   ;; bytes: 0x00000000000000000000000000000080 (INT128_MIN)
+         (i64.const 0xffffffffffffffff) (i64.const 0xffffffffffffffff)   ;; -1
+      )
+      ;;should still be all 00s
+      (if (i64.ne (i64.load (i32.const 8)) (i64.const 0)) (then
+         (unreachable)
+      ))
+      (if (i64.ne (i64.load (i32.const 16)) (i64.const 0)) (then
+         (unreachable)
+      ))
+   )
+)
+)=====";


### PR DESCRIPTION
Division (or modulo) of INT_MIN by `-1` is ultimately UB due to integer overflow. But not only that, it can cause a fault. For example, the following will fail with `SIGFPE` on x86_64 (build with `-O0` for this trivial case),
```c++
int64_t doit(int64_t in, int64_t x) {
	return in / x;
}
int main() {
	int64_t x = std::numeric_limits<int64_t>::min();
	int64_t y = doit(x, -1);
	return 0;
}
```
So what's interesting  to consider is,
https://github.com/AntelopeIO/spring/blob/abc65cef7117f83e769641f4a47d171689b41a08/libraries/chain/webassembly/compiler_builtins.cpp#L36-L51
Thus, it is possible for a contract to pass `std::numeric_limits<__int128>::min()` and `-1` resulting in a division performed via inputs to a library (libgcc/compiler-rt) that has undefined results.

Fortunately, the `int128` impl in both libgcc and compiler-rt seem to behave the same here from my tests: these inputs cause a "noop" (i.e. as if the division was by `1`) for `__divti3`, and  `__modti3` sets the result to 0.

The first commit in this PR adds a unit test that validates the above statement is currently true: for our supported platforms `__divti3` and `__modti3` behave a certain way given these inputs. Notice that the tests pass with this new unit test, except for the UBSAN build which correctly flags we are performing undefined behavior.

The second commit enforces the current behavior forever with an explicit check in the host functions.