### PR TITLE
fix dtor order for fallback asio deadline timer

### DIFF
--- a/libraries/chain/platform_timer_asio_fallback.cpp
+++ b/libraries/chain/platform_timer_asio_fallback.cpp
@@ -47,6 +47,7 @@ platform_timer::platform_timer() {
 
 platform_timer::~platform_timer() {
    stop();
+   my->timer.reset();
    if(std::lock_guard guard(timer_ref_mutex); --refcount == 0) {
       checktime_ios->stop();
       checktime_thread.join();


### PR DESCRIPTION
`platform_timer_asio_fallback.cpp` isn't expected to be used for Linux, macOS, or even freeBSD builds. For some unknown reason (that I suspect is a bug upstream), building with certain sanitizer options causes sniffing of the posix timer to fail at run time
https://github.com/AntelopeIO/spring/blob/dbbf776c3eeb05563cafc9a7248b01801b2010e3/libraries/chain/CMakeLists.txt#L9-L19
Unaware I was using this asio fallback timer I hit a sanitizer failure due to destruction order here (destroying io_context before all users of it are destroyed). Might as well fix it.