### PR TITLE
[1.0] Test: Fix liveness_test.py integration test flakiness

### DIFF
--- a/tests/liveness_test.py
+++ b/tests/liveness_test.py
@@ -37,8 +37,9 @@ try:
     cluster.setWalletMgr(walletMgr)
     Print("Stand up cluster")
 
-    # ***   setup topogrophy   ***
-    # "mesh" shape connects nodeA and nodeA to each other
+    # test relies on production continuing
+    extraNodeosArgs=" --production-pause-vote-timeout-ms 0 "
+    # "mesh" shape connects nodeA and nodeB to each other
     if cluster.launch(topo="mesh", pnodes=totalProducerNodes,
                       totalNodes=totalNodes, totalProducers=totalProducerNodes, loadSystemContract=False,
                       activateIF=activateIF, biosFinalizer=False) is False:
@@ -73,7 +74,7 @@ try:
 
     # relaunch node A so that quorum can be met
     Print("Relaunching node A to make quorum")
-    if not prodA.relaunch():
+    if not prodA.relaunch(chainArg="--enable-stale-production"):
         errorExit(f"Failure - node A should have restarted")
 
     # verify LIB advances on both nodes


### PR DESCRIPTION
- Disable production pause on missing votes since the test stops finality as part of the test.
- Enable stale production on restart of production node as it is a producer and it might be its time to produce.

Resolves #653 
Resolves #620 