### PR TITLE
[1.0.1 -> main] Log received block with qc_claim even if no qc

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3892,7 +3892,7 @@ struct controller_impl {
    // Verify basic proper_block invariants.
    // Called from net-threads. It is thread safe as signed_block is never modified after creation.
    // -----------------------------------------------------------------------------
-   std::optional<qc_t> verify_basic_proper_block_invariants( const signed_block_ptr& b, const block_header_state& prev ) {
+   std::optional<qc_t> verify_basic_proper_block_invariants( const block_id_type& id, const signed_block_ptr& b, const block_header_state& prev ) {
       assert(b->is_proper_svnn_block());
 
       auto qc_ext_id = quorum_certificate_extension::extension_id();
@@ -3916,6 +3916,15 @@ struct controller_impl {
       assert(finality_ext);
       const auto& f_ext        = std::get<finality_extension>(*finality_ext);
       const auto  new_qc_claim = f_ext.qc_claim;
+
+      if (!replaying && fc::logger::get(DEFAULT_LOGGER).is_enabled(fc::log_level::debug)) {
+         fc::time_point now = fc::time_point::now();
+         if (now - b->timestamp < fc::minutes(5) || (b->block_num() % 1000 == 0)) {
+            dlog("received block: #${bn} ${t} ${prod} ${id}, qc claim: ${qc_claim}, qc ${qc}, previous: ${p}",
+              ("bn", b->block_num())("t", b->timestamp)("prod", b->producer)("id", id)
+              ("qc_claim", new_qc_claim)("qc", qc_extension_present ? "present" : "not present")("p", b->previous));
+         }
+      }
 
       // The only time a block should have a finality block header extension but
       // its parent block does not, is if it is a Savanna Genesis block (which is
@@ -3954,7 +3963,7 @@ struct controller_impl {
                      ("s1", new_qc_claim.is_strong_qc)("s2", prev_qc_claim.is_strong_qc)("b", block_num) );
       }
 
-      // At this point, we are making a new claim in this block, so it must includes a QC to justify this claim.
+      // At this point, we are making a new claim in this block, so it must include a QC to justify this claim.
       EOS_ASSERT( qc_extension_present, block_validate_exception,
                   "Block #${b} is making a new finality claim, but doesn't include a qc to justify this claim", ("b", block_num) );
 
@@ -4056,7 +4065,7 @@ struct controller_impl {
 
    // verify basic_block invariants
    template<typename BS>
-   std::optional<qc_t> verify_basic_block_invariants(const signed_block_ptr& b, const BS& prev) {
+   std::optional<qc_t> verify_basic_block_invariants(const block_id_type& id, const signed_block_ptr& b, const BS& prev) {
       constexpr bool is_proper_savanna_block = std::is_same_v<typename std::decay_t<BS>, block_state>;
       assert(is_proper_savanna_block == b->is_proper_svnn_block());
 
@@ -4064,7 +4073,7 @@ struct controller_impl {
          EOS_ASSERT( b->is_proper_svnn_block(), block_validate_exception,
                      "create_block_state_i cannot be called on block #${b} which is not a Proper Savanna block unless the prev block state provided is of type block_state",
                      ("b", b->block_num()) );
-         return verify_basic_proper_block_invariants(b, prev);
+         return verify_basic_proper_block_invariants(id, b, prev);
       } else {
          EOS_ASSERT( !b->is_proper_svnn_block(), block_validate_exception,
                      "create_block_state_i cannot be called on block #${b} which is a Proper Savanna block unless the prev block state provided is of type block_state_legacy",
@@ -4091,15 +4100,11 @@ struct controller_impl {
       constexpr bool is_proper_savanna_block = std::is_same_v<typename std::decay_t<BS>, block_state>;
       assert(is_proper_savanna_block == b->is_proper_svnn_block());
 
-      std::optional<qc_t> qc = verify_basic_block_invariants(b, prev);
+      std::optional<qc_t> qc = verify_basic_block_invariants(id, b, prev);
 
       if constexpr (is_proper_savanna_block) {
          if (qc) {
             verify_qc(prev, *qc);
-
-            dlog("received block: #${bn} ${t} ${prod} ${id}, qc claim: ${qc_claim}, previous: ${p}",
-                 ("bn", b->block_num())("t", b->timestamp)("prod", b->producer)("id", id)
-                 ("qc_claim", qc->to_qc_claim())("p", b->previous));
          }
       }
 
@@ -4336,7 +4341,7 @@ struct controller_impl {
 
          auto do_push = [&](const auto& head) {
             if constexpr (std::is_same_v<BSP, typename std::decay_t<decltype(head)>>) {
-               std::optional<qc_t> qc = verify_basic_block_invariants(b, *head);
+               std::optional<qc_t> qc = verify_basic_block_invariants({}, b, *head);
 
                if constexpr (std::is_same_v<typename std::decay_t<BSP>, block_state_ptr>) {
                   if (conf.force_all_checks && qc) {


### PR DESCRIPTION
Debug log the `received block` with qc claim for every proper savanna block even if they do not have a qc. Only log every 1000 blocks if syncing.

Example:
```
debug 2024-09-11T18:38:19.352 net-2     controller.cpp:3939           verify_basic_proper_ ] received block: #64 2024-09-11T18:38:19.500 eosio 0000004083746bd01620fcf67d3c2e79acf7e6a50285d738aca44060cdbfdb34, qc claim: {"block_num":62,"is_strong_qc":false}, qc not present, previous: 0000003f138e55a7fcffbfffa53e2ff60c430ab28033df903b3714fae7adc30e
debug 2024-09-11T18:38:19.815 net-2     controller.cpp:3939           verify_basic_proper_ ] received block: #65 2024-09-11T18:38:20.000 eosio 000000414c96210ff400fc724135380d4ea7e6017d240f89ee5d9d99bdef509d, qc claim: {"block_num":64,"is_strong_qc":true}, qc present, previous: 0000004083746bd01620fcf67d3c2e79acf7e6a50285d738aca44060cdbfdb34
```

Merges `release/1.0` into `main` into #750 