### PR TITLE
[1.0.3] fix building with LLVM 7, 8, and 9

### DIFF
--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/LLVMJIT.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/LLVMJIT.cpp
@@ -305,14 +305,19 @@ namespace LLVMJIT
 
 		unsigned num_functions_stack_size_found = 0;
 		for(const auto& stacksizes : jitModule->unitmemorymanager->stack_sizes) {
-			llvm::DataExtractor ds(llvm::ArrayRef(stacksizes.data(), stacksizes.size()), true, 8);
-			llvm::DataExtractor::Cursor c(0);
+#if LLVM_VERSION_MAJOR < 10
+			using de_offset_t = uint32_t;
+#else
+			using de_offset_t = uint64_t;
+#endif
+			llvm::DataExtractor ds(llvm::StringRef(reinterpret_cast<const char*>(stacksizes.data()), stacksizes.size()), true, 8);
+			de_offset_t offset = 0;
 
-			while(!ds.eof(c)) {
-				ds.getAddress(c);
-				WAVM_ASSERT_THROW(!!c);
-				const uint64_t stack_size = ds.getULEB128(c);
-				WAVM_ASSERT_THROW(!!c);
+			while(ds.isValidOffsetForAddress(offset)) {
+				ds.getAddress(&offset);
+				const de_offset_t offset_before_read = offset;
+				const uint64_t stack_size = ds.getULEB128(&offset);
+				WAVM_ASSERT_THROW(offset_before_read != offset);
 
 				++num_functions_stack_size_found;
 				if(stack_size > stack_size_limit)


### PR DESCRIPTION
Spring claims that it builds with LLVM versions 7 through 11. Code says it,
https://github.com/AntelopeIO/spring/blob/1606adef60a34e52694fd75623f9615ca1bb78fb/CMakeLists.txt#L68-L70
README says it,
https://github.com/AntelopeIO/spring/blob/1606adef60a34e52694fd75623f9615ca1bb78fb/README.md?plain=1#L55

Unfortunately building with versions 7-9 was broken in leap 5.0. This change restores building with LLVM 7 through 11 by using an older interface that's common across all supported LLVM versions.

An example exhaustive workflow run with all versions 7-11 enabled:
https://github.com/AntelopeIO/spring/actions/runs/11223407160
(this is off a demonstration only branch that cherry-picks the workflow back to 1.0, as otherwise it only exists on main. plus also then adding #902 on top)