### PR TITLE
[1.0.2 -> main ] Fix reported time for produced blocks and fix confusing reported time name

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -832,7 +832,7 @@ struct block_report {
    size_t             total_net_usage = 0;
    size_t             total_cpu_usage_us = 0;
    fc::microseconds   total_elapsed_time;
-   fc::time_point     start_time;
+   fc::time_point     start_time{fc::time_point::now()};
 };
 
 struct pending_state {
@@ -3473,7 +3473,7 @@ struct controller_impl {
       if (s == controller::block_status::incomplete) {
          const auto& new_b = chain_head.block();
          ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} "
-              "[trxs: ${count}, lib: ${lib}, confirmed: ${confs}, net: ${net}, cpu: ${cpu}, elapsed: ${et} us, time: ${tt} us]",
+              "[trxs: ${count}, lib: ${lib}, confirmed: ${confs}, net: ${net}, cpu: ${cpu} us, elapsed: ${et} us, producing time: ${tt} us]",
               ("id", chain_head.id().str().substr(8, 16))("n", new_b->block_num())("p", new_b->producer)("t", new_b->timestamp)
               ("count", new_b->transactions.size())("lib", chain_head.irreversible_blocknum())
               ("confs", new_b->is_proper_svnn_block() ? "" : ", confirmed: " + std::to_string(new_b->confirmed))
@@ -3497,7 +3497,7 @@ struct controller_impl {
       }
 
       ilog("Received block ${id}... #${n} @ ${t} signed by ${p} " // "Received" instead of "Applied" so it matches existing log output
-           "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu}, elapsed: ${elapsed} us, time: ${time} us, latency: ${latency} ms]",
+           "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu} us, elapsed: ${elapsed} us, applying time: ${time} us, latency: ${latency} ms]",
            ("p", chain_head.producer())("id", chain_head.id().str().substr(8, 16))("n", chain_head.block_num())("t", chain_head.timestamp())
            ("count", chain_head.block()->transactions.size())("lib", chain_head.irreversible_blocknum())
            ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)


### PR DESCRIPTION
Forwards https://github.com/AntelopeIO/spring/pull/850

This PR
* fixes incorrect reported time for "Produced blocks"
* changes `time` for "Produced blocks" to `producing time`, and for "Received blocks" to `applying time`
* adds time unit `us` to reported CPU time

Before the changes
`info  2024-10-01T18:31:59.066 nodeos    controller.cpp:3462           commit_block         ] Produced block dd7794184632fdd2... #100 @ 2024-10-01T18:31:59.500 signed by eosio [trxs: 0, lib: 98, net: 0, cpu: 100, elapsed: 342 us, time: 1727797983669080 us]`

After
`info  2024-10-01T19:07:27.667 nodeos    controller.cpp:3461           commit_block         ] Produced block b29e040564b322f2... #100 @ 2024-10-01T19:07:28.000 signed by eosio [trxs: 0, lib: 98, net: 0, cpu: 100 us, elapsed: 291 us, producing time: 451393 us]`

Fix https://github.com/AntelopeIO/spring/issues/849
