### PR TITLE
[1.0] Logging improvements

### DIFF
--- a/libraries/chain/finality/finalizer.cpp
+++ b/libraries/chain/finality/finalizer.cpp
@@ -339,7 +339,7 @@ my_finalizers_t::fsi_map my_finalizers_t::load_finalizer_safety_info() {
 
       // close file after write
       cfile_ds.close();
-   } FC_LOG_AND_RETHROW()
+   } FC_RETHROW_EXCEPTIONS(log_level::error, "corrupted finalizer safety persistence file ${p}", ("p", persist_file_path))
    // don't remove file we can't load
    return res;
 }

--- a/libraries/chain/finality/finalizer.cpp
+++ b/libraries/chain/finality/finalizer.cpp
@@ -50,7 +50,7 @@ finalizer::vote_result finalizer::decide_vote(const block_state_ptr& bsp) {
       // Safety and Liveness both fail if `fsi.lock` is empty. It should not happen.
       // `fsi.lock` is initially set to `lib` when switching to IF or starting from a snapshot.
       // -------------------------------------------------------------------------------------
-      fc_dlog(vote_logger, "liveness check & safety check failed, block ${bn} ${id}, fsi.lock is empty",
+      fc_wlog(vote_logger, "liveness check & safety check failed, block ${bn} ${id}, fsi.lock is empty",
               ("bn", bsp->block_num())("id", bsp->id()));
       res.liveness_check = false;
       res.safety_check   = false;

--- a/libraries/chain/finality/finalizer.cpp
+++ b/libraries/chain/finality/finalizer.cpp
@@ -34,7 +34,7 @@ finalizer::vote_result finalizer::decide_vote(const block_state_ptr& bsp) {
       res.liveness_check = bsp->core.latest_qc_block_timestamp() > fsi.lock.timestamp;
 
       if (!res.liveness_check) {
-         fc_ilog(vote_logger, "liveness check failed, block ${bn} ${id}: ${c} <= ${l}, fsi.lock ${lbn} ${lid}, latest_qc_claim: ${qc}",
+         fc_dlog(vote_logger, "liveness check failed, block ${bn} ${id}: ${c} <= ${l}, fsi.lock ${lbn} ${lid}, latest_qc_claim: ${qc}",
                  ("bn", bsp->block_num())("id", bsp->id())("c", bsp->core.latest_qc_block_timestamp())("l", fsi.lock.timestamp)
                  ("lbn", fsi.lock.block_num())("lid", fsi.lock.block_id)
                  ("qc", bsp->core.latest_qc_claim()));

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -39,11 +39,13 @@ namespace eosio::chain_apis {
                return;
 
             if (!block->contains_extension(chain::quorum_certificate_extension::extension_id())) {
-               std::optional<chain::block_header_extension> fin_ext = block->extract_header_extension(chain::finality_extension::extension_id());
-               chain::qc_claim_t claim = fin_ext ? std::get<chain::finality_extension>(*fin_ext).qc_claim : chain::qc_claim_t{};
-               fc_ilog(chain::vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no qc, claim: ${c}",
-                       ("id", id.str().substr(8, 16))("n", block->block_num())("t", block->timestamp)("p", block->producer)
-                       ("l", (now - block->timestamp).count() / 1000)("c", claim));
+               if (chain::vote_logger.is_enabled(fc::log_level::info)) {
+                  std::optional<chain::block_header_extension> fin_ext = block->extract_header_extension(chain::finality_extension::extension_id());
+                  chain::qc_claim_t claim = fin_ext ? std::get<chain::finality_extension>(*fin_ext).qc_claim : chain::qc_claim_t{};
+                  fc_ilog(chain::vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no qc, claim: ${c}",
+                          ("id", id.str().substr(8, 16))("n", block->block_num())("t", block->timestamp)("p", block->producer)
+                          ("l", (now - block->timestamp).count() / 1000)("c", claim));
+               }
                return;
             }
 

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -39,9 +39,11 @@ namespace eosio::chain_apis {
                return;
 
             if (!block->contains_extension(chain::quorum_certificate_extension::extension_id())) {
-               fc_ilog(chain::vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no votes",
+               std::optional<chain::block_header_extension> fin_ext = block->extract_header_extension(chain::finality_extension::extension_id());
+               chain::qc_claim_t claim = fin_ext ? std::get<chain::finality_extension>(*fin_ext).qc_claim : chain::qc_claim_t{};
+               fc_ilog(chain::vote_logger, "Block ${id}... #${n} @ ${t} produced by ${p}, latency: ${l}ms has no qc, claim: ${c}",
                        ("id", id.str().substr(8, 16))("n", block->block_num())("t", block->timestamp)("p", block->producer)
-                       ("l", (now - block->timestamp).count() / 1000));
+                       ("l", (now - block->timestamp).count() / 1000)("c", claim));
                return;
             }
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -757,8 +757,8 @@ public:
 
    enum class implicit_pause {
       not_paused,   // not implicitly paused
-      prod_paused,  // paused do to not receiving vote associated with producer
-      other_paused  // paused do to not receiving vote from finalizers not associated with producer
+      prod_paused,  // paused due to not receiving vote associated with producer
+      other_paused  // paused due to not receiving vote from finalizers not associated with producer
    };
    implicit_pause implicitly_paused() const {
       if (_producers.empty() || _production_pause_vote_timeout.count() == 0)

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -755,23 +755,32 @@ public:
       }
    }
 
-   // true if paused due to not receiving votes
-   bool is_implicitly_paused() const {
+   enum class implicit_pause {
+      not_paused,   // not implicitly paused
+      prod_paused,  // paused do to not receiving vote associated with producer
+      other_paused  // paused do to not receiving vote from finalizers not associated with producer
+   };
+   implicit_pause implicitly_paused() const {
       if (_producers.empty() || _production_pause_vote_timeout.count() == 0)
-         return false;
+         return implicit_pause::not_paused;
       if (!_is_savanna_active)
-         return false; // no implicit pause in legacy
+         return implicit_pause::not_paused; // no implicit pause in legacy
       if (_producers.contains(eosio::chain::config::system_account_name)) // disable implicit pause for eosio
-         return false;
+         return implicit_pause::not_paused;
 
       auto last_producer_vote_received = _last_producer_vote_received.load(std::memory_order_relaxed);
       auto last_other_vote_received    = _last_other_vote_received.load(std::memory_order_relaxed);
 
       // need a vote within timeout of last accepted block
-      return (_is_producer_active_finalizer &&
-              _accepted_block_time - last_producer_vote_received > _production_pause_vote_timeout)
-          || (_other_active_finalizers &&
-              _accepted_block_time - last_other_vote_received    > _production_pause_vote_timeout);
+      if (_is_producer_active_finalizer &&
+          _accepted_block_time - last_producer_vote_received > _production_pause_vote_timeout) {
+         return implicit_pause::prod_paused;
+      }
+      if (_other_active_finalizers &&
+          _accepted_block_time - last_other_vote_received    > _production_pause_vote_timeout) {
+         return implicit_pause::other_paused;
+      }
+      return implicit_pause::not_paused;
    }
 
    void abort_block() {
@@ -1598,7 +1607,7 @@ void producer_plugin::resume() {
 }
 
 bool producer_plugin::paused() const {
-   return my->_pause_production || my->is_implicitly_paused();
+   return my->_pause_production || (my->implicitly_paused() != producer_plugin_impl::implicit_pause::not_paused);
 }
 
 void producer_plugin_impl::update_runtime_options(const producer_plugin::runtime_options& options) {
@@ -1963,28 +1972,30 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    } else if (_producers.find(scheduled_producer.producer_name) == _producers.end()) {
       _pending_block_mode = pending_block_mode::speculating;
    } else if (num_relevant_signatures == 0) {
-      fc_elog(_log, "Not producing block because I don't have any private keys relevant to authority: ${authority}",
-              ("authority", scheduled_producer.authority));
+      fc_elog(_log, "Not producing block because I don't have any private keys relevant to authority: ${authority}, block ${t}",
+              ("authority", scheduled_producer.authority)("t", block_time));
       _pending_block_mode = pending_block_mode::speculating;
       not_producing_when_time = true;
    } else if (_pause_production) {
-      fc_wlog(_log, "Not producing block because production is explicitly paused");
+      fc_wlog(_log, "Not producing block because production is explicitly paused, block ${t}", ("t", block_time));
       _pending_block_mode = pending_block_mode::speculating;
       not_producing_when_time = true;
    } else if (_max_irreversible_block_age_us.count() >= 0 && irreversible_block_age >= _max_irreversible_block_age_us) {
-      fc_elog(_log, "Not producing block because the irreversible block is too old [age:${age}s, max:${max}s]",
-              ("age", irreversible_block_age.count() / 1'000'000)("max", _max_irreversible_block_age_us.count() / 1'000'000));
+      fc_elog(_log, "Not producing block because the irreversible block is too old [age:${age}s, max:${max}s], block ${t}",
+              ("age", irreversible_block_age.count() / 1'000'000)("max", _max_irreversible_block_age_us.count() / 1'000'000)
+              ("t", block_time));
       _pending_block_mode = pending_block_mode::speculating;
       not_producing_when_time = true;
-   } else if (is_implicitly_paused()) {
-      fc_elog(_log, "Not producing block because no recent votes, last producer vote ${pv}, other votes ${ov}, last block time ${bt}",
-              ("pv", _last_producer_vote_received.load(std::memory_order_relaxed))
+   } else if (implicit_pause p = implicitly_paused(); p != implicit_pause::not_paused) {
+      std::string reason = p == implicit_pause::prod_paused ? "producer votes" : "votes received";
+      fc_elog(_log, "Not producing block because no recent ${r}, block ${t}, last producer vote ${pv}, other votes ${ov}, last accepted block time ${bt}",
+              ("r", std::move(reason))("t", block_time)("pv", _last_producer_vote_received.load(std::memory_order_relaxed))
               ("ov", _last_other_vote_received.load(std::memory_order_relaxed))("bt", _accepted_block_time));
       _pending_block_mode = pending_block_mode::speculating;
       not_producing_when_time = true;
    } else if (_max_reversible_blocks > 0 && head_block_num - head.irreversible_blocknum() > _max_reversible_blocks) {
-      fc_elog(_log, "Not producing block because max-reversible-blocks ${m} reached, head ${h}, lib ${l}.",
-              ("m", _max_reversible_blocks)("h", head_block_num)("l", head.irreversible_blocknum()));
+      fc_elog(_log, "Not producing block because max-reversible-blocks ${m} reached, head ${h}, lib ${l}, block ${t}",
+              ("m", _max_reversible_blocks)("h", head_block_num)("l", head.irreversible_blocknum())("t", block_time));
       _pending_block_mode = pending_block_mode::speculating;
       not_producing_when_time = true;
    }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -758,7 +758,7 @@ public:
    enum class implicit_pause {
       not_paused,   // not implicitly paused
       prod_paused,  // paused due to not receiving vote associated with producer
-      other_paused  // paused due to not receiving vote from finalizers not associated with producer
+      other_paused  // paused due to not receiving any vote from finalizers not associated with producer
    };
    implicit_pause implicitly_paused() const {
       if (_producers.empty() || _production_pause_vote_timeout.count() == 0)

--- a/tests/liveness_test.py
+++ b/tests/liveness_test.py
@@ -40,7 +40,7 @@ try:
     # test relies on production continuing
     extraNodeosArgs=" --production-pause-vote-timeout-ms 0 "
     # "mesh" shape connects nodeA and nodeB to each other
-    if cluster.launch(topo="mesh", pnodes=totalProducerNodes,
+    if cluster.launch(topo="mesh", pnodes=totalProducerNodes, extraNodeosArgs=extraNodeosArgs,
                       totalNodes=totalNodes, totalProducers=totalProducerNodes, loadSystemContract=False,
                       activateIF=activateIF, biosFinalizer=False) is False:
         Utils.cmdError("launcher")


### PR DESCRIPTION
Misc logging improvements:
- Change `liveness check failed` log message to `debug` level to match logging of other finality checks in `decide_vote`.
- Add block timestamp to all `Not producing because` log messages in `producer_plugin`.
- Indicate why producer is implicitly paused in the `Not producing because` log message.

- Add `info` level decide_vote summary log statement, for example:
```
info  2024-08-28T23:54:05.066 chain-0   finalizer.cpp:111             decide_vote          ] block=241 000000f1bd378c3eba4e81bd3e09677f30e7019c41e1c69da066818b2ff95a46, liveness=false, safety=false, can vote=false, voting=no_vote, 2024-08-28T23:52:23.500 <= 2024-08-28T23:52:24.500, locked=145 00000091cee2536578652ccc49fdf32eaac70fe9851e615e1f9834372541af91, latest_qc_claim: {"block_num":143,"is_strong_qc":true}
```
- Change the logging around a corrupt `safety.dat` file. Now when invalid bls key you get the following:
```
info  2024-08-29T00:23:38.026 nodeos    chain_plugin.cpp:1146         plugin_startup       ] Blockchain started; head block is #137
info  2024-08-29T00:23:38.026 nodeos    producer_plugin.cpp:1473      plugin_startup       ] producer plugin:  plugin_startup() begin
info  2024-08-29T00:23:38.027 nodeos    producer_plugin.cpp:1582      plugin_shutdown      ] exit shutdown
info  2024-08-29T00:23:38.027 nodeos    producer_plugin.cpp:1582      plugin_shutdown      ] exit shutdown
info  2024-08-29T00:23:38.041 nodeos    block_handle.cpp:11           write                ] Writing chain_head block 137 00000089843fa26b3eed676d75924faadb4a854da84c16d6fe8f5cffb92de9e1
info  2024-08-29T00:23:38.041 nodeos    fork_database.cpp:646         close                ] Persisting to fork_database file: /home/heifner/ext/spring/cmake-build-debug/TestLogs/disaster_recovery13174/node_00/blocks/reversible/fork_db.dat
info  2024-08-29T00:23:38.041 nodeos    fork_database.cpp:168         close_impl           ] Writing fork_database 8 blocks with root 129:0000008181477bd1bf43bd2f369468ea2ae174d4f43d4e4277020c94cc38604c and head 137:00000089843fa26b3eed676d75924faadb4a854da84c16d6fe8f5cffb92de9e1
debug 2024-08-29T00:23:38.069 nodeos    chain_plugin.cpp:1172         plugin_shutdown      ] exit shutdown
info  2024-08-29T00:23:38.070 nodeos    main.cpp:172                  operator()           ] appbase quit called
info  2024-08-29T00:23:38.070 nodeos    main.cpp:165                  operator()           ] nodeos version v1.0.0-rc2 v1.0.0-rc2-e61b02c84218ac62af7817545dc07dc60d6d7595-dirty
info  2024-08-29T00:23:38.070 nodeos    main.cpp:69                   log_non_default_opti ] Non-default options: blocks-dir = blocks, p2p-listen-endpoint = 0.0.0.0:9876, p2p-server-address = localhost:9876, p2p-peer-address = localhost:9776, p2p-peer-address = localhost:9877, p2p-peer-address = localhost:9878, p2p-peer-address = localhost:9879, plugin = eosio::producer_plugin, signature-provider = EOS6qQjhVb63nCxNkcCsHFW1FaAB5VKrFcnD1iViQ73TPt4jGootd=KEY:***, signature-provider = PUB_BLS_JS5CvKI_f6wZvD4UICBwrAFsHlZ95jr2o5qW04bG1Vs-b_oqcKPjaU-TAfClHV8E2shRfCma13igh-Hlq_lfqETu6h1GccxTFhyvthmCnti9QZyCg5Qs9s9yKMmaTPYAkxMHRQ=KEY:***, producer-name = defproducera, plugin = eosio::net_plugin, plugin = eosio::chain_api_plugin, vote-threads = 4, max-transaction-time = -1, abi-serializer-max-time-ms = 990000, p2p-max-nodes-per-host = 4, max-clients = 25, connection-cleanup-period = 15, plugin = eosio::producer_api_plugin, plugin = eosio::trace_api_plugin, trace-no-abis, production-pause-vote-timeout-ms = 0, http-max-response-time-ms = 990000, config-dir = /home/heifner/ext/spring/cmake-build-debug/TestLogs/disaster_recovery13174/node_00, data-dir = /home/heifner/ext/spring/cmake-build-debug/TestLogs/disaster_recovery13174/node_00, http-validate-host = false, http-server-address = localhost:8888, enable-stale-production, snapshot = /home/heifner/ext/spring/cmake-build-debug/TestLogs/disaster_recovery13174/node_00/snapshots/snapshot-0000007ab3f5f7ce5f6e4193dbf998900afbb7ef2d5db8ad8260711b5e34f4cc.bin
error 2024-08-29T00:23:38.071 nodeos    main.cpp:224                  main                 ] 10 assert_exception: Assert Exception
g1:
    {}
    nodeos  bls_public_key.cpp:18 from_affine_bytes_le
error unpacking St7variantIJN2fc6crypto6blslib14bls_public_keyEEE
    {"type":"St7variantIJN2fc6crypto6blslib14bls_public_keyEEE"}
    nodeos  raw.hpp:701 unpack
corrupted finalizer safety persistence file /home/heifner/ext/spring/cmake-build-debug/TestLogs/disaster_recovery13174/node_00/finalizers/safety.dat
    {"p":"/home/heifner/ext/spring/cmake-build-debug/TestLogs/disaster_recovery13174/node_00/finalizers/safety.dat"}
    nodeos  finalizer.cpp:342 load_finalizer_safety_info

    {}
    nodeos  producer_plugin.cpp:1565 plugin_startup
```


- Pass `extraNodeosArgs` to `cluster.launch`. missed in #661.