### PR TITLE
[1.0.1] Log calculated LIB for deep-mind

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3440,7 +3440,7 @@ struct controller_impl {
                               auto bsp = get_transition_savanna_block(head);
                               assert(bsp);
                               assert(bsp->active_finalizer_policy);
-                              dm_logger->on_accepted_block_v2(head->id(), fork_db_root_block_num(), head->block,
+                              dm_logger->on_accepted_block_v2(head->id(), chain_head.irreversible_blocknum(), head->block,
                                                               bsp->get_finality_data(),
                                                               bsp->active_proposer_policy,
                                                               finalizer_policy_with_string_key{*bsp->active_finalizer_policy});
@@ -3450,7 +3450,7 @@ struct controller_impl {
                         },
                         [&](const block_state_ptr& head) {
                            assert(head->active_finalizer_policy);
-                           dm_logger->on_accepted_block_v2(head->id(), fork_db_root_block_num(), head->block,
+                           dm_logger->on_accepted_block_v2(head->id(), chain_head.irreversible_blocknum(), head->block,
                                                            head->get_finality_data(),
                                                            head->active_proposer_policy,
                                                            finalizer_policy_with_string_key{*head->active_finalizer_policy});

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1059,6 +1059,7 @@ struct controller_impl {
 
    // --------------- access fork_db head ----------------------------------------------------------------------
    block_handle fork_db_head()const {
+      assert(fork_db_has_root());
       return fork_db.apply<block_handle>(
          [&](const auto& forkdb) {
             return block_handle{forkdb.head(include_root_t::yes)};
@@ -1066,6 +1067,7 @@ struct controller_impl {
    }
 
    uint32_t fork_db_head_block_num() const {
+      assert(fork_db_has_root());
       return fork_db.apply<uint32_t>(
          [&](const auto& forkdb) {
             return forkdb.head(include_root_t::yes)->block_num();
@@ -1073,6 +1075,7 @@ struct controller_impl {
    }
 
    block_id_type fork_db_head_block_id() const {
+      assert(fork_db_has_root());
       return fork_db.apply<block_id_type>(
          [&](const auto& forkdb) {
             return forkdb.head(include_root_t::yes)->id();
@@ -1089,20 +1092,24 @@ struct controller_impl {
    }
 
    block_id_type fork_db_root_block_id() const {
+      assert(fork_db_has_root());
       return fork_db.apply<block_id_type>([&](const auto& forkdb) { return forkdb.root()->id(); });
    }
 
    uint32_t fork_db_root_block_num() const {
+      assert(fork_db_has_root());
       return fork_db.apply<uint32_t>([&](const auto& forkdb) { return forkdb.root()->block_num(); });
    }
 
    block_timestamp_type  fork_db_root_timestamp() const {
+      assert(fork_db_has_root());
       return fork_db.apply<block_timestamp_type>([&](const auto& forkdb) { return forkdb.root()->timestamp(); });
    }
 
    // ---------------  fork_db APIs ----------------------------------------------------------------------
    template<typename ForkDB>
    uint32_t pop_block(ForkDB& forkdb) {
+      assert(fork_db_has_root());
       typename ForkDB::bsp_t prev = forkdb.get_block( chain_head.previous() );
 
       if( !prev ) {

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -107,7 +107,7 @@ public:
    uint32_t               block_num()         const { return block_header_state::block_num(); }
    block_timestamp_type   timestamp()         const { return block_header_state::timestamp(); }
    const extensions_type& header_extensions() const { return block_header_state::header.header_extensions; }
-   uint32_t               irreversible_blocknum() const { return core.last_final_block_num(); } // backwards compatibility
+   uint32_t               irreversible_blocknum() const { return core.last_final_block_num(); }
 
    uint32_t               last_final_block_num() const         { return core.last_final_block_num(); }
    block_timestamp_type   last_final_block_timestamp() const   { return core.last_final_block_timestamp(); }


### PR DESCRIPTION
For the deep-mind log, log the caculated LIB instead of the node's realized LIB. This more closely reflects legacy behavior and is more appropriate for deep-mind logging as it cares more about the state of the chain than any particular node.

Also adds debug `assert`s to all forkdb calls that expect fork database `root` to exist.

Resolves #728