### PR TITLE
[1.0] Improve finalizer safety file exception handling 

### DIFF
--- a/libraries/chain/include/eosio/chain/finality/finalizer.hpp
+++ b/libraries/chain/include/eosio/chain/finality/finalizer.hpp
@@ -148,11 +148,12 @@ namespace eosio::chain {
 
          // then save the safety info and, if successful, gossip the votes
          if (!votes.empty()) {
-            save_finalizer_safety_info();
-            g.unlock();
-            has_voted.store(true, std::memory_order::relaxed);
-            for (const auto& vote : votes)
-               std::forward<F>(process_vote)(vote);
+            if (save_finalizer_safety_info()) {
+               g.unlock();
+               has_voted.store(true, std::memory_order::relaxed);
+               for (const auto& vote : votes)
+                  std::forward<F>(process_vote)(vote);
+            }
          }
       }
 
@@ -172,12 +173,13 @@ namespace eosio::chain {
          return std::ranges::any_of(std::views::keys(finalizers), std::forward<F>(f));
       }
 
-      /// only call on startup
-      void    set_keys(const std::map<std::string, std::string>& finalizer_keys);
       void    set_default_safety_information(const fsi_t& fsi);
 
+      /// only call on startup
+      void    set_keys(const std::map<std::string, std::string>& finalizer_keys);
+
       // following two member functions could be private, but are used in testing, not thread safe
-      void    save_finalizer_safety_info() const;
+      bool    save_finalizer_safety_info() const;
       fsi_map load_finalizer_safety_info();
 
       // for testing purposes only, not thread safe
@@ -187,7 +189,6 @@ namespace eosio::chain {
    private:
       void load_finalizer_safety_info_v0(fsi_map& res);
       void load_finalizer_safety_info_v1(fsi_map& res);
-
    };
 
 }


### PR DESCRIPTION
WIP

Example error when unable to open `safety.dat` file.
```
debug 2024-08-28T01:11:29.039 nodeos    chain_plugin.cpp:1172         plugin_shutdown      ] exit shutdown
info  2024-08-28T01:11:29.039 nodeos    main.cpp:172                  operator()           ] appbase quit called
...
error 2024-08-28T01:11:29.040 nodeos    main.cpp:224                  main                 ] 13 NSt8ios_base7failureB5cxx11E: cfile unable to open: safety.dat in mode: rb+: iostream error
cfile unable to open: safety.dat in mode: rb+: iostream error: unable to open finalizer safety persistence file /home/heifner/ext/spring/cmake-build-debug/TestLogs/disaster_recovery13174/node_00/finalizers/safety.dat
    {"p":"/home/heifner/ext/spring/cmake-build-debug/TestLogs/disaster_recovery13174/node_00/finalizers/safety.dat","what":"cfile unable to open: safety.dat in mode: rb+: iostream error"}
    nodeos  finalizer.cpp:283 load_finalizer_safety_info

    {}
    nodeos  producer_plugin.cpp:1556 plugin_startup
```

Resolves #646