### PR TITLE
[1.0.1] Flush deep-mind logger after each message

### DIFF
--- a/libraries/libfc/src/log/dmlog_appender.cpp
+++ b/libraries/libfc/src/log/dmlog_appender.cpp
@@ -11,8 +11,7 @@
 #include <boost/thread/mutex.hpp>
 #include <fc/exception/exception.hpp>
 #include <iomanip>
-#include <mutex>
-#include <sstream>
+#include <cstdio>
 
 namespace fc {
    class dmlog_appender::impl {
@@ -93,5 +92,8 @@ namespace fc {
          message_ptr = &message_ptr[written];
          remaining_size -= written;
       }
+      // attempt a flush, ignore any error
+      if (!my->is_stopped)
+         fflush(my->out);
    }
 }


### PR DESCRIPTION
`fflush` each deep-mind log message.

Attempt to resolve #724, reported from issue's creator that this fixes the issue they were seeing.