### PR TITLE
bump sanitizer builds to clang19

### DIFF
--- a/.cicd/platforms/asan.Dockerfile
+++ b/.cicd/platforms/asan.Dockerfile
@@ -19,17 +19,17 @@ RUN apt-get update && apt-get upgrade -y && \
                        zlib1g-dev           \
                        zstd
 
-RUN yes | bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 18
+RUN yes | bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 19
 
 #make sure no confusion on what llvm library spring's cmake should pick up on
-RUN rm -rf /usr/lib/llvm-18/lib/cmake
+RUN rm -rf /usr/lib/llvm-19/lib/cmake
 
 ENV SPRING_PLATFORM_HAS_EXTRAS_CMAKE=1
 COPY <<-EOF /extras.cmake
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
 
-  set(CMAKE_C_COMPILER "clang-18" CACHE STRING "")
-  set(CMAKE_CXX_COMPILER "clang++-18" CACHE STRING "")
+  set(CMAKE_C_COMPILER "clang-19" CACHE STRING "")
+  set(CMAKE_CXX_COMPILER "clang++-19" CACHE STRING "")
   set(CMAKE_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "")
   set(CMAKE_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "")
 EOF

--- a/.cicd/platforms/ubsan.Dockerfile
+++ b/.cicd/platforms/ubsan.Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get upgrade -y && \
                        zlib1g-dev           \
                        zstd
 
-RUN yes | bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 18
+RUN yes | bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 19
 
 #make sure no confusion on what llvm library spring's cmake should pick up on
-RUN rm -rf /usr/lib/llvm-18/lib/cmake
+RUN rm -rf /usr/lib/llvm-19/lib/cmake
 
 COPY <<-EOF /ubsan.supp
   vptr:wasm_eosio_validation.hpp
@@ -33,8 +33,8 @@ ENV SPRING_PLATFORM_HAS_EXTRAS_CMAKE=1
 COPY <<-EOF /extras.cmake
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
 
-  set(CMAKE_C_COMPILER "clang-18" CACHE STRING "")
-  set(CMAKE_CXX_COMPILER "clang++-18" CACHE STRING "")
+  set(CMAKE_C_COMPILER "clang-19" CACHE STRING "")
+  set(CMAKE_CXX_COMPILER "clang++-19" CACHE STRING "")
   set(CMAKE_C_FLAGS "-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" CACHE STRING "")
   set(CMAKE_CXX_FLAGS "-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" CACHE STRING "")
 EOF


### PR DESCRIPTION
Upgrade from clang18 to clang19. Just under the assumption that newer versions will be better.