### PR TITLE
[1.0] Fix incorrect threshold calculation in setFinalizers

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -1034,9 +1034,6 @@ class Cluster(object):
             node = self.biosNode
         numFins = len(nodes)
         threshold = int(numFins * 2 / 3 + 1)
-        if threshold > 2 and threshold == numFins:
-            # nodes are often stopped, so do not require all node votes
-            threshold = threshold - 1
         if Utils.Debug: Utils.Print(f"threshold: {threshold}, numFins: {numFins}")
         setFinStr =  f'{{"finalizer_policy": {{'
         setFinStr += f'  "threshold": {threshold}, '

--- a/tests/nodeos_snapshot_forked_test.py
+++ b/tests/nodeos_snapshot_forked_test.py
@@ -82,7 +82,8 @@ try:
     # "bridge" shape connects defprocera through defproducerb (in node0) to each other and defproducerc is alone (in node01)
     # and the only connection between those 2 groups is through the bridge node
     if cluster.launch(prodCount=2, topo="bridge", pnodes=totalProducerNodes,
-                      totalNodes=totalNodes, totalProducers=totalProducers, activateIF=activateIF,
+                      totalNodes=totalNodes, totalProducers=totalProducers,
+                      activateIF=activateIF, biosFinalizer=False,
                       specificExtraNodeosArgs=specificExtraNodeosArgs,
                       extraNodeosArgs=extraNodeosArgs) is False:
         Utils.cmdError("launcher")


### PR DESCRIPTION
Fixes an issue that the TestHarness's setFinalizers did not use the same threshold formula as the core contract.