### PR TITLE
[1.0.2 -> main] SHiP: Fix hang on exit

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -380,6 +380,16 @@ void state_history_plugin_impl::plugin_shutdown() {
    accepted_block_connection.reset();
    block_start_connection.reset();
    thread_pool.stop();
+
+   // This is a temporary fix until https://github.com/AntelopeIO/spring/issues/842 can be worked.
+   // Drain the io_service of anything that could be referencing state_history_plugin
+   if (app().executor().get_io_service().stopped()) {
+      app().executor().get_io_service().restart();
+      while (app().executor().get_io_service().poll())
+         ;
+      // clear priority queue of anything pushed by poll(), see application_base exec()
+      app().executor().clear();
+   }
 }
 
 void state_history_plugin::plugin_shutdown() {


### PR DESCRIPTION
This is a temporary fix until issue #842 can be worked. Some alternatives were attempted, but no simple fix could be found that didn't require more work toward #842 then desired for 1.0.x. See https://github.com/AntelopeIO/appbase/pull/34

Test runs of a hacked up state_history_plugin with sleeps that caused it to hang on almost every CI/CD run.
Example failures: https://github.com/AntelopeIO/spring/actions/runs/11076070901
With this fix: https://github.com/AntelopeIO/spring/actions/runs/11124229769

Merges `release/1.0` into `main` including #845 

Resolves #822 