### PR TITLE
[1.0.3] Restart with ctrl-c during replay of forkdb spams log

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2012,6 +2012,7 @@ struct controller_impl {
                      ilog( "applying branch from fork database ending with block: ${id}", ("id", pending_head->id()) );
                      controller::block_report br;
                      maybe_switch_forks( br, pending_head, controller::block_status::complete, {}, trx_meta_cache_lookup{} );
+                     if( check_shutdown() ) return;
                   }
                }
             }

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -293,7 +293,7 @@ namespace savanna_cluster {
 
       void remove_state() {
          auto state_path = cfg.state_dir;
-         dlog("node ${i} - removing state data from: ${state_path}", ("i", _node_idx)("${state_path}", state_path));
+         dlog("node ${i} - removing state data from: ${state_path}", ("i", _node_idx)("state_path", state_path));
          remove_all(state_path);
          fs::create_directories(state_path);
       }
@@ -311,7 +311,7 @@ namespace savanna_cluster {
          for (auto const& dir_entry : std::filesystem::directory_iterator{path}) {
             auto path = dir_entry.path();
             if (path.filename().generic_string() != "reversible") {
-               dlog("node ${i} - removing : ${path}", ("i", _node_idx)("${path}", path));
+               dlog("node ${i} - removing : ${path}", ("i", _node_idx)("path", path));
                remove_all(path);
             }
          }
@@ -338,7 +338,7 @@ namespace savanna_cluster {
       void remove_blocks(bool rm_blocks_log) {
          auto reversible_path = cfg.blocks_dir / config::reversible_blocks_dir_name;
          auto& path = rm_blocks_log ? cfg.blocks_dir : reversible_path;
-         dlog("node ${i} - removing : ${path}", ("i", _node_idx)("${path}", path));
+         dlog("node ${i} - removing : ${path}", ("i", _node_idx)("path", path));
          remove_all(path);
          fs::create_directories(reversible_path);
       }

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -235,10 +235,12 @@ namespace savanna_cluster {
 
       template <class Node>
       void push_blocks_to(Node& n, uint32_t block_num_limit = std::numeric_limits<uint32_t>::max()) const {
-         auto limit = std::min(fork_db_head().block_num(), block_num_limit);
-         while (n.fork_db_head().block_num() < limit) {
-            auto sb = control->fetch_block_by_number(n.fork_db_head().block_num() + 1);
-            n.push_block(sb);
+         if (fork_db_head().is_valid() && n.fork_db_head().is_valid()) {
+            auto limit = std::min(fork_db_head().block_num(), block_num_limit);
+            while (n.fork_db_head().block_num() < limit) {
+               auto sb = control->fetch_block_by_number(n.fork_db_head().block_num() + 1);
+               n.push_block(sb);
+            }
          }
       }
 
@@ -519,11 +521,13 @@ namespace savanna_cluster {
          auto& src = _nodes[src_idx];
          assert(src.is_open() && _nodes[dst_idx].is_open());
 
-         auto end_block_num   = src.fork_db_head().block_num();
+         if (src.fork_db_head().is_valid()) {
+            auto end_block_num   = src.fork_db_head().block_num();
 
-         for (uint32_t i=start_block_num; i<=end_block_num; ++i) {
-            auto sb = src.control->fetch_block_by_number(i);
-            push_block(dst_idx, sb);
+            for (uint32_t i=start_block_num; i<=end_block_num; ++i) {
+               auto sb = src.control->fetch_block_by_number(i);
+               push_block(dst_idx, sb);
+            }
          }
       }
 

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -1106,8 +1106,8 @@ BOOST_FIXTURE_TEST_CASE(finality_advancing_past_block_claimed_on_alternate_branc
 } FC_LOG_AND_RETHROW()
 
 // ------------------------------------------------------------------------------------
-// Verify that we can restart a node from a snapshot without state or blocks (reversible
-// or not)
+// Test that replays blocks from fork_db at startup, and simulating a Ctrl-C
+// interruption of that replat
 // ------------------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) try {
    auto& A=_nodes[0]; auto& C=_nodes[2]; auto& D=_nodes[3];

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -1129,8 +1129,14 @@ BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) tr
 
    A.close();
    A.remove_state();
+
    A.open(make_protocol_feature_set(), genesis->compute_chain_id(), [genesis, &control=A.control]() {
-      control->startup( [](){}, []() { return false; }, *genesis );
+      auto check_shutdown = [](){
+         static size_t call_idx = 0;
+         return ++call_idx >= 15;                         // simulate Ctrl-C being hit on 15th call
+      };
+
+      control->startup([]() {}, check_shutdown, *genesis);
    } );
 
    BOOST_REQUIRE_EQUAL(A.control->fork_db_size(), num_forkdb_blocks);

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -1143,6 +1143,10 @@ BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) tr
       control->startup([]() {}, check_shutdown, *genesis);
    } );
 
+   A.close();
+   A.open();                                              // open() the node again to make sure it restarts correctly
+                                                          // after being interrupted.
+
    BOOST_REQUIRE_EQUAL(A.control->fork_db_size(), num_forkdb_blocks);
 
 } FC_LOG_AND_RETHROW()

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -1120,9 +1120,8 @@ BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) tr
    for (size_t i=0; i<num_blocks; ++i)
       blocks.push_back(A.produce_block());
 
-
    const size_t num_forkdb_blocks = A.control->fork_db_size();;
-   BOOST_REQUIRE_GT(num_forkdb_blocks, num_blocks);        // A should have 20+ unfinalized blocks in its fork_db
+   BOOST_REQUIRE_GT(num_forkdb_blocks, num_blocks);        // A should have 20+ unfinalized blocks in its fork_db (actually 21)
 
    controller::config copied_config = A.get_config();
    auto               genesis       = block_log::extract_genesis_state(A.get_config().blocks_dir);
@@ -1133,7 +1132,8 @@ BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) tr
    A.open(make_protocol_feature_set(), genesis->compute_chain_id(), [genesis, &control=A.control]() {
       auto check_shutdown = [](){
          static size_t call_idx = 0;
-         return ++call_idx >= 15;                         // simulate Ctrl-C being hit on 15th call
+         return ++call_idx >= 15;                         // simulate Ctrl-C being hit on 15th call, so fewer than
+                                                          // 21 blocks from fork_db will be replayed
       };
 
       control->startup([]() {}, check_shutdown, *genesis);

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -1107,10 +1107,14 @@ BOOST_FIXTURE_TEST_CASE(finality_advancing_past_block_claimed_on_alternate_branc
 
 // ------------------------------------------------------------------------------------
 // Test that replays blocks from fork_db at startup, and simulating a Ctrl-C
-// interruption of that replat
+// interruption of that replay.
+// (the cluster starts with 9 final blocks and 1 reversible block after the transition
+// to Savanna)
 // ------------------------------------------------------------------------------------
 BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) try {
    auto& A=_nodes[0]; auto& C=_nodes[2]; auto& D=_nodes[3];
+
+   // at this point we have 9 final blocks and 1 reversible block
 
    set_partition( { &C, &D } );                              // partition so blocks aren't finalized
    const size_t num_blocks = 20;
@@ -1133,7 +1137,7 @@ BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) tr
       auto check_shutdown = [](){
          static size_t call_idx = 0;
          return ++call_idx >= 15;                         // simulate Ctrl-C being hit on 15th call, so fewer than
-                                                          // 21 blocks from fork_db will be replayed
+                                                          // 21 blocks from fork_db will be replayed.
       };
 
       control->startup([]() {}, check_shutdown, *genesis);


### PR DESCRIPTION
Resolves #869 

I added a test attempting to reproduce the issue, but in order to activate the code in question, I would have to be able to update the blocks in `fork_db`  to have `validated = false`, so they are not applied during the `replay()` call. I don't think it is worth adding an API in controller allowing to do this for this test.

