### PR TITLE
[1.0.2 -> main] P2P: Normally wait for connection monitor to reconnect

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -914,7 +914,7 @@ namespace eosio {
 
       /// @param reconnect true if we should try and reconnect immediately after close
       /// @param shutdown true only if plugin is shutting down
-      void close( bool reconnect = true, bool shutdown = false );
+      void close( bool reconnect = false, bool shutdown = false );
    private:
       void _close( bool reconnect, bool shutdown ); // for easy capture
 
@@ -1396,7 +1396,7 @@ namespace eosio {
       block_sync_throttling = false;
       last_vote_received = time_point{};
 
-      if( reconnect && !shutdown ) {
+      if( reconnect && !shutdown && !incoming() ) {
          my_impl->connections.start_conn_timer( std::chrono::milliseconds( 100 ),
                                                 connection_wptr(),
                                                 connections_manager::timer_type::check );
@@ -2413,11 +2413,7 @@ namespace eosio {
       if( mode == closing_mode::immediately || c->block_status_monitor_.max_events_violated()) {
          peer_wlog(c, "block ${bn} not accepted, closing connection ${d}",
                    ("d", mode == closing_mode::immediately ? "immediately" : "max violations reached")("bn", blk_num));
-         if( mode == closing_mode::immediately ) {
-            c->close( false ); // do not reconnect
-         } else {
-            c->close();
-         }
+         c->close(mode != closing_mode::immediately);
       } else {
          peer_dlog(c, "rejected block ${bn}, sending handshake", ("bn", blk_num));
          c->send_handshake();


### PR DESCRIPTION
In almost all cases a node should wait for the connection monitor to reconnect. Change the `reconnect` default to `false` so that the connect is not retried until the next time the connection monitor runs.

Merges `release/1.0` into `main` including #838 

Resolves #830 