### PR TITLE
[1.0.1 -> main] Verify index >= 0 in apply_diff and fix warnings

### DIFF
--- a/libraries/libfc/test/test_ordered_diff.cpp
+++ b/libraries/libfc/test/test_ordered_diff.cpp
@@ -38,15 +38,15 @@ BOOST_AUTO_TEST_CASE(ordered_diff_test) try {
    { // All elements removed
       vector<char> source = {'a', 'b', 'c', 'd', 'e'};
       vector<char> target;
-      auto result = ordered_diff<char, int>::diff(source, target);
-      source = ordered_diff<char, int>::apply_diff(std::move(source), result);
+      auto result = ordered_diff<char, unsigned int>::diff(source, target);
+      source = ordered_diff<char, unsigned int>::apply_diff(std::move(source), result);
       BOOST_TEST(source == target);
    }
    { // All elements removed, size 1
       vector<char> source = {'a'};
       vector<char> target;
-      auto result = ordered_diff<char, int>::diff(source, target);
-      source = ordered_diff<char, int>::apply_diff(std::move(source), result);
+      auto result = ordered_diff<char, unsigned int>::diff(source, target);
+      source = ordered_diff<char, unsigned int>::apply_diff(std::move(source), result);
       BOOST_TEST(source == target);
    }
    { // All elements inserted


### PR DESCRIPTION
Forwards https://github.com/AntelopeIO/spring/pull/722

`index` in `apply_diff` can be a signed int and can be negative. Currently index is only checked not greater than the size. 

This also results in warnings in numerous places as `apply_diff` is in a header file which is included by a number of files:

```
libraries/libfc/include/fc/container/ordered_diff.hpp:111:35: warning: comparison of integer expressions of different signedness: ‘std::ptrdiff_t’ {aka ‘long int’} and ‘std::vector<char>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
...
ibraries/libfc/include/fc/container/ordered_diff.hpp:119:26: warning: comparison of integer expressions of different signedness: ‘std::tuple_element<0, std::pair<int, char> >::type’ {aka ‘int’} and ‘std::vector<char>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
```

Resolves https://github.com/AntelopeIO/spring/issues/723