### PR TITLE
[1.0.2] Add new testcase where finality advances on alternate branch with lesser lib

### DIFF
--- a/unittests/savanna_cluster.cpp
+++ b/unittests/savanna_cluster.cpp
@@ -21,6 +21,7 @@ node_t::node_t(size_t node_idx, cluster_t& cluster, setup_policy policy /* = set
       if (status == vote_result_t::success) {
          vote_message_ptr vote_msg = std::get<2>(v);
          _last_vote = vote_t(vote_msg->block_id, vote_msg->strong);
+         _votes[vote_msg->block_id] = vote_msg;
 
          if (_propagate_votes) {
             if (_vote_delay)

--- a/unittests/savanna_cluster.cpp
+++ b/unittests/savanna_cluster.cpp
@@ -29,10 +29,10 @@ node_t::node_t(size_t node_idx, cluster_t& cluster, setup_policy policy /* = set
             while (_delayed_votes.size() > _vote_delay) {
                vote_message_ptr vote = _delayed_votes.front();
                _delayed_votes.erase(_delayed_votes.cbegin());
-               cluster.dispatch_vote_to_peers(node_idx, skip_self_t::yes, vote);
+               _cluster.dispatch_vote_to_peers(node_idx, skip_self_t::yes, vote);
             }
             if (!_vote_delay)
-               cluster.dispatch_vote_to_peers(node_idx, skip_self_t::yes, vote_msg);
+               _cluster.dispatch_vote_to_peers(node_idx, skip_self_t::yes, vote_msg);
          }
       }
    };
@@ -42,7 +42,7 @@ node_t::node_t(size_t node_idx, cluster_t& cluster, setup_policy policy /* = set
       if (!_pushing_a_block) {
          // we want to propagate only blocks we produce, not the ones we receive from the network
          auto& b = std::get<0>(p);
-         cluster.push_block_to_peers(node_idx, skip_self_t::yes, b);
+         _cluster.push_block_to_peers(node_idx, skip_self_t::yes, b);
       }
    };
 
@@ -59,10 +59,13 @@ node_t::node_t(size_t node_idx, cluster_t& cluster, setup_policy policy /* = set
 
 node_t::~node_t() {}
 
-void node_t::propagate_delayed_votes_to(const node_t& to) {
+void node_t::propagate_delayed_votes_to(const node_t& n) {
    for (auto& vote : _delayed_votes)
-      if (to.is_open())
-         to.control->process_vote_message(++_cluster._connection_id, vote);
+      _cluster.dispatch_vote_to(n, vote);
+}
+
+void node_t::push_vote_to(const node_t& n, const block_id_type& block_id) {
+   _cluster.dispatch_vote_to(n, get_vote(block_id));
 }
 
 }

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -76,10 +76,13 @@ namespace savanna_cluster {
 
    struct qc_s {
       explicit qc_s(uint32_t block_num, bool strong) : block_num(block_num), strong(strong) {}
-      explicit qc_s(const std::optional<qc_t>& qc) : block_num(qc->block_num), strong(qc->is_strong()) {}
+      explicit qc_s(const std::optional<qc_t>& qc) : block_num(qc ? qc->block_num : uint32_t(-1)), strong(qc->is_strong()) {}
 
       friend std::ostream& operator<<(std::ostream& s, const qc_s& v) {
-         s << "qc_s(" << v.block_num << ", " << (v.strong ? "strong" : "weak") << ")";
+         if (v.block_num == uint32_t(-1))
+            s << "no_qc";
+         else
+            s << "qc_s(" << v.block_num << ", " << (v.strong ? "strong" : "weak") << ")";
          return s;
       }
       bool operator==(const qc_s&) const = default;

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -104,6 +104,8 @@ namespace savanna_cluster {
    // ----------------------------------------------------------------------------
    class node_t : public tester {
    private:
+      using votes_map_t = boost::unordered_flat_map<block_id_type, vote_message_ptr>;
+
       size_t                                          _node_idx;
       bool                                            _pushing_a_block{false};
       bool                                            _propagate_votes{true}; // if false, votes are dropped
@@ -112,6 +114,8 @@ namespace savanna_cluster {
 
       size_t                                          _vote_delay{0};         // delay vote propagation by this much
       std::vector<vote_message_ptr>                   _delayed_votes;
+
+      votes_map_t                                     _votes;                 // all votes from this node
 
       std::function<void(const block_signal_params&)> _accepted_block_cb;
       std::function<void(const vote_signal_params&)>  _voted_block_cb;
@@ -134,6 +138,8 @@ namespace savanna_cluster {
       void propagate_delayed_votes_to(const node_t& to);
 
       const vote_t& last_vote() const { return _last_vote; }
+
+      vote_message_ptr get_vote(const block_id_type& block_id) const { return _votes.at(block_id); }
 
       void set_node_finalizers(std::span<const account_name> names) {
          _node_finalizers = std::vector<account_name>{ names.begin(), names.end() };

--- a/unittests/savanna_cluster_tests.cpp
+++ b/unittests/savanna_cluster_tests.cpp
@@ -9,6 +9,8 @@ BOOST_AUTO_TEST_SUITE(savanna_cluster_tests)
 
 // test set_finalizer host function serialization and tester set_finalizers
 BOOST_FIXTURE_TEST_CASE(simple_test, savanna_cluster::cluster_t) { try {
+      auto& C=_nodes[2]; auto& D=_nodes[3];
+
       auto node3_lib = _nodes[3].lib_num();                 // Store initial lib (after Savanna transtion)
       BOOST_REQUIRE_EQUAL(num_nodes(), num_lib_advancing([&]() { // Check that lib advances on all nodes
          _nodes[0].produce_block();                         // Blocks & votes are propagated to all connected peers.
@@ -35,8 +37,7 @@ BOOST_FIXTURE_TEST_CASE(simple_test, savanna_cluster::cluster_t) { try {
       node3_lib      = _nodes[3].lib_num();
       BOOST_REQUIRE_EQUAL(node0_lib, node3_lib);
 
-      const std::vector<size_t> partition {2, 3};
-      set_partition(partition);                             // Simulate 2 disconnected partitions:
+      set_partition( {&C, &D} );                            // Simulate 2 disconnected partitions:
                                                             // nodes {0, 1} and nodes {2, 3}
 
       // at this point, each node has a QC to include into the next block it produces which will advance lib.

--- a/unittests/savanna_disaster_recovery_tests.cpp
+++ b/unittests/savanna_disaster_recovery_tests.cpp
@@ -3,7 +3,7 @@
 using namespace eosio::chain;
 using namespace eosio::testing;
 
-BOOST_AUTO_TEST_SUITE(savanna_disaster_recovery)
+BOOST_AUTO_TEST_SUITE(savanna_disaster_recovery_tests)
 
 // ------------------------------------------------------------------------------------------
 // Check that a node can go down cleanly, restart from its existing state, and start voting
@@ -213,8 +213,7 @@ BOOST_FIXTURE_TEST_CASE(all_nodes_shutdown_with_reversible_blocks_lost, savanna_
    // split network { A, B } and { C, D }
    // A produces two more blocks, so A and B will vote strong but finality will not advance
    // -------------------------------------------------------------------------------------
-   const std::vector<size_t> partition {2, 3};
-   set_partition(partition);
+   set_partition( {&C, &D} );
    BOOST_REQUIRE_EQUAL(1u, A.lib_advances_by([&]() { A.produce_blocks(2);  })); // lib stalls with network partitioned, 1 QC in flight
 
    // remove network split
@@ -306,8 +305,7 @@ BOOST_FIXTURE_TEST_CASE(restart_from_fork_db_with_only_root_block, savanna_clust
    BOOST_REQUIRE_EQUAL(2u, C.lib_advances_by([&]() { b1 = C.produce_block();  b2 = C.produce_block(); }));
 
    // Partition C by itself, so it doesn't receive b1 and b2 when opebed
-   const std::vector<size_t> tmp_partition {2};
-   set_partition(tmp_partition);
+   set_partition( {&C} );
 
    C.close();
    C.remove_state();

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -842,16 +842,16 @@ step    network partition        A        B        C        D
 (26)    A B C / D
 (28)                             b4
 (30)    A B / C / D
-(31)                                                b5(x)
+(31)                                               b5(x)
 (33)                                                        b7(x)
 (35)    A B D / C
 (36)                             b6       b6
 (38)    A B C D
 (39)                             b5       b5
-(40)                                                b6
-(41,43)                          b7       b7        b7
-(44)                             b8       b8        b8      b8(x)
-(51)                             b9       b9        b9      b9(x)
+(40)                                               b6
+(41,43)                          b7       b7       b7
+(44)                             b8       b8       b8       b8(x)
+(51)                             b9       b9       b9       b9(x)
 
 --------------------------------------------------------------------------------------------------------*/
 BOOST_FIXTURE_TEST_CASE(finality_advancing_past_block_claimed_on_alternate_branch, savanna_cluster::cluster_t) try {

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -858,7 +858,7 @@ BOOST_FIXTURE_TEST_CASE(finality_advancing_past_block_claimed_on_alternate_branc
    using namespace savanna_cluster;
    auto& A=_nodes[0]; auto& B=_nodes[1]; auto& C=_nodes[2]; auto& D=_nodes[3];
 
-   _debug_mode = true;
+   //_debug_mode = true;
 
    auto b0 = A.produce_block();
    print("b0", b0);

--- a/unittests/savanna_proposer_policy_tests.cpp
+++ b/unittests/savanna_proposer_policy_tests.cpp
@@ -5,7 +5,7 @@ using namespace eosio::testing;
 
 static const uint32_t prod_rep = static_cast<uint32_t>(config::producer_repetitions);
 
-BOOST_AUTO_TEST_SUITE(savanna_proposer_policy)
+BOOST_AUTO_TEST_SUITE(savanna_proposer_policy_tests)
 
 // ---------------------------------------------------------------------------------------------------
 //     Proposer Policy change - check expected delay when policy change initiated on
@@ -128,14 +128,13 @@ BOOST_FIXTURE_TEST_CASE(policy_change_last_block_delay_check, savanna_cluster::c
 //     Verify that a proposer policy does not become active when finality has stalled
 // ---------------------------------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(no_proposer_policy_change_without_finality, savanna_cluster::cluster_t) try {
-   auto& A=_nodes[0];
+   auto& A=_nodes[0]; auto& C=_nodes[2]; auto& D=_nodes[3];
 
    // split network { A, B } and { C, D }
    // Regardless of how many blocks A produces, finality will not advance
    // by more than one (1 QC in flight)
    // -------------------------------------------------------------------
-   const std::vector<size_t> partition {2, 3};
-   set_partition(partition);
+   set_partition( {&C, &D} );
    auto sb = A.produce_block();                        // take care of the in-flight QC
 
    const vector<account_name> producers { "pa"_n, "pb"_n };
@@ -183,14 +182,13 @@ BOOST_FIXTURE_TEST_CASE(no_proposer_policy_change_without_finality, savanna_clus
 //     finality stalled long enough)
 // ---------------------------------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(no_proposer_policy_change_without_finality_2, savanna_cluster::cluster_t) try {
-   auto& A=_nodes[0];
+   auto& A=_nodes[0]; auto& C=_nodes[2]; auto& D=_nodes[3];
 
    // split network { A, B } and { C, D }
    // Regardless of how many blocks A produces, finality will not advance
    // by more than one (1 QC in flight)
    // -------------------------------------------------------------------
-   const std::vector<size_t> partition {2, 3};
-   set_partition(partition);
+   set_partition( {&C, &D} );
    auto sb = A.produce_block();                        // take care of the in-flight QC
 
    const vector<account_name> producers { "pa"_n, "pb"_n };
@@ -233,7 +231,7 @@ BOOST_FIXTURE_TEST_CASE(no_proposer_policy_change_without_finality_2, savanna_cl
 //     Verify that a proposer policy becomes active when finality has advanced enough to make it pending
 // ---------------------------------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(pending_proposer_policy_becomes_active_without_finality, savanna_cluster::cluster_t) try {
-   auto& A=_nodes[0];
+   auto& A=_nodes[0]; auto& C=_nodes[2]; auto& D=_nodes[3];
    static_assert(prod_rep >= 4);
 
    auto sb = A.produce_block();
@@ -254,8 +252,7 @@ BOOST_FIXTURE_TEST_CASE(pending_proposer_policy_becomes_active_without_finality,
    // Regardless of how many blocks A produces, finality will not advance
    // by more than one (1 QC in flight)
    // -------------------------------------------------------------------
-   const std::vector<size_t> partition {2, 3};
-   set_partition(partition);
+   set_partition( {&C, &D} );
 
    sb = A.produce_block();                // produce one more block for lib final advance (in-flight QC)
 

--- a/unittests/savanna_transition_tests.cpp
+++ b/unittests/savanna_transition_tests.cpp
@@ -3,7 +3,7 @@
 using namespace eosio::chain;
 using namespace eosio::testing;
 
-BOOST_AUTO_TEST_SUITE(savanna_transition)
+BOOST_AUTO_TEST_SUITE(savanna_transition_tests)
 
 // ---------------------------------------------------------------------------------------------------
 // Verify a straightforward transition, with all four nodes healthy and voting
@@ -31,7 +31,7 @@ BOOST_FIXTURE_TEST_CASE(straightforward_transition,
 // ---------------------------------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(transition_with_split_network_before_critical_block,
                         savanna_cluster::pre_transition_cluster_t) try {
-   auto& A=_nodes[0];
+   auto& A=_nodes[0]; auto& C=_nodes[2]; auto& D=_nodes[3];
 
    // set two producers, so that we have at least one block between the genesis and critical block.
    // with one producer the critical block comes right after the genesis block.
@@ -62,8 +62,7 @@ BOOST_FIXTURE_TEST_CASE(transition_with_split_network_before_critical_block,
 
    // partition network and produce blocks
    // ----------------------------------------
-   const std::vector<size_t> partition {2, 3};
-   set_partition(partition);
+   set_partition( {&C, &D} );
    A.produce_blocks(20);
 
    // verify that lib has stalled
@@ -131,8 +130,7 @@ BOOST_FIXTURE_TEST_CASE(restart_from_snapshot_at_beginning_of_transition_while_p
 
    // partition network and produce blocks
    // ----------------------------------------
-   const std::vector<size_t> partition {2, 3};
-   set_partition(partition);
+   set_partition( {&C, &D} );
    A.produce_blocks(2);
 
    auto snapshot_C = C.snapshot();
@@ -230,8 +228,7 @@ BOOST_FIXTURE_TEST_CASE(restart_from_snapshot_at_end_of_transition_while_preserv
 
    // partition network and produce a block, which will be the first proper savanna block
    // -----------------------------------------------------------------------------------
-   const std::vector<size_t> partition {2, 3};
-   set_partition(partition);
+   set_partition( {&C, &D} );
 
    signed_block_ptr b = A.produce_block();
    BOOST_REQUIRE(b->is_proper_svnn_block());
@@ -308,8 +305,7 @@ BOOST_FIXTURE_TEST_CASE(restart_from_snapshot_at_beginning_of_transition_with_lo
 
    // partition network and produce blocks
    // ----------------------------------------
-   const std::vector<size_t> partition {2, 3};
-   set_partition(partition);
+   set_partition( {&C, &D} );
    A.produce_blocks(2);
 
    auto snapshot_C = C.snapshot();


### PR DESCRIPTION
Resolves #751.

Add new testcase:

```
            Finality advancing past block claimed on alternate branch
            =========================================================
Producer:    C       C       C       C       C       D       D       D       D
Timestamp:   t1      t2      t3      t4      t5      t6      t7      t8      t9
Blocks:
    b0 <---  b1 <--- b2 <--- b3 <-|- b4 <--- b5
                                  |
                                  \----------------- b6 <--- b7 <--- b8 <--- b9
QC claim:
           Strong  Strong  Strong  Strong  Strong  Strong  Strong   Weak   Strong
             b0      b0      b1      b3      b4      b1      b2      b7      b8

Votes:
  Node A:  Strong‡ Strong‡ Strong‡ Strong           Weak¹   Weak   Strong  Strong
  Node B:  Strong¹ Strong¹ Strong  Strong           Weak¹   Weak   Strong  Strong
  Node C:  Strong  Strong  Strong  Strong  Strong‡  Weak¹   Weak¹  Strong¹ Strong
  Node D:  Strong¹ Strong¹ Strong                  Strong  Strong  Strong  Strong

                                                             ^
                                                             |
                                             Validating the strong QC on b2 should
                                             not fail for nodes which receive b4 and
                                             b5 prior to b7 despite b5 advancing the
                                             fork DB root to b3.

Meaning of the superscripts and marks on the votes:
The vote on block b was delayed in reaching the node for the producer p scheduled
for the block at the next time slot t after block b by enough that a block produced on time by
producer p for time slot t could not possibly utilize the vote in any QC the block could claim.
Furthermore, the delay is such that the earliest time slot at which producer p could
produce a block that utilizes the delayed vote is the time slot (t + d) where ...
¹ ... d = 1.
‡ ... d is infinite meaning the vote may never be received by producer p.

steps mentioned in comments below refer to issue https://github.com/AntelopeIO/spring/issues/751

Diagram below shows the timeline for nodes A, B, C and D receiving blocks b1 through b9.
(x) marks the producer of the block.

step    network partition        A        B        C        D
---------------------------------------------------------------
                                 b1       b1       b1(x)    b1
(3)     A / B C D
(4)                                       b2       b2(x)    b2
(9)                                       b3       b3(x)    b3
(15)    A / B C / D
(18)                                      b4       b4(x)
(20)                                                        b6(x)
(22)    A D / B C
(23)                             b2
(25)                             b3
(26)    A B C / D
(28)                             b4
(30)    A B / C / D
(31)                                               b5(x)
(33)                                                       b7(x)
(35)    A B D / C
(36)                             b6       b6
(38)    A B C D
(39)                             b5       b5
(40)                                               b6
(41,43)                          b7       b7       b7
(44)                             b8       b8       b8      b8(x)
(51)                             b9       b9       b9      b9(x)
```

This testcase is expected to fail against the current `release_1.0` branch (as shown [here](https://github.com/AntelopeIO/spring/actions/runs/11131468398/job/30933763543)), but passes when `gh_778` (PR #788) is merged in.
