### PR TITLE
[1.0.3] Test failure: distributed-transactions-if-test

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -729,7 +729,7 @@ class Node(Transactions):
                     match = starting_block_regexp.match(line)
                     if match:
                         blockNumber, time = match.group(1), match.group(2)
-                        if blockNumber in notRestartedBlockNumbersAndTimes and notRestartedBlockNumbersAndTimes[blockNumber] != time:
+                        if blockNumber in notRestartedBlockNumbersAndTimes and notRestartedBlockNumbersAndTimes[blockNumber] == time:
                             print(f"Duplicate Starting block found: {blockNumber} in {f}")
                             duplicateStartFound = True
                             break

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -708,37 +708,36 @@ class Node(Transactions):
                 count += contents.count(searchStr)
         return count
 
-    # verify only one or two 'Starting block' per block number unless block is restarted
+    # verify only one 'Starting block' per block number unless block is restarted
     def verifyStartingBlockMessages(self):
         dataDir=Utils.getNodeDataDir(self.nodeId)
         files=Node.findStderrFiles(dataDir)
+        restarting_exhausted_regexp = re.compile(r"Restarting exhausted speculative block #(\d+)")
+        starting_block_regexp       = re.compile(r"Starting block #(\d+) .*(\d\d:\d\d\.\d\d\d) producer")
+
         for f in files:
-            blockNumbers = set()
-            duplicateBlockNumbers = set()
-            threeStartsFound = False
-            lastRestartBlockNum = 0
-            blockNumber = 0
+            notRestartedBlockNumbersAndTimes = {}
+            duplicateStartFound = False
 
             with open(f, 'r') as file:
                 for line in file:
-                    match = re.match(r".*Restarting exhausted speculative block #(\d+)", line)
+                    match = restarting_exhausted_regexp.match(line)
                     if match:
-                        lastRestartBlockNum = match.group(1)
+                        # remove restarted block
+                        notRestartedBlockNumbersAndTimes.pop(match.group(1), None)
                         continue
-                    if re.match(r".*unlinkable_block_exception", line):
-                        lastRestartBlockNum = blockNumber
-                        continue
-                    match = re.match(r".*Starting block #(\d+)", line)
+                    match = starting_block_regexp.match(line)
                     if match:
-                        blockNumber = match.group(1)
-                        if blockNumber != lastRestartBlockNum and blockNumber in duplicateBlockNumbers:
-                            print(f"Duplicate Staring block found: {blockNumber} in {f}")
-                            threeStartsFound = True
-                        if blockNumber != lastRestartBlockNum and blockNumber in blockNumbers:
-                            duplicateBlockNumbers.add(blockNumber)
-                        blockNumbers.add(blockNumber)
+                        blockNumber, time = match.group(1), match.group(2)
+                        if blockNumber in notRestartedBlockNumbersAndTimes and notRestartedBlockNumbersAndTimes[blockNumber] != time:
+                            print(f"Duplicate Starting block found: {blockNumber} in {f}")
+                            duplicateStartFound = True
+                            break
+                        notRestartedBlockNumbersAndTimes[blockNumber] = time
+            if duplicateStartFound:
+                break
 
-        return not threeStartsFound
+        return not duplicateStartFound
 
     def analyzeProduction(self, specificBlockNum=None, thresholdMs=500):
         dataDir=Utils.getNodeDataDir(self.nodeId)

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -708,7 +708,10 @@ class Node(Transactions):
                 count += contents.count(searchStr)
         return count
 
-    # verify only one 'Starting block' per block number unless block is restarted
+    # Verify that we have only one "Starting block" in the log for any block number unless:
+    # - the block was restarted because it was exhausted,
+    # - or the second "Starting block" is for a different block time than the first.
+    # -------------------------------------------------------------------------------------
     def verifyStartingBlockMessages(self):
         dataDir=Utils.getNodeDataDir(self.nodeId)
         files=Node.findStderrFiles(dataDir)


### PR DESCRIPTION
Resolves #848.

This updates the `verifyStartingBlockMessages` check in `Node.py` to check that we have only one `Starting block` in the log for any block number *unless*:

1. the block was restarted because it was exhausted, 
2. or the second `Starting block` is for a different block time than the first.

I have checked the new regular expression with a small python script against the log and it appears to work fine.

script:
```
import re

def check_file_for_pattern(file_path, pattern):
    regex = re.compile(pattern)

    with open(file_path, 'r') as file:
        for line_num, line in enumerate(file, start=1):
            match = regex.match(line)
            if match:
                blockNumber, time = match.group(1), match.group(2)
                print(f"{blockNumber} -> {time}")

if __name__ == "__main__":
    file_path = "stderr.2024_10_01_13_21_16.txt"
    pattern = r".*Starting block #(\d+) .*(\d\d:\d\d\.\d\d\d) producer"
    check_file_for_pattern(file_path, pattern)
```

execution:

```
❯ python ~/tmp/check_regexp.py
2 -> 21:17.000
3 -> 21:17.500
4 -> 21:18.000
5 -> 21:18.500
6 -> 21:19.000
7 -> 21:19.500
8 -> 21:20.000
9 -> 21:20.500
10 -> 21:21.000
...
```