### PR TITLE
[1.0 -> main] Fix production_restart test flakiness

### DIFF
--- a/tests/production_restart.py
+++ b/tests/production_restart.py
@@ -81,11 +81,12 @@ try:
     node0.keys[0].blspubkey = "PUB_BLS_JzblSr2sf_UhxQjGxOtHbRCBkHgSB1RG4xUbKKl-fKtUjx6hyOHajnVQT4IvBF4PutlX7JTC14IqIjADlP-3_G2MXRhBlkB57r2u59OCwRQQEDqmVSADf6CoT8zFUXcSgHFw7w" # setFinalizers uses the first key in key list (index 0)
     node0.keys[0].blspop    = "SIG_BLS_Z5fJqFv6DIsHFhBFpkHmL_R48h80zVKQHtB5lrKGOVZTaSQNuVaXD_eHg7HBvKwY6zqgA_vryCLQo5W0Inu6HtLkGL2gYX2UHJjrZJZpfJSKG0ynqAZmyrCglxRLNm8KkFdGGR8oJXf5Yzyu7oautqTPniuKLBvNeQxGJGDOQtHSQ0uP3mD41pWzPFRoi10BUor9MbwUTQ7fO7Of4ZjhVM3IK4JrqX1RBXkDX83Wi9xFzs_fdPIyMqmgEzFgolgUa8XN4Q"
 
-    assert cluster.setFinalizers([node0, node1], node0), "setfinalizers failed"
-    assert node0.waitForLibToAdvance(), "node0 did not advance LIB after setfinalizers"
-    # Wait for head to advance twice to make sure pending policy is in place
-    node0.waitForHeadToAdvance()
-    node0.waitForHeadToAdvance()
+    transId = cluster.setFinalizers([node0, node1], node0)
+    assert transId, "setfinalizers failed"
+    # A proposed finalizer policy is promoted to pending only after the block where it
+    # was proposed become irreversible.
+    # Wait for pending policy is in place.
+    assert node0.waitForTransFinalization(transId), f'setfinalizer transaction {transId} failed to be rolled into a LIB block'
 
     # Check if a pending policy exists
     finalizerInfo = node0.getFinalizerInfo()


### PR DESCRIPTION
The test requires pending policy to be in place. It waits on LIB. But a proposed policy is promoted to pending only after the block where it was proposed becomes final; that LIB is not necessarily the LIB where the policy was proposed.

In the test failure reported by https://github.com/AntelopeIO/spring/issues/672, it was LIB on the block before setfinalizer because the setfinalizer was sent to the node that was not producing at the time. On the producer the setfinalizer is in the next block.

The solution is wait until the block where a finalizer policy was proposed becomes final before checking pending policy.

Forwards https://github.com/AntelopeIO/spring/pull/674

Resolves https://github.com/AntelopeIO/spring/issues/672