### PR TITLE
[1.0.2 -> main] Remove explicit net_plugin pause during snapshot

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -553,14 +553,6 @@ namespace eosio {
       void start_expire_timer();
       void start_monitors();
 
-      // we currently pause on snapshot generation
-      void wait_if_paused() const {
-         controller& cc = chain_plug->chain();
-         while (cc.is_writing_snapshot()) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-         }
-      }
-
       void expire();
       /** \name Peer Timestamps
        *  Time message handling
@@ -2937,8 +2929,6 @@ namespace eosio {
             close( false );
             return;
          }
-
-         my_impl->wait_if_paused();
 
          boost::asio::async_read( *socket,
             pending_message_buffer.get_buffer_sequence_for_boost_async_read(), completion_handler,


### PR DESCRIPTION
As noted on the addition of pausing during snapshot:
https://github.com/AntelopeIO/leap/pull/2029/files#r1440851488

Pausing does cause peers to disconnect. You have to wait on the connection timer to reconnect and continue syncing. 

Now that we no longer sync ahead: #635 
The issue https://github.com/AntelopeIO/leap/issues/2021 is not an issue anymore as we do not keep syncing ahead. The sync is limited by the `sync-fetch-span`. 

Tested with EOS Mainnet node syncing and with an EOS Mainnet node in-sync.

Merges `release/1.0` into `main` including #768 

Resolves #592 