### PR TITLE
[1.0.1] tweak text layout of 1.0.0 upgrade error message

### DIFF
--- a/libraries/chain/block_handle.cpp
+++ b/libraries/chain/block_handle.cpp
@@ -45,7 +45,7 @@ bool block_handle::read(const std::filesystem::path& state_file) {
       fc::raw::unpack(f, version);
 
       EOS_ASSERT(magic == chain_head_magic && version == chain_head_version, chain_exception,
-                 "Error reading `chain_head.dat` file. It is likely a Spring 1.0.0 version which is not supported by Spring 1.0.1 and above"
+                 "Error reading `chain_head.dat` file. It is likely a Spring 1.0.0 version which is not supported by Spring 1.0.1 and above. "
                  "The best course of action might be to restart from a snapshot" );
 
       fc::raw::unpack(f, *this);


### PR DESCRIPTION
When printed this looked like
```
error 2024-09-11T21:25:16.792 nodeos    main.cpp:224                  main                 ] 3000000 chain_exception: blockchain exception
Error reading `chain_head.dat` file. It is likely a Spring 1.0.0 version which is not supported by Spring 1.0.1 and aboveThe best course of action might be to restart from a snapshot
```
This just cleans up the two words that were mashed together.