### PR TITLE
[1.0 -> main] Test accept_block_header, accept_block, and irreversible_block signals

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -8,6 +8,7 @@
 #include <fc/io/json.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/tuple/tuple_io.hpp>
+#include <boost/unordered/unordered_flat_map.hpp>
 
 #include <eosio/testing/bls_utils.hpp>
 
@@ -575,6 +576,9 @@ namespace eosio::testing {
          signed_block_ptr       _finish_block();
          void                   _check_for_vote_if_needed(controller& c, const block_handle& bh);
 
+         enum class block_signal { block_start, accepted_block_header, accepted_block, irreversible_block };
+         bool                   _check_signal(const block_id_type& id, block_signal sig);
+
       // Fields:
       protected:
          bool                   _expect_votes {true};                          // if set, ensure the node votes on each block
@@ -591,6 +595,7 @@ namespace eosio::testing {
          map<transaction_id_type, transaction_receipt> chain_transactions;
          map<account_name, block_id_type>              last_produced_block;
          unapplied_transaction_queue                   unapplied_transactions;
+         boost::unordered_flat_map<block_id_type, block_signal> blocks_signaled;
 
       public:
          vector<digest_type>                           protocol_features_to_be_activated_wo_preactivation;


### PR DESCRIPTION
Add verification to libtester that `controller` signals `accept_block_header`, `accept_block`, `irreversible_block` happen in order and do not repeat.

Working on #619 and wanted a test to verify signals continue to work the same as before.

Merges `release/1.0` into `main` including #681 