### PR TITLE
[1.0] Test failure: p2p_sync_throttle_test

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2267,7 +2267,7 @@ namespace eosio {
       if( !ec ) {
          peer_dlog(c, "sync timed out");
          sync_reassign_fetch( c );
-         close(true);
+         c->close(true);
       } else if( ec != boost::asio::error::operation_aborted ) { // don't log on operation_aborted, called on destroy
          peer_elog( c, "setting timer for sync request got error ${ec}", ("ec", ec.message()) );
       }


### PR DESCRIPTION
Resolves #882.

While moving some code around (see [here](https://github.com/AntelopeIO/spring/pull/590/files)), a call to:

`void connection::close(bool reconnect, bool shutdown)`

became a call to:

`int close(int __fd)`

This restores the intended behavior (close the actual connection, instead of closing fd number 1)