### PR TITLE
[1.0] Harden ordered_diff

### DIFF
--- a/libraries/chain/include/eosio/chain/finality/finalizer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/finality/finalizer_policy.hpp
@@ -7,7 +7,8 @@
 namespace eosio::chain {
 
    using finalizers_differ = fc::ordered_diff<finalizer_authority, uint16_t>;
-   // verify finalizers_differ size_type can represent all values of max_finalizers
+   // Verify finalizers_differ::size_type can represent all index values in the
+   // diff between two policies that could each hold up to max_finalizers entries.
    static_assert(std::numeric_limits<finalizers_differ::size_type>::max() >= config::max_finalizers - 1);
    using finalizers_diff_t = finalizers_differ::diff_result;
 

--- a/libraries/chain/include/eosio/chain/finality/finalizer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/finality/finalizer_policy.hpp
@@ -6,8 +6,9 @@
 
 namespace eosio::chain {
 
-   static_assert(std::numeric_limits<uint16_t>::max() >= config::max_finalizers - 1);
    using finalizers_differ = fc::ordered_diff<finalizer_authority, uint16_t>;
+   // verify finalizers_differ size_type can represent all values of max_finalizers
+   static_assert(std::numeric_limits<finalizers_differ::size_type>::max() >= config::max_finalizers - 1);
    using finalizers_diff_t = finalizers_differ::diff_result;
 
    struct finalizer_policy_diff {

--- a/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
@@ -6,7 +6,8 @@
 namespace eosio::chain {
 
 using producer_auth_differ = fc::ordered_diff<producer_authority, uint16_t>;
-// verify producer_auth_differ size_type can represent all values of max_proposers
+// Verify producer_auth_differ::size_type can represent all index values in the
+// diff between two policies that could each hold up to max_proposers entries.
 static_assert(std::numeric_limits<producer_auth_differ::size_type>::max() >= config::max_proposers - 1);
 using producer_auth_diff_t = producer_auth_differ::diff_result;
 

--- a/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
+++ b/libraries/chain/include/eosio/chain/finality/proposer_policy.hpp
@@ -5,8 +5,9 @@
 
 namespace eosio::chain {
 
-static_assert(std::numeric_limits<uint16_t>::max() >= config::max_proposers - 1);
 using producer_auth_differ = fc::ordered_diff<producer_authority, uint16_t>;
+// verify producer_auth_differ size_type can represent all values of max_proposers
+static_assert(std::numeric_limits<producer_auth_differ::size_type>::max() >= config::max_proposers - 1);
 using producer_auth_diff_t = producer_auth_differ::diff_result;
 
 struct proposer_policy_diff {

--- a/libraries/libfc/include/fc/container/ordered_diff.hpp
+++ b/libraries/libfc/include/fc/container/ordered_diff.hpp
@@ -41,51 +41,51 @@ public:
 
       diff_result result;
       while (s < source.size() || t < target.size()) {
+         FC_ASSERT(s < std::numeric_limits<SizeType>::max());
+         FC_ASSERT(t < std::numeric_limits<SizeType>::max());
          if (s < source.size() && t < target.size()) {
-            FC_ASSERT(s < std::numeric_limits<SizeType>::max());
-            FC_ASSERT(t < std::numeric_limits<SizeType>::max());
             if (source[s] == target[t]) {
                // nothing to do, skip over
                ++s;
                ++t;
             } else { // not equal
                if (s == source.size() - 1 && t == target.size() - 1) {
+                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
+                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   // both at end, insert target and remove source
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
-                  FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
-                  FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++s;
                   ++t;
                } else if (s + 1 < source.size() && t + 1 < target.size() && source[s + 1] == target[t + 1]) {
+                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
+                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   // misalignment, but next value equal, insert and remove
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
-                  FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
-                  FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++s;
                   ++t;
                } else if (t + 1 < target.size() && source[s] == target[t + 1]) {
                   // source equals next target, insert current target
+                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   result.insert_indexes.emplace_back(t, target[t]);
-                  FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++t;
                } else { // source[s + 1] == target[t]
                   // target matches next source, remove current source
+                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   result.remove_indexes.push_back(s);
-                  FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++s;
                }
             }
          } else if (s < source.size()) {
             // remove extra in source
+            FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
             result.remove_indexes.push_back(s);
-            FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
             ++s;
          } else if (t < target.size()) {
             // insert extra in target
+            FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
             result.insert_indexes.emplace_back(t, target[t]);
-            FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
             ++t;
          }
       }
@@ -115,8 +115,8 @@ public:
       for (auto& [index, value] : diff.insert_indexes) {
          FC_ASSERT(index <= container.size(), "diff.insert_indexes index ${idx} not in range ${s}",
                    ("idx", index)("s", container.size()));
+         FC_ASSERT(container.size() < MAX_NUM_ARRAY_ELEMENTS);
          container.insert(container.begin() + index, std::move(value));
-         FC_ASSERT(container.size() <= MAX_NUM_ARRAY_ELEMENTS);
       }
       return container;
    }

--- a/libraries/libfc/include/fc/container/ordered_diff.hpp
+++ b/libraries/libfc/include/fc/container/ordered_diff.hpp
@@ -53,7 +53,6 @@ public:
                // nothing to do, skip over
                ++s;
                ++t;
-               assert(s > 0 && t > 0);
             } else { // not equal
                if (s == source.size() - 1 && t == target.size() - 1) {
                   // both at end, insert target and remove source
@@ -63,7 +62,6 @@ public:
                   result.insert_indexes.emplace_back(t, target[t]);
                   ++s;
                   ++t;
-                  assert(s > 0 && t > 0);
                } else if (s + 1 < source.size() && t + 1 < target.size() && source[s + 1] == target[t + 1]) {
                   // misalignment, but next value equal, insert and remove
                   assert(s <= std::numeric_limits<SizeType>::max());
@@ -72,20 +70,17 @@ public:
                   result.insert_indexes.emplace_back(t, target[t]);
                   ++s;
                   ++t;
-                  assert(s > 0 && t > 0);
                } else if (t + 1 < target.size() && source[s] == target[t + 1]) {
                   // source equals next target, insert current target
                   assert(t <= std::numeric_limits<SizeType>::max());
                   result.insert_indexes.emplace_back(t, target[t]);
                   ++t;
-                  assert(t > 0);
                } else {
                   // not misalignment by one and source not equal to next target, so remove from source
                   // may be inserted later by other conditions if needed
-                  assert(t <= std::numeric_limits<SizeType>::max());
+                  assert(s <= std::numeric_limits<SizeType>::max());
                   result.remove_indexes.push_back(s);
                   ++s;
-                  assert(s > 0);
                }
             }
          } else if (s < source.size()) {
@@ -93,13 +88,11 @@ public:
             assert(s <= std::numeric_limits<SizeType>::max());
             result.remove_indexes.push_back(s);
             ++s;
-            assert(s > 0);
          } else if (t < target.size()) {
             // insert extra in target
             assert(t <= std::numeric_limits<SizeType>::max());
             result.insert_indexes.emplace_back(t, target[t]);
             ++t;
-            assert(t > 0);
          }
       }
 

--- a/libraries/libfc/include/fc/container/ordered_diff.hpp
+++ b/libraries/libfc/include/fc/container/ordered_diff.hpp
@@ -42,17 +42,15 @@ public:
       diff_result result;
       while (s < source.size() || t < target.size()) {
          if (s < source.size() && t < target.size()) {
+            FC_ASSERT(s < std::numeric_limits<SizeType>::max());
+            FC_ASSERT(t < std::numeric_limits<SizeType>::max());
             if (source[s] == target[t]) {
                // nothing to do, skip over
-               FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
-               FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
                ++s;
                ++t;
             } else { // not equal
                if (s == source.size() - 1 && t == target.size() - 1) {
                   // both at end, insert target and remove source
-                  FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
-                  FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
                   FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
@@ -61,8 +59,6 @@ public:
                   ++t;
                } else if (s + 1 < source.size() && t + 1 < target.size() && source[s + 1] == target[t + 1]) {
                   // misalignment, but next value equal, insert and remove
-                  FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
-                  FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
                   FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
@@ -71,13 +67,11 @@ public:
                   ++t;
                } else if (t + 1 < target.size() && source[s] == target[t + 1]) {
                   // source equals next target, insert current target
-                  FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
                   result.insert_indexes.emplace_back(t, target[t]);
                   FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++t;
                } else { // source[s + 1] == target[t]
                   // target matches next source, remove current source
-                  FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
                   result.remove_indexes.push_back(s);
                   FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
                   ++s;
@@ -85,13 +79,11 @@ public:
             }
          } else if (s < source.size()) {
             // remove extra in source
-            FC_ASSERT(s <= std::numeric_limits<SizeType>::max());
             result.remove_indexes.push_back(s);
             FC_ASSERT(result.remove_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
             ++s;
          } else if (t < target.size()) {
             // insert extra in target
-            FC_ASSERT(t <= std::numeric_limits<SizeType>::max());
             result.insert_indexes.emplace_back(t, target[t]);
             FC_ASSERT(result.insert_indexes.size() <= MAX_NUM_ARRAY_ELEMENTS);
             ++t;
@@ -113,7 +105,7 @@ public:
       // Remove from the source based on diff.remove_indexes
       std::ptrdiff_t offset = 0;
       for (SizeType index : diff.remove_indexes) {
-         FC_ASSERT(index + offset <= container.size(), "diff.remove_indexes index ${idx} + offset ${o} not in range ${s}",
+         FC_ASSERT(index + offset < container.size(), "diff.remove_indexes index ${idx} + offset ${o} not in range ${s}",
                    ("idx", index)("o", offset)("s", container.size()));
          container.erase(container.begin() + index + offset);
          --offset;

--- a/libraries/libfc/include/fc/container/ordered_diff.hpp
+++ b/libraries/libfc/include/fc/container/ordered_diff.hpp
@@ -43,6 +43,8 @@ public:
       while (s < source.size() || t < target.size()) {
          FC_ASSERT(s < std::numeric_limits<SizeType>::max());
          FC_ASSERT(t < std::numeric_limits<SizeType>::max());
+         FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
+         FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
          if (s < source.size() && t < target.size()) {
             if (source[s] == target[t]) {
                // nothing to do, skip over
@@ -50,16 +52,12 @@ public:
                ++t;
             } else { // not equal
                if (s == source.size() - 1 && t == target.size() - 1) {
-                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
-                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   // both at end, insert target and remove source
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
                   ++s;
                   ++t;
                } else if (s + 1 < source.size() && t + 1 < target.size() && source[s + 1] == target[t + 1]) {
-                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
-                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   // misalignment, but next value equal, insert and remove
                   result.remove_indexes.push_back(s);
                   result.insert_indexes.emplace_back(t, target[t]);
@@ -67,24 +65,20 @@ public:
                   ++t;
                } else if (t + 1 < target.size() && source[s] == target[t + 1]) {
                   // source equals next target, insert current target
-                  FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   result.insert_indexes.emplace_back(t, target[t]);
                   ++t;
                } else { // source[s + 1] == target[t]
                   // target matches next source, remove current source
-                  FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
                   result.remove_indexes.push_back(s);
                   ++s;
                }
             }
          } else if (s < source.size()) {
             // remove extra in source
-            FC_ASSERT(result.remove_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
             result.remove_indexes.push_back(s);
             ++s;
          } else if (t < target.size()) {
             // insert extra in target
-            FC_ASSERT(result.insert_indexes.size() < MAX_NUM_ARRAY_ELEMENTS);
             result.insert_indexes.emplace_back(t, target[t]);
             ++t;
          }

--- a/libraries/libfc/test/test_ordered_diff.cpp
+++ b/libraries/libfc/test/test_ordered_diff.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
       BOOST_TEST(source == target);
    }
    { // full
-      vector<uint8_t> source(std::numeric_limits<uint8_t>::max()-1);
+      vector<uint8_t> source(std::numeric_limits<uint8_t>::max()+1);
       std::iota(source.begin(), source.end(), 0);
       vector<uint8_t> target(source.size());
       std::reverse_copy(source.begin(), source.end(), target.begin());

--- a/libraries/libfc/test/test_ordered_diff.cpp
+++ b/libraries/libfc/test/test_ordered_diff.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
       BOOST_TEST(source == target);
    }
    { // full
-      vector<uint8_t> source(std::numeric_limits<uint8_t>::max());
+      vector<uint8_t> source(std::numeric_limits<uint8_t>::max()-1);
       std::iota(source.begin(), source.end(), 0);
       vector<uint8_t> target(source.size());
       std::reverse_copy(source.begin(), source.end(), target.begin());

--- a/libraries/libfc/test/test_ordered_diff.cpp
+++ b/libraries/libfc/test/test_ordered_diff.cpp
@@ -3,6 +3,9 @@
 #include <fc/container/ordered_diff.hpp>
 #include <fc/exception/exception.hpp>
 
+#include <algorithm>
+#include <random>
+
 using namespace fc;
 
 BOOST_AUTO_TEST_SUITE(ordered_diff_tests)
@@ -39,6 +42,13 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
       source = ordered_diff<char, int>::apply_diff(std::move(source), result);
       BOOST_TEST(source == target);
    }
+   { // All elements removed, size 1
+      vector<char> source = {'a'};
+      vector<char> target;
+      auto result = ordered_diff<char, int>::diff(source, target);
+      source = ordered_diff<char, int>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+   }
    { // All elements inserted
       vector<char> source;
       vector<char> target = {'a', 'b', 'c', 'd', 'e'};
@@ -46,8 +56,22 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
       source = ordered_diff<char>::apply_diff(std::move(source), result);
       BOOST_TEST(source == target);
    }
+   { // All elements inserted, size 1
+      vector<char> source;
+      vector<char> target = {'a'};
+      auto result = ordered_diff<char>::diff(source, target);
+      source = ordered_diff<char>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+   }
    { // No change
       vector<char> source = {'a', 'b', 'c', 'd', 'e'};
+      vector<char> target = source;
+      auto result = ordered_diff<char>::diff(source, target);
+      source = ordered_diff<char>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+   }
+   { // No change, size 1
+      vector<char> source = {'a'};
       vector<char> target = source;
       auto result = ordered_diff<char>::diff(source, target);
       source = ordered_diff<char>::apply_diff(std::move(source), result);
@@ -74,9 +98,37 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
       source = ordered_diff<char>::apply_diff(std::move(source), result);
       BOOST_TEST(source == target);
    }
+   { // Complete change, size 1
+      vector<char> source = {'a'};
+      vector<char> target = {'f'};
+      auto result = ordered_diff<char>::diff(source, target);
+      source = ordered_diff<char>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+   }
+   { // Complete change equal sizes
+      vector<char> source = {'a', 'b', 'c', 'd'};
+      vector<char> target = {'f', 'g', 'h', 'i'};
+      auto result = ordered_diff<char>::diff(source, target);
+      source = ordered_diff<char>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+   }
    { // Diff order
       vector<char> source = {'a', 'b', 'c', 'd', 'e'};
       vector<char> target = {'e', 'd', 'c', 'b', 'a'};
+      auto result = ordered_diff<char>::diff(source, target);
+      source = ordered_diff<char>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+   }
+   { // Diff order, size 2
+      vector<char> source = {'a', 'b'};
+      vector<char> target = {'b', 'a'};
+      auto result = ordered_diff<char>::diff(source, target);
+      source = ordered_diff<char>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+   }
+   { // Diff order, size 2
+      vector<char> source = {'b', 'a'};
+      vector<char> target = {'a', 'b'};
       auto result = ordered_diff<char>::diff(source, target);
       source = ordered_diff<char>::apply_diff(std::move(source), result);
       BOOST_TEST(source == target);
@@ -105,6 +157,27 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
    { // full
       vector<uint8_t> source(std::numeric_limits<uint8_t>::max()+1);
       std::iota(source.begin(), source.end(), 0);
+      vector<uint8_t> target(source.size());
+      std::reverse_copy(source.begin(), source.end(), target.begin());
+      auto result = ordered_diff<uint8_t, uint8_t>::diff(source, target);
+      source = ordered_diff<uint8_t, uint8_t>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+      target.clear();
+      result = ordered_diff<uint8_t, uint8_t>::diff(source, target);
+      source = ordered_diff<uint8_t, uint8_t>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+      source.clear();
+      result = ordered_diff<uint8_t, uint8_t>::diff(source, target);
+      source = ordered_diff<uint8_t, uint8_t>::apply_diff(std::move(source), result);
+      BOOST_TEST(source == target);
+   }
+   { // full, random
+      std::random_device rnd_device;
+      std::mt19937 mersenne_engine {rnd_device()};
+      std::uniform_int_distribution<uint8_t> dist {0, std::numeric_limits<uint8_t>::max()};
+      auto gen = [&](){ return dist(mersenne_engine); };
+      vector<uint8_t> source(std::numeric_limits<uint8_t>::max()+1);
+      std::generate(source.begin(), source.end(), gen);
       vector<uint8_t> target(source.size());
       std::reverse_copy(source.begin(), source.end(), target.begin());
       auto result = ordered_diff<uint8_t, uint8_t>::diff(source, target);

--- a/libraries/libfc/test/test_ordered_diff.cpp
+++ b/libraries/libfc/test/test_ordered_diff.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
       BOOST_TEST(source == target);
    }
    { // full
-      vector<uint8_t> source(std::numeric_limits<uint8_t>::max()+1);
+      vector<uint8_t> source(std::numeric_limits<uint8_t>::max());
       std::iota(source.begin(), source.end(), 0);
       vector<uint8_t> target(source.size());
       std::reverse_copy(source.begin(), source.end(), target.begin());


### PR DESCRIPTION
`ordered_diff` is used to process the finalizer and proposer policy diffs from block header extension `finality_extension`. Since the `finality_extension`, is provided to a node to validate, validate the diff during `apply_diff`.

Related to #691