### PR TITLE
[1.0] Test accept_block_header, accept_block, and irreversible_block signals

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -8,6 +8,7 @@
 #include <fc/io/json.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/tuple/tuple_io.hpp>
+#include <boost/unordered/unordered_flat_map.hpp>
 
 #include <eosio/testing/bls_utils.hpp>
 
@@ -591,7 +592,7 @@ namespace eosio::testing {
          map<transaction_id_type, transaction_receipt> chain_transactions;
          map<account_name, block_id_type>              last_produced_block;
          enum class block_signal { block_start, accepted_block_header, accepted_block, irreversible_block };
-         map<block_id_type, block_signal>              blocks_signaled;
+         boost::unordered_flat_map<block_id_type, block_signal> blocks_signaled;
          unapplied_transaction_queue                   unapplied_transactions;
 
       public:

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -576,6 +576,9 @@ namespace eosio::testing {
          signed_block_ptr       _finish_block();
          void                   _check_for_vote_if_needed(controller& c, const block_handle& bh);
 
+         enum class block_signal { block_start, accepted_block_header, accepted_block, irreversible_block };
+         bool                   _check_signal(const block_id_type& id, block_signal sig);
+
       // Fields:
       protected:
          bool                   _expect_votes {true};                          // if set, ensure the node votes on each block
@@ -591,9 +594,8 @@ namespace eosio::testing {
          controller::config                            cfg;
          map<transaction_id_type, transaction_receipt> chain_transactions;
          map<account_name, block_id_type>              last_produced_block;
-         enum class block_signal { block_start, accepted_block_header, accepted_block, irreversible_block };
-         boost::unordered_flat_map<block_id_type, block_signal> blocks_signaled;
          unapplied_transaction_queue                   unapplied_transactions;
+         boost::unordered_flat_map<block_id_type, block_signal> blocks_signaled;
 
       public:
          vector<digest_type>                           protocol_features_to_be_activated_wo_preactivation;

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -590,6 +590,8 @@ namespace eosio::testing {
          controller::config                            cfg;
          map<transaction_id_type, transaction_receipt> chain_transactions;
          map<account_name, block_id_type>              last_produced_block;
+         enum class block_signal { block_start, accepted_block_header, accepted_block, irreversible_block };
+         map<block_id_type, block_signal>              blocks_signaled;
          unapplied_transaction_queue                   unapplied_transactions;
 
       public:

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -391,7 +391,7 @@ namespace eosio::testing {
          auto i = blocks_signaled.find(id);
          if (i == blocks_signaled.end()) {
             // can be signaled on restart as the first thing since other signals happened before shutdown
-            blocks_signaled[id] = block_signal::accepted_block_header;
+            blocks_signaled[id] = block_signal::irreversible_block;
          } else {
             BOOST_TEST((i->second == block_signal::accepted_block), "should get irreversible_block signal only once");
             i->second = block_signal::irreversible_block;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -359,11 +359,10 @@ namespace eosio::testing {
             BOOST_TEST(block->block_num() > lib_number);
             auto i = blocks_signaled.find(id);
             BOOST_TEST_REQUIRE((i != blocks_signaled.end()), "should get accepted_block signal after accepted_block_header signal");
-            if (i->second == block_signal::accepted_block) {
-               // fork switch, accepted block signaled when block re-applied
+            if (i->second != block_signal::accepted_block) { // on fork switch, accepted block signaled when block re-applied
+               BOOST_TEST((i->second == block_signal::accepted_block_header));
+               i->second = block_signal::accepted_block;
             }
-            BOOST_TEST((i->second == block_signal::accepted_block_header || i->second == block_signal::accepted_block));
-            i->second = block_signal::accepted_block;
 
             for (auto receipt : block->transactions) {
                if (std::holds_alternative<packed_transaction>(receipt.trx)) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -348,8 +348,7 @@ namespace eosio::testing {
       [[maybe_unused]] auto accepted_block_header_connection = control->accepted_block_header().connect([this](const block_signal_params& t) {
             const auto& [block, id] = t;
             FC_ASSERT(block);
-            auto i = blocks_signaled.find(id);
-            BOOST_TEST((i == blocks_signaled.end()), "should get accepted_block_header signal only once, and before accepted_block signal");
+            BOOST_TEST(!blocks_signaled.contains(id), "should get accepted_block_header signal only once, and before accepted_block signal");
             blocks_signaled[id] = block_signal::accepted_block_header;
          });
       chain_transactions.clear();
@@ -357,11 +356,11 @@ namespace eosio::testing {
             const auto& [block, id] = t;
             FC_ASSERT(block);
             BOOST_TEST(block->block_num() > lib_number);
-            auto i = blocks_signaled.find(id);
-            BOOST_TEST_REQUIRE((i != blocks_signaled.end()), "should get accepted_block signal after accepted_block_header signal");
-            if (i->second != block_signal::accepted_block) { // on fork switch, accepted block signaled when block re-applied
-               BOOST_TEST((i->second == block_signal::accepted_block_header));
-               i->second = block_signal::accepted_block;
+            auto itr = blocks_signaled.find(id);
+            BOOST_TEST_REQUIRE((itr != blocks_signaled.end()), "should get accepted_block signal after accepted_block_header signal");
+            if (itr->second != block_signal::accepted_block) { // on fork switch, accepted block signaled when block re-applied
+               BOOST_TEST((itr->second == block_signal::accepted_block_header));
+               itr->second = block_signal::accepted_block;
             }
 
             for (auto receipt : block->transactions) {
@@ -387,13 +386,13 @@ namespace eosio::testing {
          lib_id    = id;
          BOOST_TEST(lib_block->block_num() > lib_number); // let's make sure that lib always increases
          lib_number = lib_block->block_num();
-         auto i = blocks_signaled.find(id);
-         if (i == blocks_signaled.end()) {
+         auto itr = blocks_signaled.find(id);
+         if (itr == blocks_signaled.end()) {
             // can be signaled on restart as the first thing since other signals happened before shutdown
             blocks_signaled[id] = block_signal::irreversible_block;
          } else {
-            BOOST_TEST((i->second == block_signal::accepted_block), "should get irreversible_block signal only once");
-            i->second = block_signal::irreversible_block;
+            BOOST_TEST((itr->second == block_signal::accepted_block), "should get irreversible_block signal only once");
+            itr->second = block_signal::irreversible_block;
          }
      });
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -344,6 +344,7 @@ namespace eosio::testing {
                             itr->second == block_signal::accepted_block);
 
       case block_signal::irreversible_block:
+         // can be signaled on restart as the first thing since other signals happened before shutdown
          return !present ||
                 (present && itr->second == block_signal::accepted_block);
       }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -347,6 +347,8 @@ namespace eosio::testing {
          return !present ||
                 (present && itr->second == block_signal::accepted_block);
       }
+
+      return false;
    }
 
    void base_tester::open( protocol_feature_set&& pfs, std::optional<chain_id_type> expected_chain_id, const std::function<void()>& lambda ) {


### PR DESCRIPTION
Add verification to libtester that `controller` signals `accept_block_header`, `accept_block`, `irreversible_block` happen in order and do not repeat.

Working on #619 and wanted a test to verify signals continue to work the same as before.