### PR TITLE
relax eosvmoc_limits_test's generated_code_size_limit pass/fail criteria; reenable test in exhaustive LLVM workflow

### DIFF
--- a/.github/workflows/llvm.yaml
+++ b/.github/workflows/llvm.yaml
@@ -38,4 +38,4 @@ jobs:
             cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -GNinja
             cmake --build build
       - name: Test spring
-        run: ctest --test-dir build -j $(nproc) --output-on-failure -LE "(nonparallelizable_tests|long_running_tests)" -E eosvmoc_limits_unit_test_eos-vm-oc --timeout 480
+        run: ctest --test-dir build -j $(nproc) --output-on-failure -LE "(nonparallelizable_tests|long_running_tests)" --timeout 480

--- a/unittests/eosvmoc_limits_tests.cpp
+++ b/unittests/eosvmoc_limits_tests.cpp
@@ -139,13 +139,14 @@ BOOST_AUTO_TEST_CASE( stack_limit ) { try {
 BOOST_AUTO_TEST_CASE( generated_code_size_limit ) { try {
    eosvmoc::config eosvmoc_config = make_eosvmoc_config_without_limits();
 
-   // The generated code size of the compiled WASM in the test is 36856.
-   // Set generated_code_size_limit to the actual generated code size
-   eosvmoc_config.generated_code_size_limit = 36856;
+   // Generated code size can vary based on the version of LLVM in use. Since this test
+   // isn't intended to detect minute differences or regressions, give the range a wide
+   // berth to work on. As a single data point, LLVM11 used in reproducible builds during
+   // Spring 1.0 timeframe was 36856
+   eosvmoc_config.generated_code_size_limit = 20*1024;
    limit_violated_test(eosvmoc_config);
 
-   // Set generated_code_size_limit to one above the actual generated code size
-   eosvmoc_config.generated_code_size_limit = 36857;
+   eosvmoc_config.generated_code_size_limit = 40*1024;
    limit_not_violated_test(eosvmoc_config);
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
Relax the pass/fail criteria for this test. Generated code size can vary based on LLVM version being used and this test is not intended to detect regressions or minute differences between those LLVM versions. (put another way, the generated code size is a subjective limit)

Reenable `eosvmoc_limits_unit_test_eos-vm-oc` in the exhaustive LLVM workflow now that the different versions the workflow uses will not get caught up on this test. Example passing run is at,
https://github.com/AntelopeIO/spring/actions/runs/11223260327