### PR TITLE
[1.0.1] Load header_exts of root in forkdb

### DIFF
--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -134,6 +134,7 @@ namespace eosio::chain {
       bsp_t _root = std::make_shared<bs_t>();
       fc::raw::unpack( ds, pending_savanna_lib_id );
       fc::raw::unpack( ds, *_root );
+      _root->header_exts = _root->block->validate_and_extract_header_extensions();
       reset_root_impl( _root );
 
       unsigned_int size; fc::raw::unpack( ds, size );

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -134,7 +134,8 @@ namespace eosio::chain {
       bsp_t _root = std::make_shared<bs_t>();
       fc::raw::unpack( ds, pending_savanna_lib_id );
       fc::raw::unpack( ds, *_root );
-      _root->header_exts = _root->block->validate_and_extract_header_extensions();
+      // if root was saved from a snapshot the block_state will not contain a block
+      _root->header_exts = _root->header.validate_and_extract_header_extensions();
       reset_root_impl( _root );
 
       unsigned_int size; fc::raw::unpack( ds, size );

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -134,8 +134,6 @@ namespace eosio::chain {
       bsp_t _root = std::make_shared<bs_t>();
       fc::raw::unpack( ds, pending_savanna_lib_id );
       fc::raw::unpack( ds, *_root );
-      // if root was saved from a snapshot the block_state will not contain a block
-      _root->header_exts = _root->header.validate_and_extract_header_extensions();
       reset_root_impl( _root );
 
       unsigned_int size; fc::raw::unpack( ds, size );
@@ -143,7 +141,6 @@ namespace eosio::chain {
          bs_t s;
          fc::raw::unpack( ds, s );
          // do not populate transaction_metadatas, they will be created as needed in apply_block with appropriate key recovery
-         s.header_exts = s.block->validate_and_extract_header_extensions();
          add_impl( std::make_shared<bs_t>( std::move( s ) ), ignore_duplicate_t::no, true, validator );
       }
    }

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -78,7 +78,7 @@ struct block_header_state_input : public building_block_input {
    digest_type                       finality_mroot_claim;
 };
 
-struct block_header_state {
+struct block_header_state : fc::reflect_init {
    // ------ data members ------------------------------------------------------------
    block_id_type                       block_id;
    block_header                        header;
@@ -197,6 +197,10 @@ struct block_header_state {
          return &std::get<Ext>(itr->second);
       }
       return nullptr;
+   }
+
+   void reflector_init() {
+      header_exts = header.validate_and_extract_header_extensions();
    }
 };
 

--- a/libraries/chain/include/eosio/chain/block_header_state_legacy.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state_legacy.hpp
@@ -112,7 +112,7 @@ protected:
  *  @struct block_header_state_legacy
  *  @brief defines the minimum state necessary to validate transaction headers
  */
-struct block_header_state_legacy : public detail::block_header_state_legacy_common {
+struct block_header_state_legacy : public detail::block_header_state_legacy_common, fc::reflect_init {
    block_id_type                        id;
    signed_block_header                  header;
    detail::schedule_info                pending_schedule;
@@ -150,6 +150,10 @@ struct block_header_state_legacy : public detail::block_header_state_legacy_comm
    void                   verify_signee()const;
 
    const vector<digest_type>& get_new_protocol_feature_activations()const;
+
+   void reflector_init() {
+      header_exts = header.validate_and_extract_header_extensions();
+   }
 };
 
 using block_header_state_legacy_ptr = std::shared_ptr<block_header_state_legacy>;

--- a/unittests/finalizer_vote_tests.cpp
+++ b/unittests/finalizer_vote_tests.cpp
@@ -93,14 +93,14 @@ bsp make_bsp(const proposal_t& p, const bsp& previous, finalizer_policy_ptr finp
       // special case of genesis block
       auto id = calc_id(fc::sha256::hash("genesis"), 0);
       auto tstamp = block_timestamp_type{0};
-      bhs new_bhs { id, block_header{tstamp}, {}, finality_core::create_core_for_genesis_block(id, tstamp),
+      bhs new_bhs { {}, id, block_header{tstamp}, {}, finality_core::create_core_for_genesis_block(id, tstamp),
                     std::move(finpol), std::make_shared<proposer_policy>() };
       return makeit(std::move(new_bhs));
    }
 
    assert(claim);
    block_ref ref = previous ? previous->make_block_ref() : block_ref{};
-   bhs new_bhs { p.calculate_id(), block_header{p.block_timestamp, {}, {}, previous->id()}, {}, previous->core.next(ref, *claim),
+   bhs new_bhs { {}, p.calculate_id(), block_header{p.block_timestamp, {}, {}, previous->id()}, {}, previous->core.next(ref, *claim),
       std::move(finpol), std::make_shared<proposer_policy>() }; // proposer_policy needed for make_block_ref
    return makeit(std::move(new_bhs));
 }

--- a/unittests/savanna_disaster_recovery_tests.cpp
+++ b/unittests/savanna_disaster_recovery_tests.cpp
@@ -317,10 +317,8 @@ BOOST_FIXTURE_TEST_CASE(restart_from_fork_db_with_only_root_block, savanna_clust
    C.close();                        // close node
    C.open();                         // and open(), so we get the root block_state from fork_db and not from the snapshot
 
-#if 0  // uncomment when issue #709 is fixed.
    C.push_block(b1);                 // when creating the block_state for b1, `prev` will be the root block_state loaded from
                                      // fork_db, which doesn't have the header extension cache created (issue #709)
-#endif
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Spring expects all `block_header_state` to have the `header_exts` cache available. The fork database was not loading it for `root` like it does for all other blocks in the fork database. Also block_handle was also not loading it. Added reflector_init so that it is always populated.

To fail requires the first block received from the network to build on the fork database `root`.

Note: Greg added a repeatable test for this issue. See #711 which is enabled by this PR.

Resolves #709 