### PR TITLE
P2P: Immediately close on bad block

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3721,7 +3721,7 @@ namespace eosio {
          sync_manager::closing_mode close_mode = sync_manager::closing_mode::immediately;
          try {
             EOS_ASSERT(ptr->timestamp < (fc::time_point::now() + fc::seconds(7)), block_from_the_future,
-                       "received a block from the future, ignoring it: ${id}", ("id", id));
+                       "received a block from the future, rejecting it: ${id}", ("id", id));
             // this will return empty optional<block_handle> if block is not linkable
             controller::accepted_block_result abh = cc.accept_block( id, ptr );
             best_head = abh.is_new_best_head;


### PR DESCRIPTION
Note almost all the work of #643 was done as part of #529. This PR represents the remaining part of closing immediately if a block is invalid.

Resolves #643 
