### PR TITLE
[1.0] Harden ordered_diff 

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4003,12 +4003,13 @@ struct controller_impl {
    template<typename ForkDB, typename BS>
    block_handle create_block_state_i( ForkDB& forkdb, const block_id_type& id, const signed_block_ptr& b, const BS& prev ) {
       constexpr bool savanna_mode = std::is_same_v<typename std::decay_t<BS>, block_state>;
-      if constexpr (savanna_mode) {
-         // Verify claim made by finality_extension in block header extension and
-         // quorum_certificate_extension in block extension are valid.
-         // This is the only place the evaluation is done.
-         verify_qc_claim(id, b, prev);
-      }
+
+      // Verify claim made by finality_extension in block header extension and
+      // quorum_certificate_extension in block extension are valid.
+      // This is the only place the evaluation is done.
+      // Note: the purpose of running verify_qc_claim on Legacy blocks too is to
+      // safe guard Legacy blocks.
+      verify_qc_claim(id, b, prev);
 
       auto trx_mroot = calculate_trx_merkle( b->transactions, savanna_mode );
       EOS_ASSERT( b->transaction_mroot == trx_mroot,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3999,8 +3999,9 @@ struct controller_impl {
       bsp->verify_qc(qc_proof);
    }
 
-   // Verify Legacy blocks do not have a block header finality extension or
-   // a block QC extension.
+   // Verify a Legacy block does not have a QC block extension.
+   // (It can have a finality block header extension during transition to
+   // Savanna)
    void verify_legacy_block_exts( const signed_block_ptr& b ) {
       uint32_t block_num = b->block_num();
 
@@ -4010,13 +4011,6 @@ struct controller_impl {
       EOS_ASSERT( !qc_extension_present,
                   block_validate_exception,
                   "Legacy block #${b} includes a QC block extension",
-                  ("b", block_num) );
-
-      auto f_ext_id = finality_extension::extension_id();
-      std::optional<block_header_extension> header_ext = b->extract_header_extension(f_ext_id);
-      EOS_ASSERT( !header_ext,
-                  block_validate_exception,
-                  "Legacy block #${b} includes a finality block header extension",
                   ("b", block_num) );
    }
 

--- a/libraries/libfc/include/fc/container/ordered_diff.hpp
+++ b/libraries/libfc/include/fc/container/ordered_diff.hpp
@@ -41,51 +41,51 @@ public:
 
       diff_result result;
       while (s < source.size() || t < target.size()) {
+         FC_ASSERT(s < std::numeric_limits<SizeType>::max());
+         FC_ASSERT(t < std::numeric_limits<SizeType>::max());
          if (s < source.size() && t < target.size()) {
-            FC_ASSERT(s < std::numeric_limits<SizeType>::max());
-            FC_ASSERT(t < std::numeric_limits<SizeType>::max());
             if (source[s] == target[t]) {
                // nothing to do, skip over
                ++s;
                ++t;
             } else { // not equal
                if (s == source.size() - 1 && t == target.size() - 1) {
+                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
+                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   // both at end, insert target and remove source
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
-                  FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
-                  FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++s;
                   ++t;
                } else if (s + 1 < source.size() && t + 1 < target.size() && source[s + 1] == target[t + 1]) {
+                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
+                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   // misalignment, but next value equal, insert and remove
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
-                  FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
-                  FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++s;
                   ++t;
                } else if (t + 1 < target.size() && source[s] == target[t + 1]) {
                   // source equals next target, insert current target
+                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   result.insert_indexes.emplace_back(t, target[t]);
-                  FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++t;
                } else { // source[s + 1] == target[t]
                   // target matches next source, remove current source
+                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   result.remove_indexes.push_back(s);
-                  FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++s;
                }
             }
          } else if (s < source.size()) {
             // remove extra in source
+            FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
             result.remove_indexes.push_back(s);
-            FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
             ++s;
          } else if (t < target.size()) {
             // insert extra in target
+            FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
             result.insert_indexes.emplace_back(t, target[t]);
-            FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
             ++t;
          }
       }
@@ -115,8 +115,8 @@ public:
       for (auto& [index, value] : diff.insert_indexes) {
          FC_ASSERT(index <= container.size(), "diff.insert_indexes index ${idx} not in range ${s}",
                    ("idx", index)("s", container.size()));
+         FC_ASSERT(container.size() < MAX_NUM_ARRAY_ELEMENTS);
          container.insert(container.begin() + index, std::move(value));
-         FC_ASSERT(container.size() <= MAX_NUM_ARRAY_ELEMENTS);
       }
       return container;
    }

--- a/libraries/libfc/include/fc/container/ordered_diff.hpp
+++ b/libraries/libfc/include/fc/container/ordered_diff.hpp
@@ -42,17 +42,15 @@ public:
       diff_result result;
       while (s < source.size() || t < target.size()) {
          if (s < source.size() && t < target.size()) {
+            FC_ASSERT(s < std::numeric_limits<SizeType>::max());
+            FC_ASSERT(t < std::numeric_limits<SizeType>::max());
             if (source[s] == target[t]) {
                // nothing to do, skip over
-               FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
-               FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
                ++s;
                ++t;
             } else { // not equal
                if (s == source.size() - 1 && t == target.size() - 1) {
                   // both at end, insert target and remove source
-                  FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
-                  FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
                   FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
@@ -61,8 +59,6 @@ public:
                   ++t;
                } else if (s + 1 < source.size() && t + 1 < target.size() && source[s + 1] == target[t + 1]) {
                   // misalignment, but next value equal, insert and remove
-                  FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
-                  FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
                   FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
@@ -71,13 +67,11 @@ public:
                   ++t;
                } else if (t + 1 < target.size() && source[s] == target[t + 1]) {
                   // source equals next target, insert current target
-                  FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
                   result.insert_indexes.emplace_back(t, target[t]);
                   FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++t;
                } else { // source[s + 1] == target[t]
                   // target matches next source, remove current source
-                  FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
                   result.remove_indexes.push_back(s);
                   FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++s;
@@ -85,13 +79,11 @@ public:
             }
          } else if (s < source.size()) {
             // remove extra in source
-            FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
             result.remove_indexes.push_back(s);
             FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
             ++s;
          } else if (t < target.size()) {
             // insert extra in target
-            FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
             result.insert_indexes.emplace_back(t, target[t]);
             FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
             ++t;
@@ -113,7 +105,7 @@ public:
       // Remove from the source based on diff.remove_indexes
       std::ptrdiff_t offset = 0;
       for (SizeType index : diff.remove_indexes) {
-         FC_ASSERT(index + offset <= container.size(), "diff.remove_indexes index ${idx} + offset ${o} not in range ${s}",
+         FC_ASSERT(index + offset < container.size(), "diff.remove_indexes index ${idx} + offset ${o} not in range ${s}",
                    ("idx", index)("o", offset)("s", container.size()));
          container.erase(container.begin() + index + offset);
          --offset;

--- a/libraries/libfc/test/test_ordered_diff.cpp
+++ b/libraries/libfc/test/test_ordered_diff.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
       BOOST_TEST(source == target);
    }
    { // full
-      vector<uint8_t> source(std::numeric_limits<uint8_t>::max());
+      vector<uint8_t> source(std::numeric_limits<uint8_t>::max()-1);
       std::iota(source.begin(), source.end(), 0);
       vector<uint8_t> target(source.size());
       std::reverse_copy(source.begin(), source.end(), target.begin());

--- a/libraries/libfc/test/test_ordered_diff.cpp
+++ b/libraries/libfc/test/test_ordered_diff.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
       BOOST_TEST(source == target);
    }
    { // full
-      vector<uint8_t> source(std::numeric_limits<uint8_t>::max()+1);
+      vector<uint8_t> source(std::numeric_limits<uint8_t>::max());
       std::iota(source.begin(), source.end(), 0);
       vector<uint8_t> target(source.size());
       std::reverse_copy(source.begin(), source.end(), target.begin());


### PR DESCRIPTION
`ordered_diff` is used to process the finalizer and proposer policy diffs from block header extension `finality_extension`. Since the `finality_extension`, is provided to a node to validate, validate the diff during `apply_diff`.

Related to #691