### PR TITLE
[1.0] Verify finality and QC extensions in Legacy and Transition blocks

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4046,7 +4046,7 @@ struct controller_impl {
          const auto& prev_finality_ext = std::get<finality_extension>(it->second);
          EOS_ASSERT( f_ext.qc_claim.block_num == prev_finality_ext.qc_claim.block_num,
                      invalid_qc_claim,
-                     "Transition block #${b} QC claim block_num not equal to previous QC claim block_num",
+                     "Non Genesis Transition block #${b} QC claim block_num not equal to previous QC claim block_num",
                      ("b", block_num) );
          EOS_ASSERT( !f_ext.new_finalizer_policy_diff, invalid_qc_claim,
                      "Non Genesis Transition block #${b} finality block header extension may not have new_finalizer_policy_diff",

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3894,26 +3894,13 @@ struct controller_impl {
       bool qc_extension_present = block_exts.count(qc_ext_id) != 0;
       uint32_t block_num = b->block_num();
 
-      if( !header_ext ) {
-         // If there is no header extension, ensure the block does not have a QC and also the previous
-         // block doesn't have a header extension either. Then return early.
-         // ------------------------------------------------------------------------------------------
-         EOS_ASSERT( !qc_extension_present,
-                     invalid_qc_claim,
-                     "Block #${b} includes a QC block extension, but doesn't have a finality header extension",
-                     ("b", block_num) );
+      // This function is called only in Savanna. Finality block header
+      // extension must exist
+      EOS_ASSERT( header_ext,
+                  invalid_qc_claim,
+                  "Block #${b} doesn't have a finality header extension",
+                  ("b", block_num) );
 
-         EOS_ASSERT( !prev_finality_ext,
-                     invalid_qc_claim,
-                     "Block #${b} doesn't have a finality header extension even though its predecessor does.",
-                     ("b", block_num) );
-
-         dlog("received block: #${bn} ${t} ${prod} ${id}, no qc claim, previous: ${p}",
-              ("bn", block_num)("t", b->timestamp)("prod", b->producer)("id", id)("p", b->previous));
-         return;
-      }
-
-      assert(header_ext);
       const auto& f_ext        = std::get<finality_extension>(*header_ext);
       const auto  new_qc_claim = f_ext.qc_claim;
 
@@ -3999,15 +3986,94 @@ struct controller_impl {
       bsp->verify_qc(qc_proof);
    }
 
+   // Verify QC block extension and finality block header extension on a Legacy
+   // or Transition block.
+   void verify_legacy_block_exts( const signed_block_ptr& b, const block_header_state_legacy& prev ) {
+      uint32_t block_num = b->block_num();
+
+      auto block_exts = b->validate_and_extract_extensions();
+      auto qc_ext_id = quorum_certificate_extension::extension_id();
+      bool qc_extension_present = block_exts.count(qc_ext_id) != 0;
+      EOS_ASSERT( !qc_extension_present,
+                  block_validate_exception,
+                  "Legacy block #${b} includes a QC block extension",
+                  ("b", block_num) );
+
+      EOS_ASSERT( !b->is_proper_svnn_block(),
+                  block_validate_exception,
+                  "Legacy block #${b} may not be Proper Savnanna block",
+                  ("b", block_num) );
+
+      EOS_ASSERT( !prev.header.is_proper_svnn_block(),
+                  block_validate_exception,
+                  "Legacy block's #${b} previous block may not be Proper Savnanna block",
+                  ("b", block_num) );
+
+      auto f_ext_id = finality_extension::extension_id();
+      std::optional<block_header_extension> header_ext = b->extract_header_extension(f_ext_id);
+
+      if (!header_ext) {
+         auto it = prev.header_exts.find(finality_extension::extension_id());
+         EOS_ASSERT( it == prev.header_exts.end(),
+                     block_validate_exception,
+                     "Block #${b} does not have finality block header extension but its previous block does have",
+                     ("b", block_num) );
+
+         return;
+      }
+
+      // Transition Block
+      const auto& f_ext = std::get<finality_extension>(*header_ext);
+      EOS_ASSERT( !f_ext.qc_claim.is_strong_qc,
+                  block_validate_exception,
+                  "Transition block #${b} has a strong QC claim",
+                  ("b", block_num) );
+      EOS_ASSERT( !f_ext.new_proposer_policy_diff,
+                  block_validate_exception,
+                  "Transition block #${b} has new_proposer_policy_diff",
+                  ("b", block_num) );
+
+      if (auto it = prev.header_exts.find(finality_extension::extension_id()); it != prev.header_exts.end()) {
+         const auto& prev_finality_ext = std::get<finality_extension>(it->second);
+         EOS_ASSERT( f_ext.qc_claim.block_num == prev_finality_ext.qc_claim.block_num,
+                     block_validate_exception,
+                     "Transition block #${b} QC claim block_num not equal to previous QC claim block_num",
+                     ("b", block_num) );
+      } else {
+         // Savanna Genesis Block
+         EOS_ASSERT( f_ext.qc_claim.block_num == block_num,
+                     block_validate_exception,
+                     "Savanna Genesis block #${b} QC claim block_num not equal to current block_num",
+                     ("b", block_num) );
+         EOS_ASSERT( f_ext.new_finalizer_policy_diff,
+                     block_validate_exception,
+                     "Savanna Genesis block #${b} finality block header extension misses new_finalizer_policy_diff",
+                     ("b", block_num) );
+
+         finalizer_policy no_policy;
+         // apply_diff will FC_ASSERT if new_finalizer_policy_diff is malformated
+         finalizer_policy genesis_policy = no_policy.apply_diff(*f_ext.new_finalizer_policy_diff);
+         EOS_ASSERT( genesis_policy.generation == 1,
+                     block_validate_exception,
+                     "Savanna Genesis block #${b} finalizer policy generation (${g}) not 1",
+                     ("b", block_num)("g", genesis_policy.generation) );
+      }
+   }
+
    // thread safe, expected to be called from thread other than the main thread
    template<typename ForkDB, typename BS>
    block_handle create_block_state_i( ForkDB& forkdb, const block_id_type& id, const signed_block_ptr& b, const BS& prev ) {
       constexpr bool savanna_mode = std::is_same_v<typename std::decay_t<BS>, block_state>;
+
+      // Verify claim made by finality_extension in block header extension and
+      // quorum_certificate_extension in block extension are valid.
+      // This is the only place the evaluation is done.
+      // Note: the purpose of running verify_qc_claim on Legacy blocks too is to
+      // safe guard Legacy blocks.
       if constexpr (savanna_mode) {
-         // Verify claim made by finality_extension in block header extension and
-         // quorum_certificate_extension in block extension are valid.
-         // This is the only place the evaluation is done.
          verify_qc_claim(id, b, prev);
+      } else {
+         verify_legacy_block_exts(b, prev);
       }
 
       auto trx_mroot = calculate_trx_merkle( b->transactions, savanna_mode );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3908,17 +3908,14 @@ struct controller_impl {
            ("bn", block_num)("t", b->timestamp)("prod", b->producer)("id", id)
            ("qc", new_qc_claim)("p", b->previous));
 
-      // If there is a header extension, but the previous block does not have a header extension,
-      // ensure the block does not have a QC and the QC claim of the current block has a block_num
-      // of the current block’s number and that it is a claim of a weak QC. Then return early.
+      // The only time a block should have a finality block header extension but
+      // its parent block does not, is if it is a Savanna Genesis block (which is
+      // necessarily a Transition block). Since verify_qc_claim will not be called
+      // on Transition blocks, prev_finality_ext should always be present
       // -------------------------------------------------------------------------------------------------
-      if (!prev_finality_ext) {
-         EOS_ASSERT( !qc_extension_present && new_qc_claim.block_num == block_num && new_qc_claim.is_strong_qc == false,
-                     invalid_qc_claim,
-                     "Block #${b}, which is the finality transition block, doesn't have the expected extensions",
-                     ("b", block_num) );
-         return;
-      }
+      EOS_ASSERT( prev_finality_ext, invalid_qc_claim,
+                  "Previous block of Block #${b} doesn't have finality block header extension",
+                  ("b", block_num) );
 
       // at this point both current block and its parent have IF extensions, and we are past the
       // IF transition block

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3882,7 +3882,7 @@ struct controller_impl {
    // and quorum_certificate_extension in block extension are valid.
    // Called from net-threads. It is thread safe as signed_block is never modified after creation.
    // -----------------------------------------------------------------------------
-   void verify_qc_claim( const block_id_type& id, const signed_block_ptr& b, const block_header_state& prev ) {
+   void verify_proper_block_exts( const block_id_type& id, const signed_block_ptr& b, const block_header_state& prev ) {
       auto qc_ext_id = quorum_certificate_extension::extension_id();
       auto f_ext_id  = finality_extension::extension_id();
 
@@ -3910,7 +3910,7 @@ struct controller_impl {
 
       // The only time a block should have a finality block header extension but
       // its parent block does not, is if it is a Savanna Genesis block (which is
-      // necessarily a Transition block). Since verify_qc_claim will not be called
+      // necessarily a Transition block). Since verify_proper_block_exts will not be called
       // on Transition blocks, prev_finality_ext should always be present
       // -------------------------------------------------------------------------------------------------
       EOS_ASSERT( prev_finality_ext, invalid_qc_claim,
@@ -4101,7 +4101,7 @@ struct controller_impl {
          EOS_ASSERT( b->is_proper_svnn_block(), block_validate_exception,
                      "create_block_state_i cannot be called on block #${b} which is not a Savanna block while its parent is a Savanna block",
                      ("b", b->block_num()) );
-         verify_qc_claim(id, b, prev);
+         verify_proper_block_exts(id, b, prev);
       } else {
          EOS_ASSERT( !b->is_proper_svnn_block(), block_validate_exception,
                      "create_block_state_i cannot be called on block #${b} which is a Savanna block while its parent is not a Savanna block",
@@ -4199,7 +4199,7 @@ struct controller_impl {
       return fork_db.apply<std::optional<block_handle>>(unlinkable, f);
    }
 
-   // thread safe, QC already verified by verify_qc_claim
+   // thread safe, QC already verified by verify_proper_block_exts
    void integrate_received_qc_to_block(const block_state_ptr& bsp_in) {
       // extract QC from block extension
       assert(bsp_in->block);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4010,10 +4010,10 @@ struct controller_impl {
                   ("b", block_num) );
 
       auto f_ext_id = finality_extension::extension_id();
-      std::optional<block_header_extension> header_ext = b->extract_header_extension(f_ext_id);
+      std::optional<block_header_extension> finality_ext = b->extract_header_extension(f_ext_id);
 
       // Make sure Transition block is not gone back to Legacy
-      if (!header_ext) {
+      if (!finality_ext) {
          auto it = prev.header_exts.find(finality_extension::extension_id());
          EOS_ASSERT( it == prev.header_exts.end(),
                      block_validate_exception,
@@ -4024,7 +4024,7 @@ struct controller_impl {
       }
 
       // Transition Block
-      const auto& f_ext = std::get<finality_extension>(*header_ext);
+      const auto& f_ext = std::get<finality_extension>(*finality_ext);
       EOS_ASSERT( !f_ext.qc_claim.is_strong_qc,
                   block_validate_exception,
                   "Transition block #${b} has a strong QC claim",

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4031,7 +4031,7 @@ struct controller_impl {
       assert(finality_ext);
       const auto& f_ext = std::get<finality_extension>(*finality_ext);
 
-      EOS_ASSERT( !f_ext.new_proposer_policy_diff, invalid_qc_claim,
+      EOS_ASSERT( !f_ext.new_proposer_policy_diff, block_validate_exception,
                   "Transition block #${b} has new_proposer_policy_diff",
                   ("b", block_num) );
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4061,9 +4061,7 @@ struct controller_impl {
             EOS_ASSERT( genesis_policy.generation == 1, block_validate_exception,
                         "Savanna Genesis block #${b} finalizer policy generation (${g}) not 1",
                         ("b", block_num)("g", genesis_policy.generation) );
-         } catch( ... ) {
-            EOS_THROW(block_validate_exception, "Failed to apply Genesis block finalizer_policy_diff");
-         }
+         } EOS_RETHROW_EXCEPTIONS(block_validate_exception, "applying diff of Savanna Genesis Bloc")
       }
    }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3919,9 +3919,6 @@ struct controller_impl {
                   "Proper Savanna block #${b} may not have previous block that is a Legacy block",
                   ("b", block_num) );
 
-      // at this point both current block and its parent have IF extensions, and we are past the
-      // IF transition block
-      // ----------------------------------------------------------------------------------------
       assert(prev_finality_ext);
       const auto& prev_qc_claim = prev_finality_ext->qc_claim;
 
@@ -4068,10 +4065,10 @@ struct controller_impl {
    // thread safe, expected to be called from thread other than the main thread
    template<typename ForkDB, typename BS>
    block_handle create_block_state_i( ForkDB& forkdb, const block_id_type& id, const signed_block_ptr& b, const BS& prev ) {
-      constexpr bool is_proper_savanna_block = std::is_same_v<typename std::decay_t<BS>, block_state>;
-      assert(is_proper_savanna_block == b->is_proper_svnn_block());
+      constexpr bool prev_is_of_type_block_state = std::is_same_v<typename std::decay_t<BS>, block_state>;
+      assert(prev_is_of_type_block_state == b->is_proper_svnn_block());
 
-      if constexpr (is_proper_savanna_block) {
+      if constexpr (prev_is_of_type_block_state) {
          EOS_ASSERT( b->is_proper_svnn_block(), block_validate_exception,
                      "create_block_state_i cannot be called on block #${b} which is not a Proper Savanna block unless the prev block state provided is of type block_state",
                      ("b", b->block_num()) );
@@ -4088,7 +4085,7 @@ struct controller_impl {
          }
       }
 
-      auto trx_mroot = calculate_trx_merkle( b->transactions, is_proper_savanna_block );
+      auto trx_mroot = calculate_trx_merkle( b->transactions, prev_is_of_type_block_state );
       EOS_ASSERT( b->transaction_mroot == trx_mroot,
                   block_validate_exception,
                   "invalid block transaction merkle root ${b} != ${c}", ("b", b->transaction_mroot)("c", trx_mroot) );
@@ -4108,14 +4105,14 @@ struct controller_impl {
       EOS_ASSERT( id == bsp->id(), block_validate_exception,
                   "provided id ${id} does not match block id ${bid}", ("id", id)("bid", bsp->id()) );
 
-      if constexpr (is_proper_savanna_block) {
+      if constexpr (prev_is_of_type_block_state) {
          integrate_received_qc_to_block(bsp); // Save the received QC as soon as possible, no matter whether the block itself is valid or not
          consider_voting(bsp, use_thread_pool_t::no);
       }
 
       if (!should_terminate(bsp->block_num())) {
          forkdb.add(bsp, ignore_duplicate_t::yes);
-         if constexpr (is_proper_savanna_block)
+         if constexpr (prev_is_of_type_block_state)
             vote_processor.notify_new_block(async_aggregation);
       }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3994,18 +3994,15 @@ struct controller_impl {
       auto block_exts = b->validate_and_extract_extensions();
       auto qc_ext_id = quorum_certificate_extension::extension_id();
       bool qc_extension_present = block_exts.count(qc_ext_id) != 0;
-      EOS_ASSERT( !qc_extension_present,
-                  block_validate_exception,
+      EOS_ASSERT( !qc_extension_present, invalid_qc_claim,
                   "Legacy or Transition block #${b} includes a QC block extension",
                   ("b", block_num) );
 
-      EOS_ASSERT( !b->is_proper_svnn_block(),
-                  block_validate_exception,
+      EOS_ASSERT( !b->is_proper_svnn_block(), invalid_qc_claim,
                   "Legacy or Transition block #${b} has invalid schedule_version",
                   ("b", block_num) );
 
-      EOS_ASSERT( !prev.header.is_proper_svnn_block(),
-                  block_validate_exception,
+      EOS_ASSERT( !prev.header.is_proper_svnn_block(), invalid_qc_claim,
                   "Legacy or Transition block #${b} may not have previous block that is a Proper Savanna block",
                   ("b", block_num) );
 
@@ -4015,8 +4012,7 @@ struct controller_impl {
       // Make sure Transition block is not gone back to Legacy
       if (!finality_ext) {
          auto it = prev.header_exts.find(finality_extension::extension_id());
-         EOS_ASSERT( it == prev.header_exts.end(),
-                     block_validate_exception,
+         EOS_ASSERT( it == prev.header_exts.end(), invalid_qc_claim,
                      "Legacy block #${b} does not have finality block header extension but its previous block does have",
                      ("b", block_num) );
 
@@ -4025,37 +4021,32 @@ struct controller_impl {
 
       // Transition Block
       const auto& f_ext = std::get<finality_extension>(*finality_ext);
-      EOS_ASSERT( !f_ext.qc_claim.is_strong_qc,
-                  block_validate_exception,
+      EOS_ASSERT( !f_ext.qc_claim.is_strong_qc, invalid_qc_claim,
                   "Transition block #${b} has a strong QC claim",
                   ("b", block_num) );
-      EOS_ASSERT( !f_ext.new_proposer_policy_diff,
-                  block_validate_exception,
+      EOS_ASSERT( !f_ext.new_proposer_policy_diff, invalid_qc_claim,
                   "Transition block #${b} has new_proposer_policy_diff",
                   ("b", block_num) );
 
       if (auto it = prev.header_exts.find(finality_extension::extension_id()); it != prev.header_exts.end()) {
          const auto& prev_finality_ext = std::get<finality_extension>(it->second);
          EOS_ASSERT( f_ext.qc_claim.block_num == prev_finality_ext.qc_claim.block_num,
-                     block_validate_exception,
+                     invalid_qc_claim,
                      "Transition block #${b} QC claim block_num not equal to previous QC claim block_num",
                      ("b", block_num) );
       } else {
          // Savanna Genesis Block
-         EOS_ASSERT( f_ext.qc_claim.block_num == block_num,
-                     block_validate_exception,
+         EOS_ASSERT( f_ext.qc_claim.block_num == block_num, invalid_qc_claim,
                      "Savanna Genesis block #${b} QC claim block_num not equal to current block_num",
                      ("b", block_num) );
-         EOS_ASSERT( f_ext.new_finalizer_policy_diff,
-                     block_validate_exception,
+         EOS_ASSERT( f_ext.new_finalizer_policy_diff, invalid_qc_claim,
                      "Savanna Genesis block #${b} finality block header extension misses new_finalizer_policy_diff",
                      ("b", block_num) );
 
          finalizer_policy no_policy;
          // apply_diff will FC_ASSERT if new_finalizer_policy_diff is malformated
          finalizer_policy genesis_policy = no_policy.apply_diff(*f_ext.new_finalizer_policy_diff);
-         EOS_ASSERT( genesis_policy.generation == 1,
-                     block_validate_exception,
+         EOS_ASSERT( genesis_policy.generation == 1, invalid_qc_claim,
                      "Savanna Genesis block #${b} finalizer policy generation (${g}) not 1",
                      ("b", block_num)("g", genesis_policy.generation) );
       }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3883,6 +3883,8 @@ struct controller_impl {
    // Called from net-threads. It is thread safe as signed_block is never modified after creation.
    // -----------------------------------------------------------------------------
    void verify_proper_block_exts( const block_id_type& id, const signed_block_ptr& b, const block_header_state& prev ) {
+      assert(b->is_proper_svnn_block());
+
       auto qc_ext_id = quorum_certificate_extension::extension_id();
       auto f_ext_id  = finality_extension::extension_id();
 
@@ -4071,6 +4073,8 @@ struct controller_impl {
    template<typename ForkDB, typename BS>
    block_handle create_block_state_i( ForkDB& forkdb, const block_id_type& id, const signed_block_ptr& b, const BS& prev ) {
       constexpr bool is_proper_savanna_block = std::is_same_v<typename std::decay_t<BS>, block_state>;
+      assert(is_proper_savanna_block == b->is_proper_svnn_block());
+
       // If is_proper_savanna_block is true, then it means that the parent block of block b has a block_state.
       //
       // For a block to have a block_state it means the block must be a Savanna block,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4061,7 +4061,7 @@ struct controller_impl {
             EOS_ASSERT( genesis_policy.generation == 1, block_validate_exception,
                         "Savanna Genesis block #${b} finalizer policy generation (${g}) not 1",
                         ("b", block_num)("g", genesis_policy.generation) );
-         } EOS_RETHROW_EXCEPTIONS(block_validate_exception, "applying diff of Savanna Genesis Bloc")
+         } EOS_RETHROW_EXCEPTIONS(block_validate_exception, "applying diff of Savanna Genesis Block")
       }
    }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4046,6 +4046,9 @@ struct controller_impl {
                      invalid_qc_claim,
                      "Transition block #${b} QC claim block_num not equal to previous QC claim block_num",
                      ("b", block_num) );
+         EOS_ASSERT( !f_ext.new_finalizer_policy_diff, invalid_qc_claim,
+                     "Non Genesis Transition block #${b} finality block header extension may not have new_finalizer_policy_diff",
+                     ("b", block_num) );
       } else {
          // Savanna Genesis Block
          EOS_ASSERT( f_ext.qc_claim.block_num == block_num, invalid_qc_claim,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3996,27 +3996,28 @@ struct controller_impl {
       bool qc_extension_present = block_exts.count(qc_ext_id) != 0;
       EOS_ASSERT( !qc_extension_present,
                   block_validate_exception,
-                  "Legacy block #${b} includes a QC block extension",
+                  "Legacy or Transition block #${b} includes a QC block extension",
                   ("b", block_num) );
 
       EOS_ASSERT( !b->is_proper_svnn_block(),
                   block_validate_exception,
-                  "Legacy block #${b} may not be Proper Savnanna block",
+                  "Legacy or Transition block #${b} has invalid schedule_version",
                   ("b", block_num) );
 
       EOS_ASSERT( !prev.header.is_proper_svnn_block(),
                   block_validate_exception,
-                  "Legacy block's #${b} previous block may not be Proper Savnanna block",
+                  "Legacy or Transition block #${b} may not have previous block that is a Proper Savanna block",
                   ("b", block_num) );
 
       auto f_ext_id = finality_extension::extension_id();
       std::optional<block_header_extension> header_ext = b->extract_header_extension(f_ext_id);
 
+      // Make sure Transition block is not gone back to Legacy
       if (!header_ext) {
          auto it = prev.header_exts.find(finality_extension::extension_id());
          EOS_ASSERT( it == prev.header_exts.end(),
                      block_validate_exception,
-                     "Block #${b} does not have finality block header extension but its previous block does have",
+                     "Legacy block #${b} does not have finality block header extension but its previous block does have",
                      ("b", block_num) );
 
          return;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4015,10 +4015,6 @@ struct controller_impl {
                   "Transition block #${b} includes a QC block extension",
                   ("b", block_num) );
 
-      EOS_ASSERT( !b->is_proper_svnn_block(), block_validate_exception,
-                  "Transition block #${b} has invalid schedule_version",
-                  ("b", block_num) );
-
       EOS_ASSERT( !prev.header.is_proper_svnn_block(), block_validate_exception,
                   "Transition block #${b} may not have previous block that is a Proper Savanna block",
                   ("b", block_num) );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3989,7 +3989,7 @@ struct controller_impl {
       auto qc_ext_id = quorum_certificate_extension::extension_id();
       bool qc_extension_present = block_exts.count(qc_ext_id) != 0;
 
-      EOS_ASSERT( !qc_extension_present, block_validate_exception,
+      EOS_ASSERT( !qc_extension_present, invalid_qc_claim,
                   "Legacy block #${b} includes a QC block extension",
                   ("b", block_num) );
 
@@ -4011,7 +4011,7 @@ struct controller_impl {
       auto qc_ext_id = quorum_certificate_extension::extension_id();
       bool qc_extension_present = block_exts.count(qc_ext_id) != 0;
 
-      EOS_ASSERT( !qc_extension_present, block_validate_exception,
+      EOS_ASSERT( !qc_extension_present, invalid_qc_claim,
                   "Transition block #${b} includes a QC block extension",
                   ("b", block_num) );
 

--- a/libraries/chain/include/eosio/chain/block_header.hpp
+++ b/libraries/chain/include/eosio/chain/block_header.hpp
@@ -92,6 +92,9 @@ namespace eosio::chain {
       // finality extension must exist.
       bool is_proper_svnn_block() const { return ( schedule_version == proper_svnn_schedule_version ); }
 
+      // Returns true if the block is a pure Legacy block
+      bool is_legacy_block() const { return !contains_header_extension(finality_extension::extension_id()); }
+
       header_extension_multimap validate_and_extract_header_extensions()const;
       std::optional<block_header_extension> extract_header_extension(uint16_t extension_id)const;
       template<typename Ext> Ext extract_header_extension()const {


### PR DESCRIPTION
Currently verify_qc_claim is only called on Savanna blocks. On Legacy and Transitions blocks, we need to verify finality and QC extensions too.

Resolves https://github.com/AntelopeIO/spring/issues/691