### PR TITLE
[1.0] restore cmake dependency needed for test contract compilation

### DIFF
--- a/libraries/testing/CMakeLists.txt
+++ b/libraries/testing/CMakeLists.txt
@@ -40,6 +40,10 @@ configure_file(contracts.hpp.in include/testing_contracts/contracts.hpp ESCAPE_Q
 add_library(eosio_testing_contracts INTERFACE)
 target_include_directories(eosio_testing_contracts INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include/testing_contracts)
 
+if( EOSIO_COMPILE_TEST_CONTRACTS )
+   add_dependencies( eosio_testing_contracts testing_contracts_project)
+endif()
+
 configure_file(contracts.cpp.in contracts.cpp ESCAPE_QUOTES)
 
 ## SORT .cpp by most likely to change / break compile


### PR DESCRIPTION
removed in https://github.com/AntelopeIO/spring/commit/dd66bfc075c5880776bc8c35011c1761d5f9723f

Without this PR  we have compilation issues such as:

```
cFAILED: libraries/testing/CMakeFiles/eosio_testing.dir/contracts.cpp.o 
/usr/bin/clang++-18 -DBN256_HAS_EXTINT 
...
 olor=always -Wno-register -MD -MT libraries/testing/CMakeFiles/eosio_testing.dir/contracts.cpp.o -MF libraries/testing/CMakeFiles/eosio_testing.dir/contracts.cpp.o.d -o libraries/testing/CMakeFiles/eosio_testing.dir/contracts.cpp.o -c /home/greg/github/enf/spring/build_clang18_debug/libraries/testing/contracts.cpp
<inline asm>:6:9: error: Could not find incbin file '/home/greg/github/enf/spring/build_clang18_debug/libraries/testing/contracts/eosio.bios/eosio.bios.wasm'
    6 | .incbin "/home/greg/github/enf/spring/build_clang18_debug/libraries/testing/contracts/eosio.bios/eosio.bios.wasm"
      |         ^
<inline asm>:24:9: error: Could not find incbin file '/home/greg/github/enf/spring/build_clang18_debug/libraries/testing/contracts/eosio.bios/eosio.bios.abi'
   24 | .incbin "/home/greg/github/enf/spring/build_clang18_debug/libraries/testing/contracts/eosio.bios/eosio.bios.abi"
      |         ^
```