### PR TITLE
resolve two unused warnings in libtester that show up only in release builds

### DIFF
--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -374,8 +374,8 @@ namespace eosio::testing {
       [[maybe_unused]] auto block_start_connection = control->block_start().connect([](block_num_type num) {
          // only block number is signaled, in forking tests will get the same block number more than once.
       });
-      [[maybe_unused]] auto accepted_block_header_connection = control->accepted_block_header().connect([this](const block_signal_params& t) {
-            const auto& [block, id] = t;
+      [[maybe_unused]] auto accepted_block_header_connection = control->accepted_block_header().connect([&](const block_signal_params& t) {
+            [[maybe_unused]] const auto& [block, id] = t;
             assert(block);
             assert(_check_signal(id, block_signal::accepted_block_header));
          });


### PR DESCRIPTION
clang18:
```
/home/spoon/f/leap/src/libraries/testing/tester.cpp:378:25: warning: unused variable '[block, id]' [-Wunused-variable]
  378 |             const auto& [block, id] = t;
      |                         ^
/home/spoon/f/leap/src/libraries/testing/tester.cpp:377:106: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
  377 |       [[maybe_unused]] auto accepted_block_header_connection = control->accepted_block_header().connect([this](const block_signal_params& t) {
      |                                                                                                          ^~~~
```

an alternative would be to wrap the 5 lines of this connection in a `#ifndef NDEBUG`