### PR TITLE
[Test only, don't merge] test ship streamer

### DIFF
--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -161,7 +161,7 @@ try:
     time.sleep(5.0)
 
     Print(f"Stopping all {args.num_clients} clients")
-    for index, (popen, _), (out, err), start in zip(range(len(clients) // 2), clients, files, starts):
+    for index, (popen, _), (out, err), start in zip(range(len(clients)), clients, files, starts):
         popen.kill()
 
     testSuccessful = True


### PR DESCRIPTION
example stuck behavior:
```
info  2024-09-24T04:02:12.400 trx_gener trx_provider.cpp:71           connect              ] Attempting P2P connection to localhost:9879.

info  2024-09-24T04:02:12.400 trx_gener trx_provider.cpp:75           connect              ] Connected to localhost:9879.

2024-09-24T04:02:13.399179    

2024-09-24T04:02:13.399297  Found first trx record: /home/kayan-u20/workspaces/spring/build/TestLogs/ship_streamer_test22340/first_trx_22757.txt

2024-09-24T04:02:13.399383  Found first trx record: /home/kayan-u20/workspaces/spring/build/TestLogs/ship_streamer_test22340/first_trx_22758.txt

2024-09-24T04:02:13.399450  first transactions: ['978ea4db0cce34065ca959d3c25636fd7bc7e9432b97f71651a572746fc1efb3', '662959e19ce2e9d19322eacde0b020db95aa16abd63c2004c2e940f11953adeb']

2024-09-24T04:02:13.749440  {'server_version': '711d7a78', 'chain_id': '3a9172c91a02325927ed5082eab363678a762be5cdd6e281dee3549cde107357', 'head_block_num': 129, 'last_irreversible_block_num': 73, 'last_irreversible_block_id': '000000497cd81faa49b07dd38c35776ec1b53c7bd3db144bb356853a354bbc42', 'head_block_id': '00000081e5e8e45c5dafef2f427dea26643b788f1317b17777114c9c849ffbb8', 'head_block_time': '2024-09-24T04:02:13.500', 'head_block_producer': 'defproducerc', 'virtual_block_cpu_limit': 567683, 'virtual_block_net_limit': 1191770, 'block_cpu_limit': 500000, 'block_net_limit': 1048576, 'server_version_string': 'v1.0.0-rc3', 'fork_db_head_block_num': 129, 'fork_db_head_block_id': '00000081e5e8e45c5dafef2f427dea26643b788f1317b17777114c9c849ffbb8', 'server_full_version_string': 'v1.0.0-rc3-711d7a786b42ff89eaeb9dc91a7c7ed42a5cf7eb', 'total_cpu_weight': 0, 'total_net_weight': 0, 'earliest_available_block_num': 1, 'last_irreversible_block_time': '2024-09-24T04:01:45.500'}

2024-09-24T04:02:13.828167 ship cmd: tests/ship_streamer --start-block-num 113 --end-block-num 1000113 --fetch-block --fetch-traces --fetch-deltas

2024-09-24T04:02:13.828322 Start client 0

2024-09-24T04:02:13.866816 Client 0 started, Ship node head is: 130

2024-09-24T04:02:18.872495 Stopping all 1 clients

2024-09-24T04:02:18.872607  Test succeeded.

2024-09-24T04:02:18.872693   Cluster shutting down.

^CTraceback (most recent call last):

  File "/home/kayan-u20/workspaces/spring/build/./tests/ship_streamer_test.py", line 169, in <module>

    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, dumpErrorDetails=dumpErrorDetails)

  File "/home/kayan-u20/workspaces/spring/build/tests/TestHarness/TestHelper.py", line 191, in shutdown

    cluster.shutdown()

  File "/home/kayan-u20/workspaces/spring/build/tests/TestHarness/Cluster.py", line 1421, in shutdown

    node.kill(signal.SIGTERM)

  File "/home/kayan-u20/workspaces/spring/build/tests/TestHarness/Node.py", line 290, in kill

    self.popenProc.wait()

  File "/usr/lib/python3.10/subprocess.py", line 1209, in wait

    return self._wait(timeout=timeout)

  File "/usr/lib/python3.10/subprocess.py", line 1959, in _wait

    (pid, sts) = self._try_wait(0)

  File "/usr/lib/python3.10/subprocess.py", line 1917, in _try_wait

    (pid, sts) = os.waitpid(self.pid, wait_flags)

KeyboardInterrupt

2024-09-24T04:03:51.823576 Shutting down wallet manager process 22493
```
