### PR TITLE
add manually run workflow to exhaustively test all LLVM versions expected to work

### DIFF
--- a/.github/workflows/llvm.yaml
+++ b/.github/workflows/llvm.yaml
@@ -1,0 +1,41 @@
+name: Exhaustive LLVM Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  doit:
+    name: 'Build & Test (${{matrix.version}})'
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['10.0.1', '11.1.0']
+    runs-on: ["self-hosted", "enf-x86-beefy"]
+    container: ubuntu:jammy
+    steps:
+      - name: Install packages
+        run: |
+          apt-get update && apt-get -y upgrade
+          apt-get install -y build-essential cmake git libcurl4-openssl-dev libgmp-dev ninja-build python3 zlib1g-dev
+      - name: Clone LLVM
+        run: git clone -b llvmorg-${{matrix.version}} --single-branch --recursive https://github.com/llvm/llvm-project
+      - name: Build LLVM
+        run: |
+          cmake -S llvm-project/llvm -B llvm-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=Off \
+                                                           -DLLVM_INCLUDE_BENCHMARKS=Off -DLLVM_INCLUDE_EXAMPLES=Off -DLLVM_BUILD_TESTS=Off \
+                                                           -DLLVM_ENABLE_RTTI=On -DLLVM_ENABLE_TERMINFO=Off -DCMAKE_INSTALL_PREFIX=/usr
+          cmake --build llvm-build -t install
+          rm -rf llvm-*
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: src
+      - name: Build spring
+        run: |
+            cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -GNinja
+            cmake --build build
+      - name: Test spring
+        run: ctest --test-dir build -j $(nproc) --output-on-failure -LE "(nonparallelizable_tests|long_running_tests)" -E eosvmoc_limits_unit_test_eos-vm-oc --timeout 480


### PR DESCRIPTION
Spring is expected to build with LLVM versions 7 through 11. As #578 is worked this range of versions will change to include newer versions. I'd like to have a way to demonstrate that newer versions do indeed compile and test successfully beyond "trust me bro".

So add a simple manually dispatched workflow that compiles with all supported LLVM major versions. This seems like a good enough tradeoff over doing something vastly more complex in CI, and I certainly do not want this to run on every PR. The main risk I see is that since this workflow is disparate to the primary per-PR build workflow it can potentially get out of date; such as the build dependencies or `cmake`/`ctest` arguments going stale. I feel like that's an acceptable risk at the moment.

A run of this workflow can be found here,
https://github.com/AntelopeIO/spring/actions/runs/11132990881