### PR TITLE
[1.0.2] Fix reported time for produced blocks and fix confusing reported time name

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3459,7 +3459,7 @@ struct controller_impl {
             fc::time_point now = fc::time_point::now();
 
             ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} "
-                 "[trxs: ${count}, lib: ${lib}${confs}, net: ${net}, cpu: ${cpu}, elapsed: ${et} us, time: ${tt} us]",
+                 "[trxs: ${count}, lib: ${lib}${confs}, net: ${net}, cpu: ${cpu}, elapsed: ${et} us, producing time: ${tt} us]",
                  ("p", new_b->producer)("id", id.str().substr(8, 16))("n", new_b->block_num())("t", new_b->timestamp)
                  ("count", new_b->transactions.size())("lib", chain_head.irreversible_blocknum())("net", br.total_net_usage)
                  ("cpu", br.total_cpu_usage_us)("et", br.total_elapsed_time)("tt", now - br.start_time)
@@ -3623,7 +3623,7 @@ struct controller_impl {
       fc::time_point now = fc::time_point::now();
       if (now - bsp->timestamp() < fc::minutes(5) || (bsp->block_num() % 1000 == 0)) {
          ilog("Received block ${id}... #${n} @ ${t} signed by ${p} " // "Received" instead of "Applied" so it matches existing log output
-              "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu}, elapsed: ${elapsed} us, time: ${time} us, latency: ${latency} ms]",
+              "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu}, elapsed: ${elapsed} us, applying time: ${time} us, latency: ${latency} ms]",
               ("p", bsp->producer())("id", bsp->id().str().substr(8, 16))("n", bsp->block_num())("t", bsp->timestamp())
               ("count", bsp->block->transactions.size())("lib", bsp->irreversible_blocknum())
               ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5244,6 +5244,8 @@ transaction_trace_ptr controller::start_block( block_timestamp_type when,
 }
 
 void controller::assemble_and_complete_block( block_report& br, const signer_callback_type& signer_callback ) {
+   fc::time_point start_time = fc::time_point::now(); // want to report total time of producing a block
+
    validate_db_available_size();
 
    my->assemble_block(false, {}, nullptr);
@@ -5257,6 +5259,7 @@ void controller::assemble_and_complete_block( block_report& br, const signer_cal
       valid_block_signing_authority);
 
    br = my->pending->_block_report;
+   br.start_time = start_time;
 }
 
 void controller::commit_block(block_report& br) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3459,7 +3459,7 @@ struct controller_impl {
             fc::time_point now = fc::time_point::now();
 
             ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} "
-                 "[trxs: ${count}, lib: ${lib}${confs}, net: ${net}, cpu: ${cpu}, elapsed: ${et} us, producing time: ${tt} us]",
+                 "[trxs: ${count}, lib: ${lib}${confs}, net: ${net}, cpu: ${cpu} us, elapsed: ${et} us, producing time: ${tt} us]",
                  ("p", new_b->producer)("id", id.str().substr(8, 16))("n", new_b->block_num())("t", new_b->timestamp)
                  ("count", new_b->transactions.size())("lib", chain_head.irreversible_blocknum())("net", br.total_net_usage)
                  ("cpu", br.total_cpu_usage_us)("et", br.total_elapsed_time)("tt", now - br.start_time)
@@ -3623,7 +3623,7 @@ struct controller_impl {
       fc::time_point now = fc::time_point::now();
       if (now - bsp->timestamp() < fc::minutes(5) || (bsp->block_num() % 1000 == 0)) {
          ilog("Received block ${id}... #${n} @ ${t} signed by ${p} " // "Received" instead of "Applied" so it matches existing log output
-              "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu}, elapsed: ${elapsed} us, applying time: ${time} us, latency: ${latency} ms]",
+              "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu} us, elapsed: ${elapsed} us, applying time: ${time} us, latency: ${latency} ms]",
               ("p", bsp->producer())("id", bsp->id().str().substr(8, 16))("n", bsp->block_num())("t", bsp->timestamp())
               ("count", bsp->block->transactions.size())("lib", bsp->irreversible_blocknum())
               ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5244,8 +5244,6 @@ transaction_trace_ptr controller::start_block( block_timestamp_type when,
 }
 
 void controller::assemble_and_complete_block( block_report& br, const signer_callback_type& signer_callback ) {
-   fc::time_point start_time = fc::time_point::now(); // want to report total time of producing a block
-
    validate_db_available_size();
 
    my->assemble_block(false, {}, nullptr);
@@ -5259,7 +5257,6 @@ void controller::assemble_and_complete_block( block_report& br, const signer_cal
       valid_block_signing_authority);
 
    br = my->pending->_block_report;
-   br.start_time = start_time;
 }
 
 void controller::commit_block(block_report& br) {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -186,7 +186,7 @@ namespace eosio::chain {
             size_t             total_net_usage = 0;
             size_t             total_cpu_usage_us = 0;
             fc::microseconds   total_elapsed_time{};
-            fc::time_point     start_time;
+            fc::time_point     start_time{fc::time_point::now()};
          };
 
          void assemble_and_complete_block( block_report& br, const signer_callback_type& signer_callback );


### PR DESCRIPTION
This PR
* fixes incorrect reported time for "Produced blocks"
* changes `time` for "Produced blocks" to `producing time`, and for "Received blocks" to `applying time`
* adds time unit `us` to reported CPU time

Before the changes
`info  2024-10-01T18:31:59.066 nodeos    controller.cpp:3462           commit_block         ] Produced block dd7794184632fdd2... #100 @ 2024-10-01T18:31:59.500 signed by eosio [trxs: 0, lib: 98, net: 0, cpu: 100, elapsed: 342 us, time: 1727797983669080 us]`

After
`info  2024-10-01T19:07:27.667 nodeos    controller.cpp:3461           commit_block         ] Produced block b29e040564b322f2... #100 @ 2024-10-01T19:07:28.000 signed by eosio [trxs: 0, lib: 98, net: 0, cpu: 100 us, elapsed: 291 us, producing time: 451393 us]`

Fix https://github.com/AntelopeIO/spring/issues/849