### PR TITLE
[1.0 -> main] Use other_branch_latest_time for liveness

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1425,9 +1425,9 @@ struct controller_impl {
                        [&](const block_state_ptr& head) { return head->make_block_ref(); }});
          // doesn't matter chain_head is not updated for IRREVERSIBLE, cannot be in irreversible mode and be a finalizer
          my_finalizers.set_default_safety_information(
-            finalizer_safety_information{ .last_vote                             = ref,
-                                          .lock                                  = ref,
-                                          .votes_forked_since_latest_strong_vote = false});
+            finalizer_safety_information{ .last_vote                = ref,
+                                          .lock                     = ref,
+                                          .other_branch_latest_time = block_timestamp_type{} });
       }
    }
 
@@ -1636,9 +1636,9 @@ struct controller_impl {
                      // we create the non-legacy fork_db, as from this point we may need to cast votes to participate
                      // to the IF consensus. See https://github.com/AntelopeIO/leap/issues/2070#issuecomment-1941901836
                      my_finalizers.set_default_safety_information(
-                        finalizer_safety_information{.last_vote                             = prev->make_block_ref(),
-                                                     .lock                                  = prev->make_block_ref(),
-                                                     .votes_forked_since_latest_strong_vote = false});
+                        finalizer_safety_information{.last_vote                = prev->make_block_ref(),
+                                                     .lock                     = prev->make_block_ref(),
+                                                     .other_branch_latest_time = block_timestamp_type{} });
                   }
                }
             });
@@ -2040,9 +2040,9 @@ struct controller_impl {
             auto set_finalizer_defaults = [&](auto& forkdb) -> void {
                auto lib = forkdb.root();
                my_finalizers.set_default_safety_information(
-                  finalizer_safety_information{ .last_vote = {},
-                                                .lock      = lib->make_block_ref(),
-                                                .votes_forked_since_latest_strong_vote = false });
+                  finalizer_safety_information{ .last_vote                = {},
+                                                .lock                     = lib->make_block_ref(),
+                                                .other_branch_latest_time = block_timestamp_type{} });
             };
             fork_db.apply_s<void>(set_finalizer_defaults);
          } else {
@@ -2050,9 +2050,9 @@ struct controller_impl {
             auto set_finalizer_defaults = [&](auto& forkdb) -> void {
                auto lib = forkdb.root();
                my_finalizers.set_default_safety_information(
-                  finalizer_safety_information{ .last_vote = {},
-                                                .lock      = lib->make_block_ref(),
-                                                .votes_forked_since_latest_strong_vote = false });
+                  finalizer_safety_information{.last_vote                = {},
+                                               .lock                     = lib->make_block_ref(),
+                                               .other_branch_latest_time = block_timestamp_type{} });
             };
             fork_db.apply_s<void>(set_finalizer_defaults);
          }

--- a/libraries/chain/include/eosio/chain/finality/finalizer.hpp
+++ b/libraries/chain/include/eosio/chain/finality/finalizer.hpp
@@ -35,7 +35,7 @@ namespace eosio::chain {
    struct finalizer_safety_information {
       block_ref            last_vote;
       block_ref            lock;
-      bool                 votes_forked_since_latest_strong_vote {false};
+      block_timestamp_type other_branch_latest_time;
 
       static constexpr uint64_t magic = 0x5AFE11115AFE1111ull;
 
@@ -44,7 +44,7 @@ namespace eosio::chain {
       auto operator==(const finalizer_safety_information& o) const {
          return last_vote == o.last_vote &&
             lock == o.lock &&
-            votes_forked_since_latest_strong_vote == o.votes_forked_since_latest_strong_vote;
+            other_branch_latest_time == o.other_branch_latest_time;
       }
    };
 
@@ -74,8 +74,10 @@ namespace eosio::chain {
       ///
       /// Version 0: Spring 1.0.0 RC2 - File has fixed packed sizes with inactive safety info written to the end
       ///                               of the file. Consists of [finalizer public_key, FSI]..
-      /// Version 1: Spring 1.0.0 RC3 - Variable length FSI with inactive safety info written at the beginning of
-      ///                               the file. Uses crc32 checksum to verify data on read.
+      /// Version 1: Spring 1.0.0 RC3 - File has inactive FSIs written at the beginning of the file. Uses crc32
+      ///                               checksum to verify data on read. Removes FSI
+      ///                               votes_forked_since_latest_strong_vote from the version 0 FSI and replaces it
+      ///                               with other_branch_latest_time.
       ///
       static constexpr uint64_t safety_file_version_0       = 0;
       static constexpr uint64_t safety_file_version_1       = 1;
@@ -192,7 +194,7 @@ namespace eosio::chain {
 
 namespace std {
    inline std::ostream& operator<<(std::ostream& os, const eosio::chain::finalizer_safety_information& fsi) {
-      os << "fsi(" << fsi.last_vote << ", " << fsi.lock << ", " << fsi.votes_forked_since_latest_strong_vote << ")";
+      os << "fsi(" << fsi.last_vote << ", " << fsi.lock << ", " << fsi.other_branch_latest_time << ")";
       return os;
    }
 
@@ -210,5 +212,5 @@ namespace std {
    }
 }
 
-FC_REFLECT(eosio::chain::finalizer_safety_information, (last_vote)(lock)(votes_forked_since_latest_strong_vote))
+FC_REFLECT(eosio::chain::finalizer_safety_information, (last_vote)(lock)(other_branch_latest_time))
 FC_REFLECT_ENUM(eosio::chain::finalizer::vote_decision, (strong_vote)(weak_vote)(no_vote))

--- a/libraries/libfc/include/fc/io/datastream_crc.hpp
+++ b/libraries/libfc/include/fc/io/datastream_crc.hpp
@@ -71,6 +71,7 @@ public:
 
    // only use with p==0, otherwise use seekp() below
    bool seekp(size_t p) {
+      assert(p == 0);
       if (p == 0) {
          crc_.reset();
          return ds_.seekp(0);

--- a/unittests/finalizer_tests.cpp
+++ b/unittests/finalizer_tests.cpp
@@ -47,7 +47,7 @@ std::vector<FSI> create_random_fsi(size_t count) {
          .lock                  = block_ref{sha256::hash("lock"s + std::to_string(i)),
                                             tstamp(i * 100),
                                             sha256::hash("lock_digest"s + std::to_string(i))},
-         .votes_forked_since_latest_strong_vote = false
+         .other_branch_latest_time = block_timestamp_type{}
       });
       if (i)
          assert(res.back() != res[0]);
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE( basic_finalizer_safety_file_io ) try {
 
    fsi_t fsi { .last_vote = proposals[6],
                .lock = proposals[2],
-               .votes_forked_since_latest_strong_vote = false };
+               .other_branch_latest_time = block_timestamp_type{} };
 
    bls_keys_t k("alice"_n);
    bls_pub_priv_key_map_t local_finalizers = { { k.pubkey_str, k.privkey_str } };
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE( corrupt_finalizer_safety_file ) try {
 
    fsi_t fsi { .last_vote = proposals[6],
                .lock = proposals[2],
-               .votes_forked_since_latest_strong_vote = false };
+               .other_branch_latest_time = block_timestamp_type{} };
 
    bls_keys_t k("alice"_n);
    bls_pub_priv_key_map_t local_finalizers = { { k.pubkey_str, k.privkey_str } };

--- a/unittests/finalizer_vote_tests.cpp
+++ b/unittests/finalizer_vote_tests.cpp
@@ -143,7 +143,7 @@ struct simulator_t {
       forkdb.reset_root(genesis);
 
       block_ref genesis_ref(genesis->id(), genesis->timestamp(), genesis->id());
-      my_finalizer.fsi = fsi_t{genesis_ref, genesis_ref, false};
+      my_finalizer.fsi = fsi_t{genesis_ref, genesis_ref, {}};
    }
 
    vote_result vote(const bsp& p) {


### PR DESCRIPTION
Use `other_branch_latest_time` block timestamp instead of a boolean `votes_forked_since_latest_strong_vote` for tracking votes on other fork branches. See #621 for complete details.

Fixes currently failing test on #619.

Merges `release/1.0` into `main` including #627 

Resolves #621 (Tests coming in separate PR #636)