### PR TITLE
Don't use deduced return type as it fails in template instantation

### DIFF
--- a/unittests/contracts/eosio.mechanics/eosmechanics.cpp
+++ b/unittests/contracts/eosio.mechanics/eosmechanics.cpp
@@ -108,7 +108,7 @@ CONTRACT eosmechanics : public eosio::contract {
             uint64_t id;
             std::string one;
 
-            auto primary_key()const { return id; }
+            uint64_t primary_key()const { return id; }
             EOSLIB_SERIALIZE(ramdata, (id)(one))
         };
 


### PR DESCRIPTION
Partially resolves #677.

An issue remains with the use of the macro `EOSIO_DISPATCH( eosiosystem::system_contract, ...` in `unittests/contracts/eosio.system/eosio.system.cpp`.

Original issue was: `error: case value is not a constant expression` because `check()` is not `constexpr`.

I tried making `check()` constexpr in cdt's `libraries/eosiolib/core/eosio/check.hpp`, but check calls the extern "C" functions `eosio_assert` which I don't think can be made constexpr.

So I tried updating the `EOSIO_DISPATCH` to use a series of `if () ... else` instead of a switch statement. This appears to work, but the `EOSIO_DISPATCH` still fails on this contract, and it appears that it is because it attempts to dispatch too many actions:

```
EOSIO_DISPATCH( eosiosystem::system_contract,
// native.hpp (newaccount definition is actually in eosio.system.cpp)
(newaccount)(updateauth)(deleteauth)(linkauth)(unlinkauth)(canceldelay)(onerror)(setabi)
// eosio.system.cpp
      (init)(setram)(setramrate)(setparams)(setpriv)(setalimits)(rmvproducer)(updtrevision)(bidname)(bidrefund)
// rex.cpp
      (deposit)(withdraw)(buyrex)(unstaketorex)(sellrex)(cnclrexorder)(rentcpu)(rentnet)(fundcpuloan)(fundnetloan)
      (defcpuloan)(defnetloan)(updaterex)(consolidate)(rexexec)(closerex)
// delegate_bandwidth.cpp
      (buyrambytes)(buyram)(sellram)(delegatebw)(undelegatebw)(refund)
// voting.cpp
      (regproducer)(unregprod)(voteproducer)(regproxy)
// producer_pay.cpp
      (onblock)(claimrewards)
)
```

The same macro builds fine if I remove a bunch of the actions.