### PR TITLE
[1.0.1] Add ability to deep-mind log to stderr

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3427,15 +3427,13 @@ struct controller_impl {
          }
 
          if (auto* dm_logger = get_deep_mind_logger(false)) {
-            // forkdb not available during replay
             block_handle_accessor::apply<void>(chain_head,
                         [&](const block_state_legacy_ptr& head) {
                            if (head->block->contains_header_extension(finality_extension::extension_id())) {
-                              block_num_type lib = replaying ? chain_head.irreversible_blocknum() : fork_db_root_block_num();
                               auto bsp = get_transition_savanna_block(head);
                               assert(bsp);
                               assert(bsp->active_finalizer_policy);
-                              dm_logger->on_accepted_block_v2(head->id(), lib, head->block,
+                              dm_logger->on_accepted_block_v2(head->id(), fork_db_root_block_num(), head->block,
                                                               bsp->get_finality_data(),
                                                               bsp->active_proposer_policy,
                                                               finalizer_policy_with_string_key{*bsp->active_finalizer_policy});
@@ -3445,8 +3443,7 @@ struct controller_impl {
                         },
                         [&](const block_state_ptr& head) {
                            assert(head->active_finalizer_policy);
-                           block_num_type lib = replaying ? chain_head.irreversible_blocknum() : fork_db_root_block_num();
-                           dm_logger->on_accepted_block_v2(head->id(), lib, head->block,
+                           dm_logger->on_accepted_block_v2(head->id(), fork_db_root_block_num(), head->block,
                                                            head->get_finality_data(),
                                                            head->active_proposer_policy,
                                                            finalizer_policy_with_string_key{*head->active_finalizer_policy});

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3427,13 +3427,15 @@ struct controller_impl {
          }
 
          if (auto* dm_logger = get_deep_mind_logger(false)) {
+            // forkdb not available during replay
             block_handle_accessor::apply<void>(chain_head,
                         [&](const block_state_legacy_ptr& head) {
                            if (head->block->contains_header_extension(finality_extension::extension_id())) {
+                              block_num_type lib = replaying ? chain_head.irreversible_blocknum() : fork_db_root_block_num();
                               auto bsp = get_transition_savanna_block(head);
                               assert(bsp);
                               assert(bsp->active_finalizer_policy);
-                              dm_logger->on_accepted_block_v2(head->id(), fork_db_root_block_num(), head->block,
+                              dm_logger->on_accepted_block_v2(head->id(), lib, head->block,
                                                               bsp->get_finality_data(),
                                                               bsp->active_proposer_policy,
                                                               finalizer_policy_with_string_key{*bsp->active_finalizer_policy});
@@ -3443,7 +3445,8 @@ struct controller_impl {
                         },
                         [&](const block_state_ptr& head) {
                            assert(head->active_finalizer_policy);
-                           dm_logger->on_accepted_block_v2(head->id(), fork_db_root_block_num(), head->block,
+                           block_num_type lib = replaying ? chain_head.irreversible_blocknum() : fork_db_root_block_num();
+                           dm_logger->on_accepted_block_v2(head->id(), lib, head->block,
                                                            head->get_finality_data(),
                                                            head->active_proposer_policy,
                                                            finalizer_policy_with_string_key{*head->active_finalizer_policy});

--- a/libraries/libfc/src/log/dmlog_appender.cpp
+++ b/libraries/libfc/src/log/dmlog_appender.cpp
@@ -24,9 +24,13 @@ namespace fc {
 
    dmlog_appender::dmlog_appender( const std::optional<dmlog_appender::config>& args )
    :dmlog_appender(){
-      if (!args || args->file == "-")
+      if (!args || (args->file == "-" || args->file == "-stdout"))
       {
          my->out = stdout;
+      }
+      else if (args && args->file == "-stderr")
+      {
+         my->out = stderr;
       }
       else
       {

--- a/programs/nodeos/logging-deep-mind.json
+++ b/programs/nodeos/logging-deep-mind.json
@@ -1,0 +1,170 @@
+{
+  "includes": [],
+  "appenders": [{
+      "name": "stderr",
+      "type": "console",
+      "args": {
+        "stream": "std_error",
+        "level_colors": [{
+            "level": "debug",
+            "color": "green"
+          },{
+            "level": "warn",
+            "color": "brown"
+          },{
+            "level": "error",
+            "color": "red"
+          }
+        ]
+      },
+      "enabled": true
+    },{
+      "name": "stdout",
+      "type": "console",
+      "args": {
+        "stream": "std_out",
+        "level_colors": [{
+            "level": "debug",
+            "color": "green"
+          },{
+            "level": "warn",
+            "color": "brown"
+          },{
+            "level": "error",
+            "color": "red"
+          }
+        ]
+      },
+      "enabled": true
+    },{
+      "name" : "deep-mind",
+      "type": "dmlog",
+      "args": {
+         "file": "-stderr",
+         "_comment": "file can be a filename or -, -stdout, -stderr. -stdout is same as -"
+      }
+    }
+  ],
+  "loggers": [{
+      "name": "default",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "net_plugin_impl",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "http_plugin",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "producer_plugin",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "transaction_success_tracing",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "transaction_failure_tracing",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "trace_api",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "transaction_trace_success",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "transaction_trace_failure",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "transient_trx_success_tracing",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "transient_trx_failure_tracing",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+    "name": "state_history",
+    "level": "warn",
+    "enabled": true,
+    "additivity": false,
+    "appenders": [
+      "stderr"
+      ]
+    },{
+    "name": "vote",
+    "level": "warn",
+    "enabled": true,
+    "additivity": false,
+    "appenders": [
+      "stderr"
+      ]
+    },{
+      "name": "transaction",
+      "level": "warn",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "stderr"
+      ]
+    },{
+      "name": "deep-mind",
+      "level": "debug",
+      "enabled": true,
+      "additivity": false,
+      "appenders": [
+        "deep-mind"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The theory is that #724 is caused by too much buffered output to the pipe. Add ability to write to stderr which is unbuffered.

Add an example `logging.json` that can be used to configure deep-mind to log to stderr.

Seems to resolve #724 