### PR TITLE
[1.0.2 -> main] Add new unittest to validate current finalizer safety file i/o

### DIFF
--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -374,7 +374,7 @@ namespace eosio::testing {
       [[maybe_unused]] auto block_start_connection = control->block_start().connect([](block_num_type num) {
          // only block number is signaled, in forking tests will get the same block number more than once.
       });
-      [[maybe_unused]] auto accepted_block_header_connection = control->accepted_block_header().connect([this](const block_signal_params& t) {
+      [[maybe_unused]] auto accepted_block_header_connection = control->accepted_block_header().connect([&](const block_signal_params& t) {
             [[maybe_unused]] const auto& [block, id] = t;
             assert(block);
             assert(_check_signal(id, block_signal::accepted_block_header));


### PR DESCRIPTION
Resolves #764 

-  `finalizer_tests/finalizer_safety_file_versioning` validates loading older versions. Also validate current version: we should be able to load the reference file, save the fsi info, and end up with exactly the same bytes.
- also check that the current version of  safety.dat file committed to the repo can be loaded on nodeos startup.
- Fixes a few compilation warnings that I noticed when looking at a build failure.