### PR TITLE
Simplify qc verification and  avoid creating a new `aggregating_qc` class.

### DIFF
--- a/libraries/chain/block_state.cpp
+++ b/libraries/chain/block_state.cpp
@@ -267,14 +267,8 @@ vote_status_t block_state::has_voted(const bls_public_key& key) const {
 
 // Called from net threads
 void block_state::verify_qc(const qc_t& qc) const {
-   // Do not use `block_state::aggregating_qc` which applies only for `this` block.
-   // `verify_qc()` can be called on a descendant `block_state` of `qc.block_num`, so we need
-   // to create a new `aggregating_qc_t` with the finalizer policies of the claimed block.
-   // ---------------------------------------------------------------------------------------
-   finalizer_policies_t policies = get_finalizer_policies(qc.block_num);
-   aggregating_qc_t aggregating_qc(policies.active_finalizer_policy, policies.pending_finalizer_policy);
-
-   aggregating_qc.verify_qc(qc, policies.finality_digest, create_weak_digest(policies.finality_digest));
+   finalizer_policies_t policies = get_finalizer_policies(qc.block_num); // get policies active at claimed block number
+   qc.verify(policies);
 }
 
 qc_claim_t block_state::extract_qc_claim() const {

--- a/libraries/chain/finality/qc.cpp
+++ b/libraries/chain/finality/qc.cpp
@@ -412,28 +412,6 @@ std::optional<qc_t> aggregating_qc_t::get_best_qc(block_num_type block_num) cons
    return std::optional<qc_t>{qc_t{block_num, std::move(*active_best_qc), {}}};
 }
 
-#if 0
-void aggregating_qc_t::verify_qc(const qc_t& qc, const digest_type& strong_digest, const weak_digest_t& weak_digest) const {
-   qc.active_policy_sig.verify_vote_format(active_finalizer_policy);
-
-   if (qc.pending_policy_sig) {
-      EOS_ASSERT(pending_finalizer_policy, invalid_qc_claim,
-                 "qc ${bn} contains pending policy signature for nonexistent pending finalizer policy", ("bn", qc.block_num));
-
-      qc.pending_policy_sig->verify_vote_format(pending_finalizer_policy);
-      verify_dual_finalizers_votes(qc);
-   } else {
-      EOS_ASSERT(!pending_finalizer_policy, invalid_qc_claim,
-                 "qc ${bn} does not contain pending policy signature for pending finalizer policy", ("bn", qc.block_num));
-   }
-
-   qc.active_policy_sig.verify(active_finalizer_policy, strong_digest, weak_digest);
-   if (pending_finalizer_policy) {
-      qc.pending_policy_sig->verify(pending_finalizer_policy, strong_digest, weak_digest);
-   }
-}
-#endif
-
 bool aggregating_qc_t::set_received_qc(const qc_t& qc) {
    // qc should have already been verified via verify_qc, this EOS_ASSERT should never fire
    EOS_ASSERT(!pending_policy_sig || qc.pending_policy_sig, invalid_qc_claim,

--- a/libraries/chain/finality/qc.cpp
+++ b/libraries/chain/finality/qc.cpp
@@ -31,6 +31,53 @@ bool qc_t::vote_same_at(uint32_t active_vote_index, uint32_t pending_vote_index)
                                          pending_vote_index);
 }
 
+// A dual finalizer votes on both active and pending finalizer policies.
+void qc_t::verify_dual_finalizers_votes(const finalizer_policies_t& policies) const {
+   // Find dual finalizers (which vote on both active and pending policies)
+   // and verify each dual finalizer votes in the same way.
+   // As the number of finalizers is small, to avoid copying bls_public_keys
+   // all over the places,
+   // we choose to use nested loops instead of sorting public keys and doing
+   // a binary search.
+   uint32_t active_vote_index = 0;
+   for (const auto& active_fin: policies.active_finalizer_policy->finalizers) {
+      uint32_t pending_vote_index = 0;
+      for (const auto& pending_fin: policies.pending_finalizer_policy->finalizers) {
+         if (active_fin.public_key == pending_fin.public_key) {
+            EOS_ASSERT(vote_same_at(active_vote_index, pending_vote_index),
+                       invalid_qc_claim,
+                       "qc ${bn} contains a dual finalizer ${k} which does not vote the same on active and pending policies",
+                       ("bn", block_num)("k", active_fin.public_key));
+            break;
+         }
+         ++pending_vote_index;
+      }
+      ++active_vote_index;
+   }
+}
+
+void qc_t::verify(const finalizer_policies_t& policies) const {
+   const auto& strong_digest = policies.finality_digest;
+   auto weak_digest = create_weak_digest(strong_digest);
+
+   active_policy_sig.verify_vote_format(policies.active_finalizer_policy);
+   active_policy_sig.verify(policies.active_finalizer_policy, strong_digest, weak_digest);
+
+   if (pending_policy_sig) {
+      EOS_ASSERT(policies.pending_finalizer_policy, invalid_qc_claim,
+                 "qc ${bn} contains pending policy signature for nonexistent pending finalizer policy", ("bn", block_num));
+
+      verify_dual_finalizers_votes(policies); // verify every finalizer included in both policies voted the same
+
+      pending_policy_sig->verify_vote_format(policies.pending_finalizer_policy);
+      pending_policy_sig->verify(policies.pending_finalizer_policy, strong_digest, weak_digest);
+   } else {
+      EOS_ASSERT(!policies.pending_finalizer_policy, invalid_qc_claim,
+                 "qc ${bn} does not contain pending policy signature for pending finalizer policy", ("bn", block_num));
+   }
+
+}
+
 // returns true iff the other and I voted iin the same way.
 bool qc_sig_t::vote_same_at(const qc_sig_t& other, uint32_t my_vote_index, uint32_t other_vote_index) const {
    assert(!strong_votes || my_vote_index < strong_votes->size());
@@ -365,31 +412,7 @@ std::optional<qc_t> aggregating_qc_t::get_best_qc(block_num_type block_num) cons
    return std::optional<qc_t>{qc_t{block_num, std::move(*active_best_qc), {}}};
 }
 
-// A dual finalizer votes on both active and pending finalizer policies.
-void aggregating_qc_t::verify_dual_finalizers_votes(const qc_t& qc) const {
-   // Find dual finalizers (which vote on both active and pending policies)
-   // and verify each dual finalizer votes in the same way.
-   // As the number of finalizers is small, to avoid copying bls_public_keys
-   // all over the places,
-   // we choose to use nested loops instead of sorting public keys and doing
-   // a binary search.
-   uint32_t active_vote_index = 0;
-   for (const auto& active_fin: active_finalizer_policy->finalizers) {
-      uint32_t pending_vote_index = 0;
-      for (const auto& pending_fin: pending_finalizer_policy->finalizers) {
-         if (active_fin.public_key == pending_fin.public_key) {
-            EOS_ASSERT(qc.vote_same_at(active_vote_index, pending_vote_index),
-                       invalid_qc_claim,
-                       "qc ${bn} contains a dual finalizer ${k} which does not vote the same on active and pending policies",
-                       ("bn", qc.block_num)("k", active_fin.public_key));
-            break;
-         }
-         ++pending_vote_index;
-      }
-      ++active_vote_index;
-   }
-}
-
+#if 0
 void aggregating_qc_t::verify_qc(const qc_t& qc, const digest_type& strong_digest, const weak_digest_t& weak_digest) const {
    qc.active_policy_sig.verify_vote_format(active_finalizer_policy);
 
@@ -409,6 +432,7 @@ void aggregating_qc_t::verify_qc(const qc_t& qc, const digest_type& strong_diges
       qc.pending_policy_sig->verify(pending_finalizer_policy, strong_digest, weak_digest);
    }
 }
+#endif
 
 bool aggregating_qc_t::set_received_qc(const qc_t& qc) {
    // qc should have already been verified via verify_qc, this EOS_ASSERT should never fire

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -79,13 +79,6 @@ struct block_header_state_input : public building_block_input {
    digest_type                       finality_mroot_claim;
 };
 
-
-struct finalizer_policies_t {
-   digest_type          finality_digest;
-   finalizer_policy_ptr active_finalizer_policy;  // Never null
-   finalizer_policy_ptr pending_finalizer_policy; // Only null if the block has no pending finalizer policy
-};
-
 struct block_header_state : fc::reflect_init {
    // ------ data members ------------------------------------------------------------
    block_id_type                       block_id;

--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -35,6 +35,12 @@ namespace eosio::chain {
       return res;
    }
 
+   struct finalizer_policies_t {
+      digest_type          finality_digest;
+      finalizer_policy_ptr active_finalizer_policy;  // Never null
+      finalizer_policy_ptr pending_finalizer_policy; // Only null if the block has no pending finalizer policy
+   };
+
    enum class vote_result_t {
       success,
       duplicate,             // duplicate vote, expected as votes arrive on multiple connections
@@ -93,6 +99,11 @@ namespace eosio::chain {
       // returns true if vote indicated by active_vote_index in active_policy
       // is the same as vote indicated by pending_vote_index in pending_policy
       bool vote_same_at(uint32_t active_vote_index, uint32_t pending_vote_index) const;
+
+      void verify(const finalizer_policies_t& policies) const;
+
+      // verify qc against active and pending policy
+      void verify_dual_finalizers_votes(const finalizer_policies_t& policies) const;
    };
 
    struct qc_data_t {
@@ -268,9 +279,6 @@ namespace eosio::chain {
       finalizer_policy_ptr                pending_finalizer_policy; // not modified after construction
       aggregating_qc_sig_t                active_policy_sig;
       std::optional<aggregating_qc_sig_t> pending_policy_sig;
-
-      // verify qc against active and pending policy
-      void verify_dual_finalizers_votes(const qc_t& qc) const;
    };
 
 } //eosio::chain

--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -96,14 +96,7 @@ namespace eosio::chain {
          return { .block_num = block_num, .is_strong_qc = is_strong() };
       }
 
-      // returns true if vote indicated by active_vote_index in active_policy
-      // is the same as vote indicated by pending_vote_index in pending_policy
-      bool vote_same_at(uint32_t active_vote_index, uint32_t pending_vote_index) const;
-
       void verify(const finalizer_policies_t& policies) const;
-
-      // verify qc against active and pending policy
-      void verify_dual_finalizers_votes(const finalizer_policies_t& policies) const;
    };
 
    struct qc_data_t {

--- a/libraries/chain/include/eosio/chain/finality/qc.hpp
+++ b/libraries/chain/include/eosio/chain/finality/qc.hpp
@@ -260,13 +260,15 @@ namespace eosio::chain {
       aggregating_qc_t() = default;
 
       std::optional<qc_t> get_best_qc(block_num_type block_num) const;
-      // verify qc against active and pending policy
-      void verify_qc(const qc_t& qc, const digest_type& strong_digest, const weak_digest_t& weak_digest) const;
+
       qc_vote_metrics_t vote_metrics(const qc_t& qc) const;
+
       // return qc missing vote's finalizers
       qc_vote_metrics_t::fin_auth_set_t missing_votes(const qc_t& qc) const;
+
       // return true if better qc
       bool set_received_qc(const qc_t& qc);
+
       bool received_qc_is_strong() const;
       aggregate_vote_result_t aggregate_vote(uint32_t connection_id, const vote_message& vote,
                                              const block_id_type& block_id, std::span<const uint8_t> finalizer_digest);


### PR DESCRIPTION
Resolves #743.

This moves the `verify_qc` API from `aggregating_qc_t` to `qc_t`.

It also renames it to `verify`, because `qc.verify_qc(policies)` seems a bit redundant.

It also removes `verify_dual_finalizers_votes` and `votes_same_at` from the external API because these are internal implementation details.