### PR TITLE
[1.0.2] Test: p2p_sync_throttle_test. Increase sync timeout.

### DIFF
--- a/tests/p2p_sync_throttle_test.py
+++ b/tests/p2p_sync_throttle_test.py
@@ -132,7 +132,7 @@ try:
     assert unThrottledNode.waitForBlock(endLargeBlocksHeadBlock), f'wait for block {endLargeBlocksHeadBlock}  on un-throttled node timed out'
     endUnThrottledSync = time.time()
 
-    assert throttledNode.waitForBlock(endLargeBlocksHeadBlock, timeout=120), f'Wait for block {endLargeBlocksHeadBlock} on throttled node timed out'
+    assert throttledNode.waitForBlock(endLargeBlocksHeadBlock, timeout=240), f'Wait for block {endLargeBlocksHeadBlock} on throttled node timed out'
     endThrottledSync = time.time()
 
     throttledElapsed = endThrottledSync - clusterStart


### PR DESCRIPTION
Give the `p2p_sync_throttle_test` plenty of time to sync as it is suppose to sync slowly. Double the timeout. If it synced before the timeout it will not waste any more time.

Resolves #786 