### PR TITLE
[1.0.2] Prevent sync ahead in irreversible mode

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2192,15 +2192,15 @@ namespace eosio {
          controller& cc = my_impl->chain_plug->chain();
          if (cc.get_read_mode() == db_read_mode::IRREVERSIBLE) {
             auto forkdb_head = cc.fork_db_head();
-            if (forkdb_head.block_num() >= blk_num) {
-               auto calculated_lib = forkdb_head.irreversible_blocknum();
-               auto num_blocks_that_can_be_applied = calculated_lib > head_num ? calculated_lib - head_num : 0;
-               if (num_blocks_that_can_be_applied < sync_fetch_span) {
-                  if (head_num )
-                     fc_ilog(logger, "sync ahead allowed past sync-fetch-span ${sp}, block ${bn} for paused LIB ${l}, chain_lib ${cl}, forkdb size ${s}",
-                             ("bn", blk_num)("sp", sync_fetch_span)("l", calculated_lib)("cl", head_num)("s", cc.fork_db_size()));
-                  return true;
-               }
+            auto calculated_lib = forkdb_head.irreversible_blocknum();
+            auto num_blocks_that_can_be_applied = calculated_lib > head_num ? calculated_lib - head_num : 0;
+            // add blocks that can potentially be applied as they are not in the forkdb yet
+            num_blocks_that_can_be_applied += blk_num > forkdb_head.block_num() ? blk_num - forkdb_head.block_num() : 0;
+            if (num_blocks_that_can_be_applied < sync_fetch_span) {
+               if (head_num )
+                  fc_ilog(logger, "sync ahead allowed past sync-fetch-span ${sp}, block ${bn} for paused LIB ${l}, chain_lib ${cl}, forkdb size ${s}",
+                          ("bn", blk_num)("sp", sync_fetch_span)("l", calculated_lib)("cl", head_num)("s", cc.fork_db_size()));
+               return true;
             }
          }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2192,13 +2192,15 @@ namespace eosio {
          controller& cc = my_impl->chain_plug->chain();
          if (cc.get_read_mode() == db_read_mode::IRREVERSIBLE) {
             auto forkdb_head = cc.fork_db_head();
-            auto calculated_lib = forkdb_head.irreversible_blocknum();
-            auto num_blocks_that_can_be_applied = calculated_lib > head_num ? calculated_lib - head_num : 0;
-            if (num_blocks_that_can_be_applied < sync_fetch_span) {
-               if (head_num )
-               fc_ilog(logger, "sync ahead allowed past sync-fetch-span ${sp}, block ${bn} for paused LIB ${l}, chain_lib ${cl}, forkdb size ${s}",
-                       ("bn", blk_num)("sp", sync_fetch_span)("l", calculated_lib)("cl", head_num)("s", cc.fork_db_size()));
-               return true;
+            if (forkdb_head.block_num() >= blk_num) {
+               auto calculated_lib = forkdb_head.irreversible_blocknum();
+               auto num_blocks_that_can_be_applied = calculated_lib > head_num ? calculated_lib - head_num : 0;
+               if (num_blocks_that_can_be_applied < sync_fetch_span) {
+                  if (head_num )
+                     fc_ilog(logger, "sync ahead allowed past sync-fetch-span ${sp}, block ${bn} for paused LIB ${l}, chain_lib ${cl}, forkdb size ${s}",
+                             ("bn", blk_num)("sp", sync_fetch_span)("l", calculated_lib)("cl", head_num)("s", cc.fork_db_size()));
+                  return true;
+               }
             }
          }
 

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -687,6 +687,27 @@ class Node(Transactions):
                         return True
         return False
 
+    def linesInLog(self, searchStr):
+        dataDir=Utils.getNodeDataDir(self.nodeId)
+        files=Node.findStderrFiles(dataDir)
+        lines=[]
+        for file in files:
+            with open(file, 'r') as f:
+                for line in f:
+                    if searchStr in line:
+                        lines.append(line)
+        return lines
+
+    def countInLog(self, searchStr) -> int:
+        dataDir=Utils.getNodeDataDir(self.nodeId)
+        files=Node.findStderrFiles(dataDir)
+        count = 0
+        for file in files:
+            with open(file, 'r') as f:
+                contents = f.read()
+                count += contents.count(searchStr)
+        return count
+
     # verify only one or two 'Starting block' per block number unless block is restarted
     def verifyStartingBlockMessages(self):
         dataDir=Utils.getNodeDataDir(self.nodeId)


### PR DESCRIPTION
Issue #789 was to create a test that verifies #777. The new test exposed an issue with the current implementation that would allow it to sync ahead too far when blocks have not made it to the fork database yet. Includes a fix that verifies fork database has the block being evaluated before considering syncing ahead.

Failing test before fix: https://github.com/AntelopeIO/spring/actions/runs/11002592099

Resolves #789 