### PR TITLE
[1.0.2] Fix incorrect reported total time of applying a received block or produced block

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3366,8 +3366,6 @@ struct controller_impl {
     * @post regardless of the success of commit block there is no active pending block
     */
    void commit_block( controller::block_report& br, controller::block_status s ) {
-      fc::time_point start = fc::time_point::now();
-
       auto reset_pending_on_exit = fc::make_scoped_exit([this]{
          pending.reset();
       });

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3629,7 +3629,7 @@ struct controller_impl {
               ("p", bsp->producer())("id", bsp->id().str().substr(8, 16))("n", bsp->block_num())("t", bsp->timestamp())
               ("count", bsp->block->transactions.size())("lib", bsp->irreversible_blocknum())
               ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)
-              ("elapsed", br.total_elapsed_time)("time", now - br.start_time)("latency", (now - chain_head.timestamp()).count() / 1000));
+              ("elapsed", br.total_elapsed_time)("time", now - br.start_time)("latency", (now - bsp->timestamp()).count() / 1000));
          const auto& hb_id = chain_head.id();
          const auto& hb = chain_head.block();
          if (read_mode != db_read_mode::IRREVERSIBLE && hb && hb_id != bsp->id() && hb != nullptr) { // not applied to head

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -187,6 +187,7 @@ namespace eosio::chain {
             size_t             total_cpu_usage_us = 0;
             fc::microseconds   total_elapsed_time{};
             fc::microseconds   total_time{};
+            fc::time_point     start_time;
          };
 
          void assemble_and_complete_block( block_report& br, const signer_callback_type& signer_callback );

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -186,7 +186,6 @@ namespace eosio::chain {
             size_t             total_net_usage = 0;
             size_t             total_cpu_usage_us = 0;
             fc::microseconds   total_elapsed_time{};
-            fc::microseconds   total_time{};
             fc::time_point     start_time;
          };
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -972,7 +972,7 @@ public:
          _update_incoming_block_metrics({.trxs_incoming_total   = block->transactions.size(),
                                          .cpu_usage_us          = br.total_cpu_usage_us,
                                          .total_elapsed_time_us = br.total_elapsed_time.count(),
-                                         .total_time_us         = br.total_time.count(),
+                                         .total_time_us         = (now - br.start_time).count(),
                                          .net_usage_us          = br.total_net_usage,
                                          .block_latency_us      = (now - block->timestamp).count(),
                                          .last_irreversible     = chain.last_irreversible_block_num(),
@@ -2951,7 +2951,6 @@ void producer_plugin_impl::produce_block() {
       return sigs;
    });
 
-   br.total_time += fc::time_point::now() - start;
    chain.commit_block(br);
 
    const signed_block_ptr new_b = chain.head().block();
@@ -2963,7 +2962,7 @@ void producer_plugin_impl::produce_block() {
       metrics.trxs_produced_total = new_b->transactions.size();
       metrics.cpu_usage_us = br.total_cpu_usage_us;
       metrics.total_elapsed_time_us = br.total_elapsed_time.count();
-      metrics.total_time_us = br.total_time.count();
+      metrics.total_time_us = (fc::time_point::now() - br.start_time).count();
       metrics.net_usage_us = br.total_net_usage;
       metrics.last_irreversible = chain.last_irreversible_block_num();
       metrics.head_block_num = chain.head().block_num();


### PR DESCRIPTION
Ported  fix from `main` for incorrect reported total time of applying a received block or produced block.

Only minimum required changes were made, except adding time unit `us` for `elapsed` and `time` for better clarity because `latency` already had `ms` as postfix.

Before the change:
`info  2024-09-30T14:33:33.415 nodeos    controller.cpp:3633           log_applied          ]  Received block bcd746757a3db674... #366563000 @ 2024-08-04T19:14:51.500 signed by eosusacartel [trxs: 0, lib: 366562668, net: 0, cpu: 100, elapsed: 259, time: 869, latency: 4907921915 ms`

After the change:
`info  2024-09-30T14:35:11.723 nodeos    controller.cpp:3627           log_applied          ]  Received block bcd746757a3db674... #366563000 @ 2024-08-04T19:14:51.500 signed by eosusacartel [trxs: 0, lib: 366562668, net: 0, cpu: 100, elapsed: 258 us, time: 554 us, latency: 4908020223 ms]`

Resolves https://github.com/AntelopeIO/spring/issues/828