### PR TITLE
Normalize usage of LIB

### DIFF
--- a/docs/01_nodeos/04_replays/how-to-replay-from-a-blocks.log.md
+++ b/docs/01_nodeos/04_replays/how-to-replay-from-a-blocks.log.md
@@ -2,15 +2,15 @@
 content_title: How to replay from a blocks.log file
 ---
 
-Once you have obtained a copy of the `blocks.log` file which you wish to replay the blockchain from, copy it to your `data/blocks` directory, backing up any existing contents if you wish to keep them, and remove the `blocks.index`, `forkdb.dat`, `shared_memory.bin`, and `shared_memory.meta`.
+Once you have obtained a copy of the `blocks.log` file which you wish to replay the blockchain from, copy it to your `data/blocks` directory, backing up any existing contents if you wish to keep them, and remove the `blocks.index`, `fork_db.dat`, `shared_memory.bin`, and `shared_memory.meta`.
 
 The table below sumarizes the actions you should take for each of the files enumerated above:
 
 Folder name             | File name          | Action
------------------------ | ------------------ | ------
+----------------------- |--------------------| ------
 data/blocks             | blocks.index       | Remove
 data/blocks             | blocks.log         | Replace this file with the `block.log` you want to replay
-data/blocks/reversible  | forkdb.dat         | Remove
+data/blocks/reversible  | fork_db.dat        | Remove
 data/blocks/reversible  | shared_memory.bin  | Remove
 data/blocks/reversible  | shared_memory.meta | Remove
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1615,7 +1615,7 @@ struct controller_impl {
 
       bool should_replay = start_block_num <= blog_head->block_num();
       if (!should_replay) {
-         ilog( "no irreversible blocks need to be replayed" );
+         ilog( "no irreversible blocks need to be replayed from block log" );
       }
       return should_replay;
    }
@@ -1687,7 +1687,7 @@ struct controller_impl {
       }
       transition_legacy_branch.clear(); // not needed after replay
       auto end = fc::time_point::now();
-      ilog( "${n} irreversible blocks replayed", ("n", 1 + chain_head.block_num() - start_block_num) );
+      ilog( "${n} irreversible blocks replayed from block log", ("n", 1 + chain_head.block_num() - start_block_num) );
       ilog( "replayed ${n} blocks in ${duration} seconds, ${mspb} ms/block",
             ("n", chain_head.block_num() + 1 - start_block_num)("duration", (end-start).count()/1000000)
             ("mspb", ((end-start).count()/1000.0)/(chain_head.block_num()-start_block_num)) );
@@ -1871,7 +1871,7 @@ struct controller_impl {
                         "Snapshot is invalid." );
             blog.reset( chain_id, chain_head.block_num() + 1 );
          }
-         ilog( "Snapshot loaded, lib: ${lib}", ("lib", chain_head.block_num()) );
+         ilog( "Snapshot loaded, head: ${h} : ${id}", ("h", chain_head.block_num())("id", chain_head.id()) );
 
          init(startup_t::snapshot);
          block_handle_accessor::apply_l<void>(chain_head, [&](auto& head) {
@@ -5355,15 +5355,15 @@ size_t controller::fork_db_size() const {
    return my->fork_db_size();
 }
 
-uint32_t controller::last_irreversible_block_num() const {
+uint32_t controller::fork_db_root_block_num() const {
    return my->fork_db_root_block_num();
 }
 
-block_id_type controller::last_irreversible_block_id() const {
+block_id_type controller::fork_db_root_block_id() const {
    return my->fork_db_root_block_id();
 }
 
-time_point controller::last_irreversible_block_time() const {
+time_point controller::fork_db_root_block_time() const {
    return my->fork_db_root_timestamp().to_time_point();
 }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1101,6 +1101,13 @@ struct controller_impl {
       return fork_db.size();
    }
 
+   block_handle fork_db_root()const {
+      return fork_db.apply<block_handle>(
+         [&](const auto& forkdb) {
+            return block_handle{forkdb.root()};
+         });
+   }
+
    block_id_type fork_db_root_block_id() const {
       assert(fork_db_has_root());
       return fork_db.apply<block_id_type>([&](const auto& forkdb) { return forkdb.root()->id(); });
@@ -1109,11 +1116,6 @@ struct controller_impl {
    uint32_t fork_db_root_block_num() const {
       assert(fork_db_has_root());
       return fork_db.apply<uint32_t>([&](const auto& forkdb) { return forkdb.root()->block_num(); });
-   }
-
-   block_timestamp_type  fork_db_root_timestamp() const {
-      assert(fork_db_has_root());
-      return fork_db.apply<block_timestamp_type>([&](const auto& forkdb) { return forkdb.root()->timestamp(); });
    }
 
    // ---------------  fork_db APIs ----------------------------------------------------------------------
@@ -5351,20 +5353,12 @@ bool controller::fork_db_has_root() const {
    return my->fork_db_has_root();
 }
 
+block_handle controller::fork_db_root()const {
+   return my->fork_db_root();
+}
+
 size_t controller::fork_db_size() const {
    return my->fork_db_size();
-}
-
-uint32_t controller::fork_db_root_block_num() const {
-   return my->fork_db_root_block_num();
-}
-
-block_id_type controller::fork_db_root_block_id() const {
-   return my->fork_db_root_block_id();
-}
-
-time_point controller::fork_db_root_block_time() const {
-   return my->fork_db_root_timestamp().to_time_point();
 }
 
 const dynamic_global_property_object& controller::get_dynamic_global_properties()const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -673,8 +673,8 @@ struct building_block {
       // find most recent ancestor block that has a QC by traversing fork db
       // branch from parent
 
-      return fork_db.apply_s<qc_data_t>([&](const auto& forkdb) {
-         auto branch = forkdb.fetch_branch(parent.id());
+      return fork_db.apply_s<qc_data_t>([&parent](const auto& fork_db) {
+         auto branch = fork_db.fetch_branch(parent.id());
 
          for( auto it = branch.begin(); it != branch.end(); ++it ) {
             if( auto qc = (*it)->get_best_qc(); qc ) {
@@ -949,7 +949,7 @@ struct controller_impl {
    block_handle                    chain_head;
    block_state_ptr                 chain_head_trans_svnn_block; // chain_head's Savanna representation during transition
    std::vector<block_state_legacy_ptr> transition_legacy_branch; // transition legacy branch used during replay
-   fork_database                   fork_db;
+   fork_database                   fork_db_;
    resource_limits_manager         resource_limits;
    subjective_billing              subjective_bill;
    authorization_manager           authorization;
@@ -1000,8 +1000,8 @@ struct controller_impl {
 
    vote_processor_t vote_processor{aggregated_vote,
                                    [this](const block_id_type& id) -> block_state_ptr {
-                                      return fork_db.apply_s<block_state_ptr>([&](const auto& forkdb) {
-                                         return forkdb.get_block(id);
+                                      return fork_db_.apply_s<block_state_ptr>([&](const auto& fork_db) {
+                                         return fork_db.get_block(id);
                                       });
                                    }};
 
@@ -1070,64 +1070,64 @@ struct controller_impl {
 
    // --------------- access fork_db head ----------------------------------------------------------------------
    block_handle fork_db_head()const {
-      return fork_db.apply<block_handle>(
-         [&](const auto& forkdb) {
-            return block_handle{forkdb.head(include_root_t::yes)};
+      return fork_db_.apply<block_handle>(
+         [&](const auto& fork_db) {
+            return block_handle{fork_db.head(include_root_t::yes)};
          });
    }
 
    uint32_t fork_db_head_block_num() const {
       assert(fork_db_has_root());
-      return fork_db.apply<uint32_t>(
-         [&](const auto& forkdb) {
-            return forkdb.head(include_root_t::yes)->block_num();
+      return fork_db_.apply<uint32_t>(
+         [&](const auto& fork_db) {
+            return fork_db.head(include_root_t::yes)->block_num();
          });
    }
 
    block_id_type fork_db_head_block_id() const {
       assert(fork_db_has_root());
-      return fork_db.apply<block_id_type>(
-         [&](const auto& forkdb) {
-            return forkdb.head(include_root_t::yes)->id();
+      return fork_db_.apply<block_id_type>(
+         [&](const auto& fork_db) {
+            return fork_db.head(include_root_t::yes)->id();
          });
    }
 
    // --------------- access fork_db root ----------------------------------------------------------------------
    bool fork_db_has_root() const {
-      return fork_db.apply<bool>([&](const auto& forkdb) { return !!forkdb.has_root(); });
+      return fork_db_.apply<bool>([&](const auto& fork_db) { return !!fork_db.has_root(); });
    }
 
    size_t fork_db_size() const {
-      return fork_db.size();
+      return fork_db_.size();
    }
 
    block_handle fork_db_root()const {
-      return fork_db.apply<block_handle>(
-         [&](const auto& forkdb) {
-            return block_handle{forkdb.root()};
+      return fork_db_.apply<block_handle>(
+         [&](const auto& fork_db) {
+            return block_handle{fork_db.root()};
          });
    }
 
    block_id_type fork_db_root_block_id() const {
       assert(fork_db_has_root());
-      return fork_db.apply<block_id_type>([&](const auto& forkdb) { return forkdb.root()->id(); });
+      return fork_db_.apply<block_id_type>([&](const auto& fork_db) { return fork_db.root()->id(); });
    }
 
    uint32_t fork_db_root_block_num() const {
       assert(fork_db_has_root());
-      return fork_db.apply<uint32_t>([&](const auto& forkdb) { return forkdb.root()->block_num(); });
+      return fork_db_.apply<uint32_t>([&](const auto& fork_db) { return fork_db.root()->block_num(); });
    }
 
    // ---------------  fork_db APIs ----------------------------------------------------------------------
    template<typename ForkDB>
-   uint32_t pop_block(ForkDB& forkdb) {
+   uint32_t pop_block(ForkDB& fork_db) {
       assert(fork_db_has_root());
-      typename ForkDB::bsp_t prev = forkdb.get_block( chain_head.previous() );
+      typename ForkDB::bsp_t prev = fork_db.get_block( chain_head.previous() );
 
       if( !prev ) {
-         EOS_ASSERT( forkdb.root()->id() == chain_head.previous(), block_validate_exception,
+         EOS_ASSERT( fork_db.root()->id() == chain_head.previous(), block_validate_exception,
                      "attempt to pop beyond last irreversible block" );
-         prev = forkdb.root();
+         prev = fork_db.root();
       }
 
       EOS_ASSERT( chain_head.block(), block_validate_exception,
@@ -1138,14 +1138,14 @@ struct controller_impl {
    }
 
    bool fork_db_block_exists( const block_id_type& id ) const {
-      return fork_db.apply<bool>([&](const auto& forkdb) {
-         return forkdb.block_exists(id);
+      return fork_db_.apply<bool>([&](const auto& fork_db) {
+         return fork_db.block_exists(id);
       });
    }
 
    bool fork_db_validated_block_exists( const block_id_type& id ) const {
-       return fork_db.apply<bool>([&](const auto& forkdb) {
-         auto bsp = forkdb.get_block(id);
+       return fork_db_.apply<bool>([&](const auto& fork_db) {
+         auto bsp = fork_db.get_block(id);
          return bsp ? bsp->is_valid() : false;
       });
    }
@@ -1155,29 +1155,29 @@ struct controller_impl {
    // and `is_valid()`
    // ------------------------------------------------------------------------------------------------------
    bool fork_db_validated_block_exists( const block_id_type& id, const block_id_type& claimed_id ) const {
-      return fork_db.apply<bool>([&](const auto& forkdb) {
-         return forkdb.validated_block_exists(id, claimed_id);
+      return fork_db_.apply<bool>([&](const auto& fork_db) {
+         return fork_db.validated_block_exists(id, claimed_id);
       });
    }
 
    signed_block_ptr fork_db_fetch_block_by_id( const block_id_type& id ) const {
-      return fork_db.apply<signed_block_ptr>([&](const auto& forkdb) {
-         auto bsp = forkdb.get_block(id);
+      return fork_db_.apply<signed_block_ptr>([&](const auto& fork_db) {
+         auto bsp = fork_db.get_block(id);
          return bsp ? bsp->block : signed_block_ptr{};
       });
    }
 
    signed_block_ptr fork_db_fetch_block_on_best_branch_by_num(uint32_t block_num) const {
-      return fork_db.apply<signed_block_ptr>([&](const auto& forkdb) {
-         auto bsp = forkdb.search_on_head_branch(block_num);
+      return fork_db_.apply<signed_block_ptr>([&](const auto& fork_db) {
+         auto bsp = fork_db.search_on_head_branch(block_num);
          if (bsp) return bsp->block;
          return signed_block_ptr{};
       });
    }
 
    std::optional<block_id_type> fork_db_fetch_block_id_on_best_branch_by_num(uint32_t block_num) const {
-      return fork_db.apply<std::optional<block_id_type>>([&](const auto& forkdb) -> std::optional<block_id_type> {
-         auto bsp = forkdb.search_on_head_branch(block_num, include_root_t::yes);
+      return fork_db_.apply<std::optional<block_id_type>>([&](const auto& fork_db) -> std::optional<block_id_type> {
+         auto bsp = fork_db.search_on_head_branch(block_num, include_root_t::yes);
          if (bsp)
             return std::optional<block_id_type>{bsp->id()};
          return {};
@@ -1186,8 +1186,8 @@ struct controller_impl {
 
    // not thread-safe
    std::optional<block_id_type> fork_db_fetch_block_id_on_chain_head_branch_by_num(uint32_t block_num) const {
-      return fork_db.apply<std::optional<block_id_type>>([&](const auto& forkdb) -> std::optional<block_id_type> {
-         auto bsp = forkdb.search_on_branch(chain_head.id(), block_num, include_root_t::yes);
+      return fork_db_.apply<std::optional<block_id_type>>([&](const auto& fork_db) -> std::optional<block_id_type> {
+         auto bsp = fork_db.search_on_branch(chain_head.id(), block_num, include_root_t::yes);
          if (bsp)
             return std::optional<block_id_type>{bsp->id()};
          return {};
@@ -1196,19 +1196,19 @@ struct controller_impl {
 
    // search on the branch of given id
    block_state_ptr fork_db_fetch_bsp_on_branch_by_num(const block_id_type& id, uint32_t block_num) const {
-      return fork_db.apply<block_state_ptr>(
+      return fork_db_.apply<block_state_ptr>(
          overloaded{
             [](const fork_database_legacy_t&) -> block_state_ptr { return block_state_ptr{}; },
-            [&](const fork_database_if_t& forkdb) -> block_state_ptr {
-               return forkdb.search_on_branch(id, block_num, include_root_t::yes);
+            [&](const fork_database_if_t& fork_db) -> block_state_ptr {
+               return fork_db.search_on_branch(id, block_num, include_root_t::yes);
             }
          }
       );
    }
 
    void pop_block() {
-      uint32_t prev_block_num = fork_db.apply<uint32_t>([&](auto& forkdb) {
-         return pop_block(forkdb);
+      uint32_t prev_block_num = fork_db_.apply<uint32_t>([&](auto& fork_db) {
+         return pop_block(fork_db);
       });
       db.undo();
       protocol_features.popped_blocks_to(prev_block_num);
@@ -1242,7 +1242,7 @@ struct controller_impl {
         cfg.read_only ? database::read_only : database::read_write,
         cfg.state_size, false, cfg.db_map_mode ),
     blog( cfg.blocks_dir, cfg.blog ),
-    fork_db(cfg.blocks_dir / config::reversible_blocks_dir_name),
+    fork_db_(cfg.blocks_dir / config::reversible_blocks_dir_name),
     resource_limits( db, [&s](bool is_trx_transient) { return s.get_deep_mind_logger(is_trx_transient); }),
     authorization( s, db ),
     protocol_features( std::move(pfs), [&s](bool is_trx_transient) { return s.get_deep_mind_logger(is_trx_transient); } ),
@@ -1301,7 +1301,7 @@ struct controller_impl {
    }
 
    void open_fork_db() {
-      fork_db.open([this](block_timestamp_type timestamp, const flat_set<digest_type>& cur_features,
+      fork_db_.open([this](block_timestamp_type timestamp, const flat_set<digest_type>& cur_features,
                           const vector<digest_type>& new_features) {
          check_protocol_features(timestamp, cur_features, new_features);
       });
@@ -1320,7 +1320,7 @@ struct controller_impl {
 
    // When in IRREVERSIBLE mode fork_db blocks are applied and marked valid when they become irreversible
    template<typename ForkDB, typename BSP>
-   bool apply_irreversible_block(ForkDB& forkdb, const BSP& bsp) {
+   bool apply_irreversible_block(ForkDB& fork_db, const BSP& bsp) {
       if (read_mode != db_read_mode::IRREVERSIBLE)
          return true; // ignore
       if constexpr (std::is_same_v<block_state_legacy_ptr, std::decay_t<decltype(bsp)>>) {
@@ -1331,34 +1331,34 @@ struct controller_impl {
          if (bsp->block->is_proper_svnn_block()) {
             block_handle_accessor::apply_l<void>(chain_head, [&](const auto&) {
                // if chain_head is legacy, update to non-legacy chain_head, this is needed so that the correct block_state is created in apply_block
-               block_state_ptr prev = forkdb.get_block(bsp->previous(), include_root_t::yes);
+               block_state_ptr prev = fork_db.get_block(bsp->previous(), include_root_t::yes);
                assert(prev);
                chain_head = block_handle{prev};
             });
             return apply_block(bsp, controller::block_status::complete, trx_meta_cache_lookup{});
          }
          // only called during transition when not a proper savanna block
-         return fork_db.apply_l<bool>([&](const auto& forkdb_l) {
-            block_state_legacy_ptr legacy = forkdb_l.get_block(bsp->id());
-            fork_db.switch_to(fork_database::in_use_t::legacy); // apply block uses to know what types to create
-            block_state_ptr prev = forkdb.get_block(legacy->previous(), include_root_t::yes);
+         return fork_db_.apply_l<bool>([&](const auto& fork_db_l) {
+            block_state_legacy_ptr legacy = fork_db_l.get_block(bsp->id());
+            fork_db_.switch_to(fork_database::in_use_t::legacy); // apply block uses to know what types to create
+            block_state_ptr prev = fork_db.get_block(legacy->previous(), include_root_t::yes);
             assert(prev);
             if( apply_block(legacy, controller::block_status::complete, trx_meta_cache_lookup{}) ) {
-               fc::scoped_exit<std::function<void()>> e([&]{fork_db.switch_to(fork_database::in_use_t::both);});
+               fc::scoped_exit<std::function<void()>> e([&]{fork_db_.switch_to(fork_database::in_use_t::both);});
                // irreversible apply was just done, calculate new_valid here instead of in transition_to_savanna()
                assert(legacy->action_mroot_savanna);
-               transition_add_to_savanna_fork_db(forkdb, legacy, bsp, prev);
+               transition_add_to_savanna_fork_db(fork_db, legacy, bsp, prev);
                return true;
             }
-            // add to forkdb as it expects root != head
-            transition_add_to_savanna_fork_db(forkdb, legacy, bsp, prev);
-            fork_db.switch_to(fork_database::in_use_t::legacy);
+            // add to fork_db as it expects root != head
+            transition_add_to_savanna_fork_db(fork_db, legacy, bsp, prev);
+            fork_db_.switch_to(fork_database::in_use_t::legacy);
             return false;
          });
       }
    }
 
-   void transition_add_to_savanna_fork_db(fork_database_if_t& forkdb,
+   void transition_add_to_savanna_fork_db(fork_database_if_t& fork_db,
                                           const block_state_legacy_ptr& legacy, const block_state_ptr& new_bsp,
                                           const block_state_ptr& prev) {
       // legacy_branch is from head, all will be validated unless irreversible_mode(),
@@ -1370,7 +1370,7 @@ struct controller_impl {
       }
       if (legacy->is_valid())
          new_bsp->set_valid(true);
-      forkdb.add(new_bsp, ignore_duplicate_t::yes);
+      fork_db.add(new_bsp, ignore_duplicate_t::yes);
    }
 
    void transition_to_savanna_if_needed() {
@@ -1383,14 +1383,14 @@ struct controller_impl {
    }
 
    void transition_to_savanna() {
-      // copy head branch from legacy forkdb legacy to savanna forkdb
+      // copy head branch from legacy fork_db legacy to savanna fork_db
       if (check_shutdown())
          return;
       fork_database_legacy_t::branch_t legacy_branch;
       block_state_legacy_ptr legacy_root;
-      fork_db.apply_l<void>([&](const auto& forkdb) {
-         legacy_root = forkdb.root();
-         legacy_branch = forkdb.fetch_branch(forkdb.head()->id());
+      fork_db_.apply_l<void>([&](const auto& fork_db) {
+         legacy_root = fork_db.root();
+         legacy_branch = fork_db.fetch_branch(fork_db.head()->id());
       });
 
       assert(!!legacy_root);
@@ -1403,8 +1403,8 @@ struct controller_impl {
          // If the snapshot is from during transition then the IF genesis block should not be created, instead
          // chain_head_trans_svnn_block contains the block_state to build from
          if (legacy_root->id() == chain_head_trans_svnn_block->id()) {
-            // setup savanna forkdb with the block_state from the snapshot
-            fork_db.switch_from_legacy(chain_head_trans_svnn_block);
+            // setup savanna fork_db with the block_state from the snapshot
+            fork_db_.switch_from_legacy(chain_head_trans_svnn_block);
          } else {
             // root has moved from chain_head_trans_svnn_block, so transition the legacy root
             // legacy_root can be one past the snapshot start block when running in irreversible mode as LIB is advanced
@@ -1416,14 +1416,14 @@ struct controller_impl {
                   protocol_features.get_protocol_feature_set(),
                   validator_t{}, skip_validate_signee,
                   legacy_root->action_mroot_savanna);
-            fork_db.switch_from_legacy(new_root);
+            fork_db_.switch_from_legacy(new_root);
          }
       } else {
          auto new_root = block_state::create_if_genesis_block(*legacy_root);
-         fork_db.switch_from_legacy(new_root);
+         fork_db_.switch_from_legacy(new_root);
       }
-      fork_db.apply_s<void>([&](auto& forkdb) {
-         block_state_ptr prev = forkdb.root();
+      fork_db_.apply_s<void>([&](auto& fork_db) {
+         block_state_ptr prev = fork_db.root();
          assert(prev);
          for (auto bitr = legacy_branch.rbegin(); bitr != legacy_branch.rend(); ++bitr) {
             assert(read_mode == db_read_mode::IRREVERSIBLE || (*bitr)->action_mroot_savanna.has_value());
@@ -1436,7 +1436,7 @@ struct controller_impl {
                   protocol_features.get_protocol_feature_set(),
                   validator_t{}, skip_validate_signee,
                   (*bitr)->action_mroot_savanna);
-            transition_add_to_savanna_fork_db(forkdb, *bitr, new_bsp, prev);
+            transition_add_to_savanna_fork_db(fork_db, *bitr, new_bsp, prev);
             prev = new_bsp;
          }
          assert(read_mode == db_read_mode::IRREVERSIBLE || chain_head.id() == legacy_branch.front()->id());
@@ -1481,20 +1481,20 @@ struct controller_impl {
       }
 
       auto pending_lib_id = [&]() {
-         return fork_db.apply<block_id_type>(
-            [&](const fork_database_legacy_t& forkdb) -> block_id_type {
+         return fork_db_.apply<block_id_type>(
+            [&](const fork_database_legacy_t& fork_db) -> block_id_type {
                // maintain legacy only advancing LIB via validated blocks, hence pass in chain_head id for use
-               block_state_legacy_ptr head = irreversible_mode() ? forkdb.head() : forkdb.get_block(chain_head.id());
+               block_state_legacy_ptr head = irreversible_mode() ? fork_db.head() : fork_db.get_block(chain_head.id());
                if (!head)
                   return {};
                block_num_type dpos_lib_num = head->irreversible_blocknum();
-               block_state_legacy_ptr lib = forkdb.search_on_branch(head->id(), dpos_lib_num, include_root_t::no);
+               block_state_legacy_ptr lib = fork_db.search_on_branch(head->id(), dpos_lib_num, include_root_t::no);
                if (!lib)
                   return {};
                return lib->id();
             },
-            [&](const fork_database_if_t& forkdb) -> block_id_type {
-               return forkdb.pending_savanna_lib_id();
+            [&](const fork_database_if_t& fork_db) -> block_id_type {
+               return fork_db.pending_savanna_lib_id();
             }
          );
       };
@@ -1505,13 +1505,13 @@ struct controller_impl {
       if( new_lib_num <= lib_num )
          return;
 
-      auto mark_branch_irreversible = [&, this](auto& forkdb) {
-         assert(!irreversible_mode() || forkdb.head());
-         const auto& head_id = irreversible_mode() ? forkdb.head()->id() : chain_head.id();
+      auto mark_branch_irreversible = [&, this](auto& fork_db) {
+         assert(!irreversible_mode() || fork_db.head());
+         const auto& head_id = irreversible_mode() ? fork_db.head()->id() : chain_head.id();
          // verifies lib is on head branch, otherwise returns an empty branch
-         // The new lib needs to be on the head branch because the forkdb.advance_root() below could purge blocks that
+         // The new lib needs to be on the head branch because the fork_db.advance_root() below could purge blocks that
          // would be needed to be re-applied on a fork switch from the exiting chain_head.
-         auto branch = forkdb.fetch_branch(head_id, new_lib_id);
+         auto branch = fork_db.fetch_branch(head_id, new_lib_id);
          try {
             auto should_process = [&](auto& bsp) {
                // Only make irreversible blocks that have been validated. Blocks in the fork database may not be on our current best head
@@ -1532,7 +1532,7 @@ struct controller_impl {
             auto it = v.begin();
 
             for( auto bitr = branch.rbegin(); bitr != branch.rend() && should_process(*bitr); ++bitr ) {
-               if (!apply_irreversible_block(forkdb, *bitr))
+               if (!apply_irreversible_block(fork_db, *bitr))
                   break;
 
                emit( irreversible_block, std::tie((*bitr)->block, (*bitr)->id()), __FILE__, __LINE__ );
@@ -1545,15 +1545,15 @@ struct controller_impl {
                db.commit( (*bitr)->block_num() );
                root_id = (*bitr)->id();
 
-               if ((*bitr)->block->is_proper_svnn_block() && fork_db.version_in_use() == fork_database::in_use_t::both) {
-                  fork_db.switch_to(fork_database::in_use_t::savanna);
+               if ((*bitr)->block->is_proper_svnn_block() && fork_db_.version_in_use() == fork_database::in_use_t::both) {
+                  fork_db_.switch_to(fork_database::in_use_t::savanna);
                   break;
                }
             }
          } catch( const std::exception& e ) {
             try {
-               if (root_id != forkdb.root()->id()) {
-                  forkdb.advance_root(root_id);
+               if (root_id != fork_db.root()->id()) {
+                  fork_db.advance_root(root_id);
                }
             } catch( const fc::exception& e2 ) {
                wlog("Caught exception ${e2}, while processing exception ${e}", ("e2", e2.to_detail_string())("e", e.what()));
@@ -1565,16 +1565,16 @@ struct controller_impl {
 
          //db.commit( new_lib ); // redundant
 
-         if( root_id != forkdb.root()->id() ) {
-            branch.emplace_back(forkdb.root());
-            forkdb.advance_root( root_id );
+         if( root_id != fork_db.root()->id() ) {
+            branch.emplace_back(fork_db.root());
+            fork_db.advance_root( root_id );
          }
 
          // delete branch in thread pool
          boost::asio::post( thread_pool.get_executor(), [branch{std::move(branch)}]() {} );
       };
 
-      fork_db.apply<void>(mark_branch_irreversible);
+      fork_db_.apply<void>(mark_branch_irreversible);
    }
 
    void initialize_blockchain_state(const genesis_state& genesis) {
@@ -1746,11 +1746,11 @@ struct controller_impl {
                }
             }
 
-            auto do_startup = [&](auto& forkdb) {
+            auto do_startup = [&](auto& fork_db) {
                if( read_mode == db_read_mode::IRREVERSIBLE) {
-                  auto root = forkdb.root();
+                  auto root = fork_db.root();
                   if (root && chain_head.id() != root->id()) {
-                     chain_head = block_handle{forkdb.root()};
+                     chain_head = block_handle{fork_db.root()};
                      // rollback db to LIB
                      while( db.revision() > chain_head.block_num() ) {
                         db.undo();
@@ -1758,39 +1758,39 @@ struct controller_impl {
                   }
                }
             };
-            fork_db.apply<void>(do_startup);
+            fork_db_.apply<void>(do_startup);
          }
       }
 
       auto fork_db_reset_root_to_chain_head = [&]() {
-         fork_db.apply<void>([&](auto& forkdb) {
+         fork_db_.apply<void>([&](auto& fork_db) {
             block_handle_accessor::apply<void>(chain_head, [&](const auto& head) {
-               if constexpr (std::is_same_v<std::decay_t<decltype(head)>, std::decay_t<decltype(forkdb.root())>>)
-                  forkdb.reset_root(head);
+               if constexpr (std::is_same_v<std::decay_t<decltype(head)>, std::decay_t<decltype(fork_db.root())>>)
+                  fork_db.reset_root(head);
             });
          });
       };
 
       auto switch_from_legacy_if_needed = [&]() {
-         if (fork_db.version_in_use() == fork_database::in_use_t::legacy) {
+         if (fork_db_.version_in_use() == fork_database::in_use_t::legacy) {
             // switch to savanna if needed
             block_handle_accessor::apply_s<void>(chain_head, [&](const auto& head) {
-               fork_db.switch_from_legacy(head);
+               fork_db_.switch_from_legacy(head);
             });
          }
       };
 
       if (startup == startup_t::genesis) {
          switch_from_legacy_if_needed();
-         auto do_startup = [&](auto& forkdb) {
-            if( forkdb.head() ) {
+         auto do_startup = [&](auto& fork_db) {
+            if( fork_db.head() ) {
                wlog( "No existing chain state. Initializing fresh blockchain state." );
             } else {
                wlog( "No existing chain state or fork database. Initializing fresh blockchain state and resetting fork database.");
                fork_db_reset_root_to_chain_head();
             }
          };
-         fork_db.apply<void>(do_startup);
+         fork_db_.apply<void>(do_startup);
       }
 
       if( !fork_db_has_root() ) {
@@ -1798,12 +1798,12 @@ struct controller_impl {
          fork_db_reset_root_to_chain_head();
       }
 
-      auto replay_fork_db = [&](auto& forkdb) {
-         auto pending_head = forkdb.head();
-         auto root = forkdb.root();
+      auto replay_fork_db = [&](auto& fork_db) {
+         auto pending_head = fork_db.head();
+         auto root = fork_db.root();
          if( pending_head ) {
             ilog("fork database size ${s} head ${hn} : ${h}, root ${rn} : ${r}",
-                 ("s", forkdb.size())("hn", pending_head->block_num())("h", pending_head->id())
+                 ("s", fork_db.size())("hn", pending_head->block_num())("h", pending_head->id())
                  ("rn", root->block_num())("r", root->id()));
          } else if (root) {
             ilog("fork database has no pending blocks root ${rn} : ${r}",
@@ -1812,35 +1812,35 @@ struct controller_impl {
             ilog("fork database empty, no pending or root");
          }
          if( pending_head && blog_head && start_block_num <= blog_head->block_num() ) {
-            if( pending_head->block_num() < chain_head.block_num() || chain_head.block_num() < forkdb.root()->block_num() ) {
+            if( pending_head->block_num() < chain_head.block_num() || chain_head.block_num() < fork_db.root()->block_num() ) {
                ilog( "resetting fork database with new last irreversible block as the new root: ${id}", ("id", chain_head.id()) );
                fork_db_reset_root_to_chain_head();
-            } else if( chain_head.block_num() != forkdb.root()->block_num() ) {
-               auto new_root = forkdb.search_on_branch( pending_head->id(), chain_head.block_num() );
+            } else if( chain_head.block_num() != fork_db.root()->block_num() ) {
+               auto new_root = fork_db.search_on_branch( pending_head->id(), chain_head.block_num() );
                EOS_ASSERT( new_root, fork_database_exception,
                            "unexpected error: could not find new LIB in fork database" );
                ilog( "advancing fork database root to new last irreversible block within existing fork database: ${id}",
                      ("id", new_root->id()) );
                new_root->set_valid(true);
-               forkdb.advance_root( new_root->id() );
+               fork_db.advance_root( new_root->id() );
             }
          }
 
          if (snapshot_head_block != 0 && !blog.head()) {
             // loading from snapshot without a block log so fork_db can't be considered valid
             fork_db_reset_root_to_chain_head();
-         } else if( !except_ptr && !check_shutdown() && !irreversible_mode() && forkdb.head()) {
-            // applies all blocks up to forkdb head from forkdb
+         } else if( !except_ptr && !check_shutdown() && !irreversible_mode() && fork_db.head()) {
+            // applies all blocks up to fork_db head from fork_db
             maybe_apply_blocks(forked_callback_t{}, trx_meta_cache_lookup{});
-            auto head = forkdb.head();
+            auto head = fork_db.head();
             ilog( "reversible blocks replayed to ${bn} : ${id}", ("bn", head->block_num())("id", head->id()) );
          }
 
-         if( !forkdb.head() ) {
+         if( !fork_db.head() ) {
             fork_db_reset_root_to_chain_head();
          }
       };
-      fork_db.apply<void>(replay_fork_db);
+      fork_db_.apply<void>(replay_fork_db);
 
       replaying = false;
 
@@ -1864,7 +1864,7 @@ struct controller_impl {
                   ("b", blog.first_block_num())("e", blog_head->block_num()) );
             block_states = read_from_snapshot( snapshot, blog.first_block_num(), blog_head->block_num() );
          } else {
-            EOS_ASSERT( !fork_db.file_exists(), fork_database_exception,
+            EOS_ASSERT( !fork_db_.file_exists(), fork_database_exception,
                         "When starting from a snapshot with no block log, we shouldn't have a fork database either" );
             ilog( "Starting initialization from snapshot and no block log, this may take a significant amount of time" );
             block_states = read_from_snapshot( snapshot, 0, std::numeric_limits<uint32_t>::max() );
@@ -1879,8 +1879,8 @@ struct controller_impl {
          block_handle_accessor::apply_l<void>(chain_head, [&](auto& head) {
             if (block_states.second && head->header.contains_header_extension(finality_extension::extension_id())) {
                // snapshot generated in transition to savanna
-               if (fork_db.version_in_use() == fork_database::in_use_t::legacy) {
-                  fork_db.switch_from_legacy(block_states.second);
+               if (fork_db_.version_in_use() == fork_database::in_use_t::legacy) {
+                  fork_db_.switch_from_legacy(block_states.second);
                }
             }
          });
@@ -2000,12 +2000,12 @@ struct controller_impl {
       // Furthermore, fork_db.root()->block_num() <= lib_num.
       // Also, even though blog.head() may still be nullptr, blog.first_block_num() is guaranteed to be lib_num + 1.
 
-      auto finish_init = [&](auto& forkdb) {
+      auto finish_init = [&](auto& fork_db) {
          if( read_mode != db_read_mode::IRREVERSIBLE ) {
-            auto pending_head = forkdb.head();
+            auto pending_head = fork_db.head();
             if ( pending_head && pending_head->id() != chain_head.id() ) {
                // chain_head equal to root means that read_mode was changed from irreversible mode to head/speculative
-               bool chain_head_is_root = chain_head.id() == forkdb.root()->id();
+               bool chain_head_is_root = chain_head.id() == fork_db.root()->id();
                if (chain_head_is_root) {
                   ilog( "read_mode has changed from irreversible: applying best branch from fork database" );
                }
@@ -2025,14 +2025,14 @@ struct controller_impl {
             // is a bit of a hack for Spring 1.0.0 until we can add a proper pause-at-block (issue #570) which could
             // be used to explicitly request a node to not process beyond a specified block.
             if (conf.num_configured_p2p_peers > 0) {
-               ilog("Process blocks out of forkdb if needed");
+               ilog("Process blocks out of fork_db if needed");
                log_irreversible();
                transition_to_savanna_if_needed();
             }
          }
       };
 
-      fork_db.apply<void>(finish_init);
+      fork_db_.apply<void>(finish_init);
 
       // At Leap startup, we want to provide to our local finalizers the correct safety information
       // to use if they don't already have one.
@@ -2041,31 +2041,31 @@ struct controller_impl {
       // If we start at a block during or after the IF transition, we need to provide this information
       // at startup.
       // ---------------------------------------------------------------------------------------------
-      if (auto in_use = fork_db.version_in_use(); in_use  == fork_database::in_use_t::both || in_use  == fork_database::in_use_t::savanna) {
+      if (auto in_use = fork_db_.version_in_use(); in_use  == fork_database::in_use_t::both || in_use  == fork_database::in_use_t::savanna) {
          // we are already past the IF transition point where we create the updated fork_db.
          // so we can't rely on the finalizer safety information update happening during the transition.
          // see https://github.com/AntelopeIO/leap/issues/2070#issuecomment-1941901836
          // -------------------------------------------------------------------------------------------
          if (in_use  == fork_database::in_use_t::both) {
             // fork_db_legacy is present as well, which means that we have not completed the transition
-            auto set_finalizer_defaults = [&](auto& forkdb) -> void {
-               auto lib = forkdb.root();
+            auto set_finalizer_defaults = [&](auto& fork_db) -> void {
+               auto lib = fork_db.root();
                my_finalizers.set_default_safety_information(
                   finalizer_safety_information{ .last_vote                = {},
                                                 .lock                     = lib->make_block_ref(),
                                                 .other_branch_latest_time = block_timestamp_type{} });
             };
-            fork_db.apply_s<void>(set_finalizer_defaults);
+            fork_db_.apply_s<void>(set_finalizer_defaults);
          } else {
             // we are past the IF transition.
-            auto set_finalizer_defaults = [&](auto& forkdb) -> void {
-               auto lib = forkdb.root();
+            auto set_finalizer_defaults = [&](auto& fork_db) -> void {
+               auto lib = fork_db.root();
                my_finalizers.set_default_safety_information(
                   finalizer_safety_information{.last_vote                = {},
                                                .lock                     = lib->make_block_ref(),
                                                .other_branch_latest_time = block_timestamp_type{} });
             };
-            fork_db.apply_s<void>(set_finalizer_defaults);
+            fork_db_.apply_s<void>(set_finalizer_defaults);
          }
       }
    }
@@ -2226,7 +2226,7 @@ struct controller_impl {
       snapshot->write_section("eosio::chain::block_state", [&]( auto& section ) {
          section.add_row(snapshot_detail::snapshot_block_state_data_v8(get_block_state_to_snapshot()), db);
       });
-      
+
       controller_index_set::walk_indices([this, &snapshot, &row_counter]( auto utils ){
          using value_t = typename decltype(utils)::index_t::value_type;
 
@@ -2462,11 +2462,11 @@ struct controller_impl {
    }
 
    digest_type get_strong_digest_by_id( const block_id_type& id ) const {
-      return fork_db.apply<digest_type>(
+      return fork_db_.apply<digest_type>(
          overloaded{
             [](const fork_database_legacy_t&) -> digest_type { return digest_type{}; },
-            [&](const fork_database_if_t& forkdb) -> digest_type {
-               auto bsp = forkdb.get_block(id);
+            [&](const fork_database_if_t& fork_db) -> digest_type {
+               auto bsp = fork_db.get_block(id);
                return bsp ? bsp->strong_digest : digest_type{};
             }
          }
@@ -3362,7 +3362,7 @@ struct controller_impl {
          auto assembled_block =
             bb.assemble_block(thread_pool.get_executor(),
                               protocol_features.get_protocol_feature_set(),
-                              fork_db, std::move(new_proposer_policy),
+                              fork_db_, std::move(new_proposer_policy),
                               std::move(new_finalizer_policy),
                               validating, std::move(validating_qc_data), validating_bsp);
 
@@ -3389,22 +3389,22 @@ struct controller_impl {
          auto& cb = std::get<completed_block>(pending->_block_stage);
 
          if (s != controller::block_status::irreversible) {
-            auto add_completed_block = [&](auto& forkdb) {
-               assert(std::holds_alternative<std::decay_t<decltype(forkdb.root())>>(cb.bsp.internal()));
-               const auto& bsp = std::get<std::decay_t<decltype(forkdb.root())>>(cb.bsp.internal());
+            auto add_completed_block = [&](auto& fork_db) {
+               assert(std::holds_alternative<std::decay_t<decltype(fork_db.root())>>(cb.bsp.internal()));
+               const auto& bsp = std::get<std::decay_t<decltype(fork_db.root())>>(cb.bsp.internal());
                if( s == controller::block_status::incomplete ) {
                   bsp->set_valid(true);
-                  forkdb.add( bsp, ignore_duplicate_t::no );
+                  fork_db.add( bsp, ignore_duplicate_t::no );
                   emit( accepted_block_header, std::tie(bsp->block, bsp->id()), __FILE__, __LINE__ );
                   vote_processor.notify_new_block(async_aggregation);
                } else {
                   assert(s != controller::block_status::irreversible);
-                  auto existing = forkdb.get_block(bsp->id());
+                  auto existing = fork_db.get_block(bsp->id());
                   assert(existing);
                   existing->set_valid(true);
                }
             };
-            fork_db.apply<void>(add_completed_block);
+            fork_db_.apply<void>(add_completed_block);
          }
 
          chain_head = block_handle{cb.bsp};
@@ -3862,8 +3862,8 @@ struct controller_impl {
    }
 
    std::optional<finalizer_policy> active_finalizer_policy(const block_id_type& id) const {
-      return fork_db.apply_s<std::optional<finalizer_policy>>([&](auto& forkdb) -> std::optional<finalizer_policy> {
-         auto bsp = forkdb.get_block(id);
+      return fork_db_.apply_s<std::optional<finalizer_policy>>([&](auto& fork_db) -> std::optional<finalizer_policy> {
+         auto bsp = fork_db.get_block(id);
          if (bsp)
             return *bsp->active_finalizer_policy;
          return {};
@@ -4120,7 +4120,7 @@ struct controller_impl {
    // thread safe, expected to be called from thread other than the main thread
    // tuple<bool best_head, block_handle new_block_handle>
    template<typename ForkDB, typename BS>
-   controller::accepted_block_result create_block_state_i( ForkDB& forkdb, const block_id_type& id, const signed_block_ptr& b, const BS& prev ) {
+   controller::accepted_block_result create_block_state_i( ForkDB& fork_db, const block_id_type& id, const signed_block_ptr& b, const BS& prev ) {
       constexpr bool is_proper_savanna_block = std::is_same_v<typename std::decay_t<BS>, block_state>;
       assert(is_proper_savanna_block == b->is_proper_svnn_block());
 
@@ -4166,7 +4166,7 @@ struct controller_impl {
          assert(!verify_qc_future.valid());
       }
 
-      bool best_head = forkdb.add(bsp, ignore_duplicate_t::yes);
+      bool best_head = fork_db.add(bsp, ignore_duplicate_t::yes);
       if constexpr (is_proper_savanna_block)
          vote_processor.notify_new_block(async_aggregation);
 
@@ -4176,13 +4176,13 @@ struct controller_impl {
    // thread safe, expected to be called from thread other than the main thread
    controller::accepted_block_result create_block_handle( const block_id_type& id, const signed_block_ptr& b ) {
       EOS_ASSERT( b, block_validate_exception, "null block" );
-      
-      auto f = [&](auto& forkdb) -> controller::accepted_block_result {
+
+      auto f = [&](auto& fork_db) -> controller::accepted_block_result {
          // previous not found, means it is unlinkable
-         auto prev = forkdb.get_block( b->previous, include_root_t::yes );
+         auto prev = fork_db.get_block( b->previous, include_root_t::yes );
          if( !prev ) return {};
 
-         return create_block_state_i( forkdb, id, b, *prev );
+         return create_block_state_i( fork_db, id, b, *prev );
       };
 
       auto unlinkable = [&](const auto&) -> controller::accepted_block_result {
@@ -4190,9 +4190,9 @@ struct controller_impl {
       };
 
       if (!b->is_proper_svnn_block()) {
-         return fork_db.apply<controller::accepted_block_result>(f, unlinkable);
+         return fork_db_.apply<controller::accepted_block_result>(f, unlinkable);
       }
-      return fork_db.apply<controller::accepted_block_result>(unlinkable, f);
+      return fork_db_.apply<controller::accepted_block_result>(unlinkable, f);
    }
 
    // thread safe, QC already verified by verify_proper_block_exts
@@ -4207,7 +4207,7 @@ struct controller_impl {
 
       block_state_ptr claimed_bsp = fork_db_fetch_bsp_on_branch_by_num( bsp_in->previous(), qc_ext.qc.block_num );
       if( !claimed_bsp ) {
-         dlog("block state of claimed qc not found in forkdb, qc: ${qc} for block ${bn} ${id}, previous ${p}",
+         dlog("block state of claimed qc not found in fork_db, qc: ${qc} for block ${bn} ${id}, previous ${p}",
               ("qc", qc_ext.qc.to_qc_claim())("bn", bsp_in->block_num())("id", bsp_in->id())("p", bsp_in->previous()));
          return;
       }
@@ -4314,11 +4314,11 @@ struct controller_impl {
 
    void maybe_apply_blocks( const forked_callback_t& forked_cb, const trx_meta_cache_lookup& trx_lookup )
    {
-      auto do_apply_blocks = [&](auto& forkdb) {
-         auto new_head = forkdb.head(); // use best head
+      auto do_apply_blocks = [&](auto& fork_db) {
+         auto new_head = fork_db.head(); // use best head
          if (!new_head)
-            return; // nothing to do, forkdb at root
-         auto [new_head_branch, old_head_branch] = forkdb.fetch_branch_from( new_head->id(), chain_head.id() );
+            return; // nothing to do, fork_db at root
+         auto [new_head_branch, old_head_branch] = fork_db.fetch_branch_from( new_head->id(), chain_head.id() );
 
          bool switch_fork = !old_head_branch.empty();
          if( switch_fork ) {
@@ -4383,7 +4383,7 @@ struct controller_impl {
             if( except ) {
                // ritr currently points to the block that threw
                // Remove the block that threw and all forks built off it.
-               forkdb.remove( (*ritr)->id() );
+               fork_db.remove( (*ritr)->id() );
 
                // pop all blocks from the bad fork, discarding their transactions
                // ritr base is a forward itr to the last block successfully applied
@@ -4420,7 +4420,7 @@ struct controller_impl {
          transition_to_savanna_if_needed();
       };
 
-      fork_db.apply<void>(do_apply_blocks);
+      fork_db_.apply<void>(do_apply_blocks);
    }
 
    deque<transaction_metadata_ptr> abort_block() {
@@ -4675,8 +4675,8 @@ struct controller_impl {
    }
 
    void set_savanna_lib_id(const block_id_type& id) {
-      fork_db.apply_s<void>([&](auto& forkdb) {
-         forkdb.set_pending_savanna_lib_id(id);
+      fork_db_.apply_s<void>([&](auto& fork_db) {
+         fork_db.set_pending_savanna_lib_id(id);
       });
    }
 
@@ -4691,9 +4691,9 @@ struct controller_impl {
          legacy_branch = {transition_legacy_branch.begin()+1, transition_legacy_branch.end()};
          std::ranges::reverse(legacy_branch);
       } else {
-         fork_db.apply_l<void>([&](const auto& forkdb) {
-            legacy_root = forkdb.root();
-            legacy_branch = forkdb.fetch_branch(head->id());
+         fork_db_.apply_l<void>([&](const auto& fork_db) {
+            legacy_root = fork_db.root();
+            legacy_branch = fork_db.fetch_branch(head->id());
          });
       }
 

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -263,7 +263,7 @@ namespace eosio::chain {
 
       auto prev_bh = get_block_impl( n->previous(), include_root_t::yes );
       EOS_ASSERT( prev_bh, unlinkable_block_exception,
-                  "forkdb unlinkable block ${id} previous ${p}", ("id", n->id())("p", n->previous()) );
+                  "fork_db unlinkable block ${id} previous ${p}", ("id", n->id())("p", n->previous()) );
 
       if (validate) {
          try {
@@ -641,7 +641,7 @@ namespace eosio::chain {
    }
 
    void fork_database::close() {
-      auto fork_db_file {data_dir / config::forkdb_filename};
+      auto fork_db_file {data_dir / config::fork_db_filename};
       bool legacy_valid  = fork_db_l.is_valid();
       bool savanna_valid = fork_db_s.is_valid();
 
@@ -684,7 +684,7 @@ namespace eosio::chain {
    }
 
    bool fork_database::file_exists() const {
-      auto fork_db_file = data_dir / config::forkdb_filename;
+      auto fork_db_file = data_dir / config::fork_db_filename;
       return std::filesystem::exists( fork_db_file );
    };
 
@@ -694,7 +694,7 @@ namespace eosio::chain {
 
       assert(!fork_db_l.is_valid() && !fork_db_s.is_valid());
 
-      auto fork_db_file = data_dir / config::forkdb_filename;
+      auto fork_db_file = data_dir / config::fork_db_filename;
       if( std::filesystem::exists( fork_db_file ) ) {
          try {
             fc::cfile f;
@@ -760,26 +760,26 @@ namespace eosio::chain {
    }
 
    size_t fork_database::size() const {
-      return apply<size_t>([](const auto& forkdb) {
-         return forkdb.size();
+      return apply<size_t>([](const auto& fork_db) {
+         return fork_db.size();
       });
    }
 
    // only called from the main thread
    void fork_database::switch_from_legacy(const block_state_ptr& root) {
       // no need to close fork_db because we don't want to write anything out, file is removed on open
-      // threads may be accessing (or locked on mutex about to access legacy forkdb) so don't delete it until program exit
+      // threads may be accessing (or locked on mutex about to access legacy fork_db) so don't delete it until program exit
       if (in_use == in_use_t::legacy) {
          fork_db_s.reset_root(root);
          if (fork_db_l.has_root()) {
-            dlog("Switching forkdb from legacy to both");
+            dlog("Switching fork_db from legacy to both");
             in_use = in_use_t::both;
          } else {
-            dlog("Switching forkdb from legacy to savanna");
+            dlog("Switching fork_db from legacy to savanna");
             in_use = in_use_t::savanna;
          }
       } else if (in_use == in_use_t::both) {
-         dlog("Switching forkdb from legacy, already both root ${rid}, forkdb root ${fid}", ("rid", root->id())("fid", fork_db_s.root()->id()));
+         dlog("Switching fork_db from legacy, already both root ${rid}, fork_db root ${fid}", ("rid", root->id())("fid", fork_db_s.root()->id()));
          assert(fork_db_s.root()->id() == root->id()); // should always set the same root
       } else {
          assert(false);
@@ -787,10 +787,10 @@ namespace eosio::chain {
    }
 
    block_branch_t fork_database::fetch_branch_from_head() const {
-      return apply<block_branch_t>([&](auto& forkdb) {
-         auto head = forkdb.head();
+      return apply<block_branch_t>([&](auto& fork_db) {
+         auto head = fork_db.head();
          if (head)
-            return forkdb.fetch_block_branch(head->id());
+            return fork_db.fetch_block_branch(head->id());
          return block_branch_t{};
       });
    }

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -350,7 +350,7 @@ namespace eosio::chain {
       block_num_type new_lib = block_header::num_from_id(id);
       block_num_type old_lib = block_header::num_from_id(pending_savanna_lib_id);
       if (new_lib > old_lib) {
-         dlog("set pending savanna lib ${bn}: ${id}", ("bn", block_header::num_from_id(id))("id", id));
+         dlog("set fork db pending savanna lib ${bn}: ${id}", ("bn", block_header::num_from_id(id))("id", id));
          pending_savanna_lib_id = id;
          return true;
       }

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -12,7 +12,7 @@ const static auto default_blocks_dir_name     = "blocks";
 const static auto reversible_blocks_dir_name  = "reversible";
 
 const static auto default_state_dir_name      = "state";
-const static auto forkdb_filename             = "fork_db.dat";
+const static auto fork_db_filename            = "fork_db.dat";
 const static auto safety_filename             = "safety.dat";
 const static auto chain_head_filename         = "chain_head.dat";
 const static auto default_state_size          = 1*1024*1024*1024ll;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -230,7 +230,7 @@ namespace eosio::chain {
          void set_async_voting(async_t val);
          void set_async_aggregation(async_t val);
 
-         /// Apply any blocks that are ready from the forkdb
+         /// Apply any blocks that are ready from the fork_db
          void apply_blocks(const forked_callback_t& cb, const trx_meta_cache_lookup& trx_lookup);
 
          struct accepted_block_result {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -329,15 +329,11 @@ namespace eosio::chain {
          void set_savanna_lib_id(const block_id_type& id);
 
          // thread-safe
-         bool   fork_db_has_root() const;
+         bool         fork_db_has_root() const;
          // thread-safe
-         size_t fork_db_size() const;
-         // thread-safe, only valid if fork_db_has_root()
-         uint32_t fork_db_root_block_num() const;
-         // thread-safe, only valid if fork_db_has_root()
-         block_id_type fork_db_root_block_id() const;
-         // thread-safe, only valid if fork_db_has_root()
-         time_point fork_db_root_block_time() const;
+         block_handle fork_db_root()const;
+         // thread-safe
+         size_t       fork_db_size() const;
 
          // thread-safe, retrieves block according to fork db best branch which can change at any moment
          signed_block_ptr fetch_block_by_number( uint32_t block_num )const;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -328,15 +328,16 @@ namespace eosio::chain {
 
          void set_savanna_lib_id(const block_id_type& id);
 
+         // thread-safe
          bool   fork_db_has_root() const;
+         // thread-safe
          size_t fork_db_size() const;
-
-         // thread-safe, applied LIB, fork db root
-         uint32_t last_irreversible_block_num() const;
-         // thread-safe, applied LIB, fork db root
-         block_id_type last_irreversible_block_id() const;
-         // thread-safe, applied LIB, fork db root
-         time_point last_irreversible_block_time() const;
+         // thread-safe, only valid if fork_db_has_root()
+         uint32_t fork_db_root_block_num() const;
+         // thread-safe, only valid if fork_db_has_root()
+         block_id_type fork_db_root_block_id() const;
+         // thread-safe, only valid if fork_db_has_root()
+         time_point fork_db_root_block_time() const;
 
          // thread-safe, retrieves block according to fork db best branch which can change at any moment
          signed_block_ptr fetch_block_by_number( uint32_t block_num )const;

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -85,7 +85,7 @@ namespace eosio::chain {
       bsp_t  root() const;
 
       /**
-       * The best branch head of blocks in the fork database, can be null if include_root_t::no and forkdb is empty
+       * The best branch head of blocks in the fork database, can be null if include_root_t::no and fork_db is empty
        * @param include_root yes if root should be returned if no blocks in fork database
        */
       bsp_t  head(include_root_t include_root = include_root_t::no) const;
@@ -181,7 +181,7 @@ namespace eosio::chain {
 
       in_use_t version_in_use() const { return in_use.load(); }
 
-      // see fork_database_t::fetch_branch(forkdb->head()->id())
+      // see fork_database_t::fetch_branch(fork_db->head()->id())
       block_branch_t fetch_branch_from_head() const;
 
       template <class R, class F>

--- a/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
@@ -15,7 +15,7 @@ namespace appbase {
 // Add entries for each new non-unique handler type.
 enum class handler_id {
    unique,                                // identifies handler is unique, will not de-dup
-   process_incoming_block                 // process blocks already added to forkdb
+   process_incoming_block                 // process blocks already added to fork_db
 };
 
 enum class exec_queue {

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -536,8 +536,8 @@ namespace eosio::testing {
          block_handle     fork_db_head() const { return control->fork_db_head(); }
 
          chain_id_type    get_chain_id() const { return control->get_chain_id(); }
-         block_id_type    last_irreversible_block_id() const { return control->fork_db_root_block_id(); }
-         uint32_t         last_irreversible_block_num() const { return control->fork_db_root_block_num(); }
+         block_id_type    last_irreversible_block_id() const { return control->fork_db_root().id(); }
+         uint32_t         last_irreversible_block_num() const { return control->fork_db_root().block_num(); }
          bool             block_exists(const block_id_type& id) const { return  control->block_exists(id); }
 
          signed_block_ptr fetch_block_by_id(const block_id_type& id) const {

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -536,8 +536,8 @@ namespace eosio::testing {
          block_handle     fork_db_head() const { return control->fork_db_head(); }
 
          chain_id_type    get_chain_id() const { return control->get_chain_id(); }
-         block_id_type    last_irreversible_block_id() const { return control->last_irreversible_block_id(); }
-         uint32_t         last_irreversible_block_num() const { return control->last_irreversible_block_num(); }
+         block_id_type    last_irreversible_block_id() const { return control->fork_db_root_block_id(); }
+         uint32_t         last_irreversible_block_num() const { return control->fork_db_root_block_num(); }
          bool             block_exists(const block_id_type& id) const { return  control->block_exists(id); }
 
          signed_block_ptr fetch_block_by_id(const block_id_type& id) const {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -400,7 +400,7 @@ namespace eosio::testing {
       control->set_async_voting(async_t::no);      // vote synchronously so we don't have to wait for votes
       control->set_async_aggregation(async_t::no); // aggregate votes synchronously for `_check_for_vote_if_needed`
 
-      lib_id = control->fork_db_has_root() ? control->fork_db_root_block_id() : block_id_type{};
+      lib_id = control->fork_db_has_root() ? control->fork_db_root().id() : block_id_type{};
       lib_number = block_header::num_from_id(lib_id);
       lib_block = control->fetch_block_by_id(lib_id);
       [[maybe_unused]] auto lib_connection = control->irreversible_block().connect([&](const block_signal_params& t) {
@@ -515,10 +515,10 @@ namespace eosio::testing {
       auto head_block_number = control->head().block_num();
       auto producer = control->head_active_producers().get_scheduled_producer(block_time);
 
-      auto last_produced_block_num = control->fork_db_root_block_num();
+      auto last_produced_block_num = control->fork_db_root().block_num();
       auto itr = last_produced_block.find(producer.producer_name);
       if (itr != last_produced_block.end()) {
-         last_produced_block_num = std::max(control->fork_db_root_block_num(), block_header::num_from_id(itr->second));
+         last_produced_block_num = std::max(control->fork_db_root().block_num(), block_header::num_from_id(itr->second));
       }
 
       unapplied_transactions.add_aborted( control->abort_block() );

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -400,7 +400,7 @@ namespace eosio::testing {
       control->set_async_voting(async_t::no);      // vote synchronously so we don't have to wait for votes
       control->set_async_aggregation(async_t::no); // aggregate votes synchronously for `_check_for_vote_if_needed`
 
-      lib_id = control->fork_db_has_root() ? control->last_irreversible_block_id() : block_id_type{};
+      lib_id = control->fork_db_has_root() ? control->fork_db_root_block_id() : block_id_type{};
       lib_number = block_header::num_from_id(lib_id);
       lib_block = control->fetch_block_by_id(lib_id);
       [[maybe_unused]] auto lib_connection = control->irreversible_block().connect([&](const block_signal_params& t) {
@@ -515,10 +515,10 @@ namespace eosio::testing {
       auto head_block_number = control->head().block_num();
       auto producer = control->head_active_producers().get_scheduled_producer(block_time);
 
-      auto last_produced_block_num = control->last_irreversible_block_num();
+      auto last_produced_block_num = control->fork_db_root_block_num();
       auto itr = last_produced_block.find(producer.producer_name);
       if (itr != last_produced_block.end()) {
-         last_produced_block_num = std::max(control->last_irreversible_block_num(), block_header::num_from_id(itr->second));
+         last_produced_block_num = std::max(control->fork_db_root_block_num(), block_header::num_from_id(itr->second));
       }
 
       unapplied_transactions.add_aborted( control->abort_block() );

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -23,8 +23,6 @@ namespace eosio::chain::plugin_interface {
    namespace methods {
       using get_block_by_id        = method_decl<chain_plugin_interface, signed_block_ptr(const block_id_type& block_id)>;
       using get_head_block_id      = method_decl<chain_plugin_interface, block_id_type ()>;
-
-      using get_last_irreversible_block_number = method_decl<chain_plugin_interface, uint32_t ()>;
    }
 
    namespace incoming {

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -144,11 +144,11 @@ namespace eosio::chain_apis {
          auto start = fc::time_point::now();
          const auto& index = controller.db().get_index<chain::permission_index>().indices().get<by_id>();
 
-         // build a initial time to block number map
-         const auto froot_num = controller.fork_db_root_block_num();
-         const auto head_num  = controller.head().block_num();
+         // build an initial time to block number map
+         const auto fork_root_num = controller.fork_db_root().block_num();
+         const auto head_num      = controller.head().block_num();
 
-         for (uint32_t block_num = froot_num + 1; block_num <= head_num; block_num++) {
+         for (uint32_t block_num = fork_root_num + 1; block_num <= head_num; block_num++) {
             const auto block_p = controller.fetch_block_by_number(block_num);
             EOS_ASSERT(block_p, chain::plugin_exception, "cannot fetch reversible block ${block_num}, required for account_db initialization", ("block_num", block_num));
             time_to_block_num.emplace(block_p->timestamp.to_time_point(), block_num);
@@ -212,11 +212,12 @@ namespace eosio::chain_apis {
       }
 
       uint32_t last_updated_time_to_height( const fc::time_point& last_updated) {
-         const auto froot_num  = controller.fork_db_root_block_num();
-         const auto froot_time = controller.fork_db_root_block_time();
+         const auto fork_root = controller.fork_db_root();
+         const auto fork_root_num  = fork_root.block_num();
+         const auto fork_root_time = fork_root.block_time();
 
-         uint32_t last_updated_height = froot_num;
-         if (last_updated > froot_time) {
+         uint32_t last_updated_height = fork_root_num;
+         if (last_updated > fork_root_time) {
             const auto iter = time_to_block_num.find(last_updated);
             EOS_ASSERT(iter != time_to_block_num.end(), chain::plugin_exception, "invalid block time encountered in on-chain accounts ${time}", ("time", last_updated));
             last_updated_height = iter->second;

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -145,10 +145,10 @@ namespace eosio::chain_apis {
          const auto& index = controller.db().get_index<chain::permission_index>().indices().get<by_id>();
 
          // build a initial time to block number map
-         const auto lib_num = controller.last_irreversible_block_num();
-         const auto head_num = controller.head().block_num();
+         const auto froot_num = controller.fork_db_root_block_num();
+         const auto head_num  = controller.head().block_num();
 
-         for (uint32_t block_num = lib_num + 1; block_num <= head_num; block_num++) {
+         for (uint32_t block_num = froot_num + 1; block_num <= head_num; block_num++) {
             const auto block_p = controller.fetch_block_by_number(block_num);
             EOS_ASSERT(block_p, chain::plugin_exception, "cannot fetch reversible block ${block_num}, required for account_db initialization", ("block_num", block_num));
             time_to_block_num.emplace(block_p->timestamp.to_time_point(), block_num);
@@ -212,11 +212,11 @@ namespace eosio::chain_apis {
       }
 
       uint32_t last_updated_time_to_height( const fc::time_point& last_updated) {
-         const auto lib_num = controller.last_irreversible_block_num();
-         const auto lib_time = controller.last_irreversible_block_time();
+         const auto froot_num  = controller.fork_db_root_block_num();
+         const auto froot_time = controller.fork_db_root_block_time();
 
-         uint32_t last_updated_height = lib_num;
-         if (last_updated > lib_time) {
+         uint32_t last_updated_height = froot_num;
+         if (last_updated > froot_time) {
             const auto iter = time_to_block_num.find(last_updated);
             EOS_ASSERT(iter != time_to_block_num.end(), chain::plugin_exception, "invalid block time encountered in on-chain accounts ${time}", ("time", last_updated));
             last_updated_height = iter->second;

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -145,10 +145,10 @@ namespace eosio::chain_apis {
          const auto& index = controller.db().get_index<chain::permission_index>().indices().get<by_id>();
 
          // build an initial time to block number map
-         const auto fork_root_num = controller.fork_db_root().block_num();
-         const auto head_num      = controller.head().block_num();
+         const auto fork_db_root_num = controller.fork_db_root().block_num();
+         const auto head_num         = controller.head().block_num();
 
-         for (uint32_t block_num = fork_root_num + 1; block_num <= head_num; block_num++) {
+         for (uint32_t block_num = fork_db_root_num + 1; block_num <= head_num; block_num++) {
             const auto block_p = controller.fetch_block_by_number(block_num);
             EOS_ASSERT(block_p, chain::plugin_exception, "cannot fetch reversible block ${block_num}, required for account_db initialization", ("block_num", block_num));
             time_to_block_num.emplace(block_p->timestamp.to_time_point(), block_num);
@@ -212,12 +212,12 @@ namespace eosio::chain_apis {
       }
 
       uint32_t last_updated_time_to_height( const fc::time_point& last_updated) {
-         const auto fork_root = controller.fork_db_root();
-         const auto fork_root_num  = fork_root.block_num();
-         const auto fork_root_time = fork_root.block_time();
+         const auto fork_db_root = controller.fork_db_root();
+         const auto fork_db_root_num  = fork_db_root.block_num();
+         const auto fork_db_root_time = fork_db_root.block_time();
 
-         uint32_t last_updated_height = fork_root_num;
-         if (last_updated > fork_root_time) {
+         uint32_t last_updated_height = fork_db_root_num;
+         if (last_updated > fork_db_root_time) {
             const auto iter = time_to_block_num.find(last_updated);
             EOS_ASSERT(iter != time_to_block_num.end(), chain::plugin_exception, "invalid block time encountered in on-chain accounts ${time}", ("time", last_updated));
             last_updated_height = iter->second;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1286,17 +1286,17 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
 
    auto head = db.head();
    auto head_id = head.id();
-   auto fork_root = db.fork_db_root();
-   auto fork_head = db.fork_db_head();
-   auto fork_root_id = fork_root.id();
-   auto fork_head_id = fork_head.id();
+   auto fork_db_root = db.fork_db_root();
+   auto fork_db_head = db.fork_db_head();
+   auto fork_db_root_id = fork_db_root.id();
+   auto fork_db_head_id = fork_db_head.id();
 
    return {
       itoh(static_cast<uint32_t>(app().version())),
       db.get_chain_id(),
       block_header::num_from_id(head_id),
-      block_header::num_from_id(fork_root_id),
-      fork_root_id,
+      block_header::num_from_id(fork_db_root_id),
+      fork_db_root_id,
       head_id,
       db.head().block_time(),
       db.head().producer(),
@@ -1307,13 +1307,13 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       //std::bitset<64>(db.get_dynamic_global_properties().recent_slots_filled).to_string(),
       //__builtin_popcountll(db.get_dynamic_global_properties().recent_slots_filled) / 64.0,
       app().version_string(),
-      block_header::num_from_id(fork_head_id),
-      fork_head_id,
+      block_header::num_from_id(fork_db_head_id),
+      fork_db_head_id,
       app().full_version_string(),
       rm.get_total_cpu_weight(),
       rm.get_total_net_weight(),
       db.earliest_available_block_num(),
-      fork_root.block_time()
+      fork_db_root.block_time()
    };
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1286,15 +1286,17 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
 
    auto head = db.head();
    auto head_id = head.id();
-   auto froot_id = db.fork_db_root_block_id();
-   auto fhead_id = db.fork_db_head().id();
+   auto fork_root = db.fork_db_root();
+   auto fork_head = db.fork_db_head();
+   auto fork_root_id = fork_root.id();
+   auto fork_head_id = fork_head.id();
 
    return {
       itoh(static_cast<uint32_t>(app().version())),
       db.get_chain_id(),
       block_header::num_from_id(head_id),
-      block_header::num_from_id(froot_id),
-      froot_id,
+      block_header::num_from_id(fork_root_id),
+      fork_root_id,
       head_id,
       db.head().block_time(),
       db.head().producer(),
@@ -1305,13 +1307,13 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       //std::bitset<64>(db.get_dynamic_global_properties().recent_slots_filled).to_string(),
       //__builtin_popcountll(db.get_dynamic_global_properties().recent_slots_filled) / 64.0,
       app().version_string(),
-      block_header::num_from_id(fhead_id),
-      fhead_id,
+      block_header::num_from_id(fork_head_id),
+      fork_head_id,
       app().full_version_string(),
       rm.get_total_cpu_weight(),
       rm.get_total_net_weight(),
       db.earliest_available_block_num(),
-      db.fork_db_root_block_time()
+      fork_root.block_time()
    };
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -451,8 +451,8 @@ void clear_directory_contents( const std::filesystem::path& p ) {
 namespace {
   // This can be removed when versions of eosio that support reversible chainbase state file no longer supported.
   void upgrade_from_reversible_to_fork_db(chain_plugin_impl* my) {
-          std::filesystem::path old_fork_db = my->chain_config->state_dir / config::forkdb_filename;
-     std::filesystem::path new_fork_db = my->blocks_dir / config::reversible_blocks_dir_name / config::forkdb_filename;
+          std::filesystem::path old_fork_db = my->chain_config->state_dir / config::fork_db_filename;
+     std::filesystem::path new_fork_db = my->blocks_dir / config::reversible_blocks_dir_name / config::fork_db_filename;
      if( std::filesystem::exists( old_fork_db ) && std::filesystem::is_regular_file( old_fork_db ) ) {
         bool copy_file = false;
         if( std::filesystem::exists( new_fork_db ) && std::filesystem::is_regular_file( new_fork_db ) ) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -184,7 +184,6 @@ public:
    // method provider handles
    methods::get_block_by_id::method_type::handle                     get_block_by_id_provider;
    methods::get_head_block_id::method_type::handle                   get_head_block_id_provider;
-   methods::get_last_irreversible_block_number::method_type::handle  get_last_irreversible_block_number_provider;
 
    // scoped connections for chain controller
    std::optional<scoped_connection>                                   accepted_block_header_connection;
@@ -1028,11 +1027,6 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          return chain->head().id();
       } );
 
-      get_last_irreversible_block_number_provider = app().get_method<methods::get_last_irreversible_block_number>().register_provider(
-            [this]() {
-               return chain->last_irreversible_block_num();
-            } );
-
       // relay signals to channels
       accepted_block_header_connection = chain->accepted_block_header().connect(
             [this]( const block_signal_params& t ) {
@@ -1290,16 +1284,17 @@ const string read_only::KEYi64 = "i64";
 read_only::get_info_results read_only::get_info(const read_only::get_info_params&, const fc::time_point&) const {
    const auto& rm = db.get_resource_limits_manager();
 
-   auto head_id = db.head().id();
-   auto lib_id = db.last_irreversible_block_id();
+   auto head = db.head();
+   auto head_id = head.id();
+   auto froot_id = db.fork_db_root_block_id();
    auto fhead_id = db.fork_db_head().id();
 
    return {
       itoh(static_cast<uint32_t>(app().version())),
       db.get_chain_id(),
       block_header::num_from_id(head_id),
-      block_header::num_from_id(lib_id),
-      lib_id,
+      block_header::num_from_id(froot_id),
+      froot_id,
       head_id,
       db.head().block_time(),
       db.head().producer(),
@@ -1316,7 +1311,7 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
       rm.get_total_cpu_weight(),
       rm.get_total_net_weight(),
       db.earliest_available_block_num(),
-      db.last_irreversible_block_time()
+      db.fork_db_root_block_time()
    };
 }
 

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -32,8 +32,8 @@ namespace eosio {
       fc::sha256                 token; ///< digest of time to prove we own the private key of the key above
       chain::signature_type      sig; ///< signature for the digest
       string                     p2p_address;
-      uint32_t                   last_irreversible_block_num = 0;
-      block_id_type              last_irreversible_block_id;
+      uint32_t                   fork_root_num = 0;
+      block_id_type              fork_root_id;
       uint32_t                   fork_head_num = 0;
       block_id_type              fork_head_id;
       string                     os;
@@ -154,7 +154,7 @@ FC_REFLECT( eosio::chain_size_message,
 FC_REFLECT( eosio::handshake_message,
             (network_version)(chain_id)(node_id)(key)
             (time)(token)(sig)(p2p_address)
-            (last_irreversible_block_num)(last_irreversible_block_id)
+            (fork_root_num)(fork_root_id)
             (fork_head_num)(fork_head_id)
             (os)(agent)(generation) )
 FC_REFLECT( eosio::go_away_message, (reason)(node_id) )

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -32,10 +32,10 @@ namespace eosio {
       fc::sha256                 token; ///< digest of time to prove we own the private key of the key above
       chain::signature_type      sig; ///< signature for the digest
       string                     p2p_address;
-      uint32_t                   fork_root_num = 0;
-      block_id_type              fork_root_id;
-      uint32_t                   fork_head_num = 0;
-      block_id_type              fork_head_id;
+      uint32_t                   fork_db_root_num = 0;
+      block_id_type              fork_db_root_id;
+      uint32_t                   fork_db_head_num = 0;
+      block_id_type              fork_db_head_id;
       string                     os;
       string                     agent;
       int16_t                    generation = 0;
@@ -154,8 +154,8 @@ FC_REFLECT( eosio::chain_size_message,
 FC_REFLECT( eosio::handshake_message,
             (network_version)(chain_id)(node_id)(key)
             (time)(token)(sig)(p2p_address)
-            (fork_root_num)(fork_root_id)
-            (fork_head_num)(fork_head_id)
+            (fork_db_root_num)(fork_db_root_id)
+            (fork_db_head_num)(fork_db_head_id)
             (os)(agent)(generation) )
 FC_REFLECT( eosio::go_away_message, (reason)(node_id) )
 FC_REFLECT( eosio::time_message, (org)(rec)(xmt)(dst) )

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -145,7 +145,7 @@ namespace eosio {
 
       alignas(hardware_destructive_interference_sz)
       fc::mutex      sync_mtx;
-      uint32_t       sync_known_lib_num      GUARDED_BY(sync_mtx) {0};  // highest known lib num from currently connected peers
+      uint32_t       sync_known_froot_num    GUARDED_BY(sync_mtx) {0};  // highest known forkdb root num from currently connected peers
       uint32_t       sync_last_requested_num GUARDED_BY(sync_mtx) {0};  // end block number of the last requested range, inclusive
       uint32_t       sync_next_expected_num  GUARDED_BY(sync_mtx) {0};  // the next block number we need from peer
       connection_ptr sync_source             GUARDED_BY(sync_mtx);      // connection we are currently syncing from
@@ -162,10 +162,10 @@ namespace eosio {
       // applied the blocks and our controller head is updated
       std::atomic<bool> send_handshakes_when_synced{false};
 
-      // Instant finality makes it likely peers think their lib and head are
+      // Instant finality makes it likely peers think their froot and head are
       // not in sync but in reality they are only within small difference.
       // To avoid unnecessary catchups, a margin of min_blocks_distance
-      // between lib and head must be reached before catchup starts.
+      // between froot and head must be reached before catchup starts.
       const uint32_t min_blocks_distance{0};
 
    private:
@@ -187,7 +187,7 @@ namespace eosio {
       static void send_handshakes();
       bool syncing_from_peer() const { return sync_state == lib_catchup; }
       bool is_in_sync() const { return sync_state == in_sync; }
-      void sync_reset_lib_num( const connection_ptr& conn, bool closing );
+      void sync_reset_froot_num( const connection_ptr& conn, bool closing );
       void sync_timeout(const connection_ptr& c, const boost::system::error_code& ec);
       void sync_wait(const connection_ptr& c);
       void sync_reassign_fetch( const connection_ptr& c );
@@ -218,7 +218,7 @@ namespace eosio {
       void rejected_transaction(const packed_transaction_ptr& trx);
       void bcast_block( const signed_block_ptr& b, const block_id_type& id );
 
-      void expire_blocks( uint32_t lib_num );
+      void expire_blocks( uint32_t froot_num );
       void recv_notice(const connection_ptr& conn, const notice_message& msg, bool generated);
 
       bool add_peer_block( const block_id_type& blkid, uint32_t connection_id );
@@ -420,8 +420,8 @@ namespace eosio {
 
 
       struct chain_info_t {
-         block_id_type lib_id;
-         uint32_t      lib_num = 0;
+         block_id_type fork_root_id;
+         uint32_t      fork_root_num = 0;
          block_id_type head_id;
          uint32_t      head_num = 0;
          block_id_type fork_head_id;
@@ -439,9 +439,9 @@ namespace eosio {
 
    public:
       void update_chain_info();
-      void update_chain_info(const block_id_type& lib);
+      void update_chain_info(const block_id_type& froot_id);
       chain_info_t get_chain_info() const;
-      uint32_t get_chain_lib_num() const;
+      uint32_t get_fork_root_num() const;
       uint32_t get_chain_head_num() const;
       uint32_t get_fork_head_num() const;
 
@@ -842,8 +842,8 @@ namespace eosio {
       string                  log_remote_endpoint_port;
       string                  local_endpoint_ip;
       string                  local_endpoint_port;
-      // kept in sync with last_handshake_recv.last_irreversible_block_num, only accessed from connection strand
-      uint32_t                peer_lib_num = 0;
+      // kept in sync with last_handshake_recv.fork_root_num, only accessed from connection strand
+      uint32_t                peer_froot_num = 0;
 
       std::atomic<uint32_t>   sync_ordinal{0};
       // when syncing from a peer, the last block expected of the current range
@@ -907,7 +907,7 @@ namespace eosio {
       bool connected() const;
       bool closed() const; // socket is not open or is closed or closing, thread safe
       bool current() const;
-      bool should_sync_from(uint32_t sync_next_expected_num, uint32_t sync_known_lib_num, uint32_t sync_fetch_span) const;
+      bool should_sync_from(uint32_t sync_next_expected_num, uint32_t sync_known_froot_num, uint32_t sync_fetch_span) const;
 
       /// @param reconnect true if we should try and reconnect immediately after close
       /// @param shutdown true only if plugin is shutting down
@@ -967,7 +967,7 @@ namespace eosio {
       /** @} */
 
       void blk_send_branch( const block_id_type& msg_head_id );
-      void blk_send_branch( uint32_t msg_head_num, uint32_t lib_num, uint32_t head_num );
+      void blk_send_branch( uint32_t msg_head_num, uint32_t froot_num, uint32_t head_num );
 
       void enqueue( const net_message &msg );
       size_t enqueue_block( const std::vector<char>& sb, uint32_t block_num, bool to_sync_queue = false);
@@ -1331,7 +1331,7 @@ namespace eosio {
    }
 
    // thread safe
-   bool connection::should_sync_from(uint32_t sync_next_expected_num, uint32_t sync_known_lib_num, uint32_t sync_fetch_span) const {
+   bool connection::should_sync_from(uint32_t sync_next_expected_num, uint32_t sync_known_froot_num, uint32_t sync_fetch_span) const {
       fc_dlog(logger, "id: ${id} blocks conn: ${t} current: ${c} socket_open: ${so} syncing from us: ${s} state: ${con} peer_start_block: ${sb} peer_fhead: ${h} ping: ${p}us no_retry: ${g}",
               ("id", connection_id)("t", is_blocks_connection())
               ("c", current())("so", socket_is_open())("s", peer_syncing_from_us.load())("con", state_str(state()))
@@ -1339,8 +1339,8 @@ namespace eosio {
       if (is_blocks_connection() && current()) {
          if (no_retry == go_away_reason::no_reason) {
             if (peer_start_block_num <= sync_next_expected_num) { // has blocks we want
-               auto needed_end = std::min(sync_next_expected_num + sync_fetch_span, sync_known_lib_num);
-               if (peer_fork_head_block_num >= needed_end) { // has lib blocks
+               auto needed_end = std::min(sync_next_expected_num + sync_fetch_span, sync_known_froot_num);
+               if (peer_fork_head_block_num >= needed_end) { // has blocks
                   return true;
                }
             }
@@ -1382,11 +1382,11 @@ namespace eosio {
          last_close = fc::time_point::now();
          conn_node_id = fc::sha256();
       }
-      peer_lib_num = 0;
+      peer_froot_num = 0;
       peer_ping_time_ns = std::numeric_limits<decltype(peer_ping_time_ns)::value_type>::max();
       peer_requested.reset();
       sent_handshake_count = 0;
-      if( !shutdown) my_impl->sync_master->sync_reset_lib_num( shared_from_this(), true );
+      if( !shutdown) my_impl->sync_master->sync_reset_froot_num( shared_from_this(), true );
       cancel_sync_wait();
       sync_last_requested_block = 0;
       org = std::chrono::nanoseconds{0};
@@ -1425,8 +1425,8 @@ namespace eosio {
                        ("h", block_header::num_from_id(last_handshake_recv.fork_head_id))("id", last_handshake_recv.fork_head_id) );
          }
       }
-      const auto lib_num = peer_lib_num;
-      if( lib_num == 0 ) return; // if last_irreversible_block_id is null (we have not received handshake or reset)
+      const auto froot_num = peer_froot_num;
+      if( froot_num == 0 ) return; // if fork_root_id is null (we have not received handshake or reset)
 
       auto msg_head_num = block_header::num_from_id(msg_head_id);
       bool on_fork = msg_head_num == 0;
@@ -1447,18 +1447,18 @@ namespace eosio {
          enqueue( go_away_message( benign_other ) );
       } else {
          if( on_fork ) msg_head_num = 0;
-         // if peer on fork, start at their last lib, otherwise we can start at msg_head+1
-         blk_send_branch( msg_head_num, lib_num, head_num );
+         // if peer on fork, start at their last froot_num, otherwise we can start at msg_head+1
+         blk_send_branch( msg_head_num, froot_num, head_num );
       }
    }
 
    // called from connection strand
-   void connection::blk_send_branch( uint32_t msg_head_num, uint32_t lib_num, uint32_t head_num ) {
+   void connection::blk_send_branch( uint32_t msg_head_num, uint32_t froot_num, uint32_t head_num ) {
       if( !peer_requested ) {
-         auto last = msg_head_num != 0 ? msg_head_num : lib_num;
+         auto last = msg_head_num != 0 ? msg_head_num : froot_num;
          peer_requested = peer_sync_state( last+1, head_num, last );
       } else {
-         auto last = msg_head_num != 0 ? msg_head_num : std::min( peer_requested->last, lib_num );
+         auto last = msg_head_num != 0 ? msg_head_num : std::min( peer_requested->last, froot_num );
          uint32_t end   = std::max( peer_requested->end_block, head_num );
          peer_requested = peer_sync_state( last+1, end, last );
       }
@@ -1482,9 +1482,9 @@ namespace eosio {
             c->last_handshake_sent.generation = ++c->sent_handshake_count;
             auto last_handshake = c->last_handshake_sent;
             g_conn.unlock();
-            peer_dlog( c, "Sending handshake generation ${g}, lib ${lib}, fhead ${h}, id ${id}",
+            peer_dlog( c, "Sending handshake generation ${g}, froot ${r}, fhead ${h}, id ${id}",
                        ("g", last_handshake.generation)
-                       ("lib", last_handshake.last_irreversible_block_num)
+                       ("r", last_handshake.fork_root_num)
                        ("h", last_handshake.fork_head_num)("id", last_handshake.fork_head_id.str().substr(8,16)) );
             c->enqueue( last_handshake );
          }
@@ -1912,7 +1912,7 @@ namespace eosio {
    //-----------------------------------------------------------
 
     sync_manager::sync_manager( uint32_t span, uint32_t sync_peer_limit, uint32_t min_blocks_distance )
-      :sync_known_lib_num( 0 )
+      :sync_known_froot_num( 0 )
       ,sync_last_requested_num( 0 )
       ,sync_next_expected_num( 1 )
       ,sync_source()
@@ -1942,34 +1942,34 @@ namespace eosio {
    }
 
    // called from c's connection strand
-   void sync_manager::sync_reset_lib_num(const connection_ptr& c, bool closing) {
+   void sync_manager::sync_reset_froot_num(const connection_ptr& c, bool closing) {
       fc::unique_lock g( sync_mtx );
       if( sync_state == in_sync ) {
          sync_source.reset();
       }
       if( !c ) return;
       if( !closing ) {
-         if( c->peer_lib_num > sync_known_lib_num ) {
-            sync_known_lib_num = c->peer_lib_num;
+         if( c->peer_froot_num > sync_known_froot_num ) {
+            sync_known_froot_num = c->peer_froot_num;
          }
       } else {
-         // Closing connection, therefore its view of LIB can no longer be considered as we will no longer be connected.
-         // Determine current LIB of remaining peers as our sync_known_lib_num.
-         uint32_t highest_lib_num = 0;
-         my_impl->connections.for_each_block_connection( [&highest_lib_num]( const auto& cc ) {
+         // Closing connection, therefore its view of froot can no longer be considered as we will no longer be connected.
+         // Determine current froot of remaining peers as our sync_known_froot_num.
+         uint32_t highest_fork_root_num = 0;
+         my_impl->connections.for_each_block_connection( [&highest_fork_root_num]( const auto& cc ) {
             fc::lock_guard g_conn( cc->conn_mtx );
-            if( cc->current() && cc->last_handshake_recv.last_irreversible_block_num > highest_lib_num ) {
-               highest_lib_num = cc->last_handshake_recv.last_irreversible_block_num;
+            if( cc->current() && cc->last_handshake_recv.fork_root_num > highest_fork_root_num ) {
+               highest_fork_root_num = cc->last_handshake_recv.fork_root_num;
             }
          } );
-         sync_known_lib_num = highest_lib_num;
+         sync_known_froot_num = highest_fork_root_num;
 
          // if closing the connection we are currently syncing from then request from a diff peer
          if( c == sync_source ) {
-            // if starting to sync need to always start from lib as we might be on our own fork
-            uint32_t lib_num = my_impl->get_chain_lib_num();
+            // if starting to sync need to always start from froot as we might be on our own fork
+            uint32_t froot_num = my_impl->get_fork_root_num();
             sync_last_requested_num = 0;
-            sync_next_expected_num = std::max( lib_num + 1, sync_next_expected_num );
+            sync_next_expected_num = std::max( froot_num + 1, sync_next_expected_num );
             sync_source.reset();
             request_next_chunk();
          }
@@ -1977,14 +1977,14 @@ namespace eosio {
    }
 
    connection_ptr sync_manager::find_next_sync_node() REQUIRES(sync_mtx) {
-      fc_dlog(logger, "Number connections ${s}, sync_next_expected_num: ${e}, sync_known_lib_num: ${l}",
-              ("s", my_impl->connections.number_connections())("e", sync_next_expected_num)("l", sync_known_lib_num));
+      fc_dlog(logger, "Number connections ${s}, sync_next_expected_num: ${e}, sync_known_froot_num: ${l}",
+              ("s", my_impl->connections.number_connections())("e", sync_next_expected_num)("l", sync_known_froot_num));
       deque<connection_ptr> conns;
       my_impl->connections.for_each_block_connection([sync_next_expected_num = sync_next_expected_num,
-                                                      sync_known_lib_num = sync_known_lib_num,
+                                                      sync_known_froot_num = sync_known_froot_num,
                                                       sync_fetch_span = sync_fetch_span,
                                                       &conns](const auto& c) {
-         if (c->should_sync_from(sync_next_expected_num, sync_known_lib_num, sync_fetch_span)) {
+         if (c->should_sync_from(sync_next_expected_num, sync_known_froot_num, sync_fetch_span)) {
             conns.push_back(c);
          }
       });
@@ -2031,13 +2031,13 @@ namespace eosio {
    void sync_manager::request_next_chunk( const connection_ptr& conn ) REQUIRES(sync_mtx) {
       auto chain_info = my_impl->get_chain_info();
 
-      fc_dlog( logger, "sync_last_requested_num: ${r}, sync_next_expected_num: ${e}, sync_known_lib_num: ${k}, sync-fetch-span: ${s}, fhead: ${h}, lib: ${lib}",
-               ("r", sync_last_requested_num)("e", sync_next_expected_num)("k", sync_known_lib_num)("s", sync_fetch_span)("h", chain_info.fork_head_num)("lib", chain_info.lib_num) );
+      fc_dlog( logger, "sync_last_requested_num: ${r}, sync_next_expected_num: ${e}, sync_known_froot_num: ${k}, sync-fetch-span: ${s}, fhead: ${h}, froot: ${fr}",
+               ("r", sync_last_requested_num)("e", sync_next_expected_num)("k", sync_known_froot_num)("s", sync_fetch_span)("h", chain_info.fork_head_num)("fr", chain_info.fork_root_num) );
 
       if (conn) {
          // p2p_high_latency_test.py test depends on this exact log statement.
          peer_ilog(conn, "Catching up with chain, our last req is ${cc}, theirs is ${t}, next expected ${n}, fhead ${h}",
-                   ("cc", sync_last_requested_num)("t", sync_known_lib_num)("n", sync_next_expected_num)("h", chain_info.fork_head_num));
+                   ("cc", sync_last_requested_num)("t", sync_known_froot_num)("n", sync_next_expected_num)("h", chain_info.fork_head_num));
       }
 
       /* ----------
@@ -2049,9 +2049,9 @@ namespace eosio {
 
       auto reset_on_failure = [&]() REQUIRES(sync_mtx) {
          sync_source.reset();
-         sync_known_lib_num = chain_info.lib_num;
+         sync_known_froot_num = chain_info.fork_root_num;
          sync_last_requested_num = 0;
-         sync_next_expected_num = std::max( sync_known_lib_num + 1, sync_next_expected_num );
+         sync_next_expected_num = std::max( sync_known_froot_num + 1, sync_next_expected_num );
          // not in sync, but need to be out of lib_catchup for start_sync to work
          set_state( in_sync );
          send_handshakes();
@@ -2065,18 +2065,18 @@ namespace eosio {
       }
 
       bool request_sent = false;
-      if( sync_last_requested_num != sync_known_lib_num ) {
+      if( sync_last_requested_num != sync_known_froot_num ) {
          uint32_t start = sync_next_expected_num;
          uint32_t end = start + sync_fetch_span - 1;
-         if( end > sync_known_lib_num )
-            end = sync_known_lib_num;
+         if( end > sync_known_froot_num )
+            end = sync_known_froot_num;
          if( end > 0 && end >= start ) {
             sync_last_requested_num = end;
             sync_source = new_sync_source;
             request_sent = true;
             sync_active_time = std::chrono::steady_clock::now();
-            boost::asio::post(new_sync_source->strand, [new_sync_source, start, end, fork_head_num=chain_info.fork_head_num, lib=chain_info.lib_num]() {
-               peer_ilog( new_sync_source, "requesting range ${s} to ${e}, fhead ${h}, lib ${lib}", ("s", start)("e", end)("h", fork_head_num)("lib", lib) );
+            boost::asio::post(new_sync_source->strand, [new_sync_source, start, end, fork_head_num=chain_info.fork_head_num, froot=chain_info.fork_root_num]() {
+               peer_ilog( new_sync_source, "requesting range ${s} to ${e}, fhead ${h}, froot ${r}", ("s", start)("e", end)("h", fork_head_num)("r", froot) );
                new_sync_source->request_sync_blocks( start, end );
             } );
          }
@@ -2098,23 +2098,23 @@ namespace eosio {
 
    bool sync_manager::is_sync_required( uint32_t fork_head_block_num ) const REQUIRES(sync_mtx) {
       fc_dlog( logger, "last req = ${req}, last recv = ${recv} known = ${known} our fhead = ${h}",
-               ("req", sync_last_requested_num)( "recv", sync_next_expected_num-1 )( "known", sync_known_lib_num )
+               ("req", sync_last_requested_num)( "recv", sync_next_expected_num-1 )( "known", sync_known_froot_num )
                ("h", fork_head_block_num ) );
 
-      return( sync_last_requested_num < sync_known_lib_num ||
+      return( sync_last_requested_num < sync_known_froot_num ||
               sync_next_expected_num < sync_last_requested_num );
    }
 
    // called from c's connection strand
    bool sync_manager::is_sync_request_ahead_allowed(block_num_type blk_num) const REQUIRES(sync_mtx) {
-      if (blk_num >= sync_last_requested_num && sync_last_requested_num < sync_known_lib_num) {
+      if (blk_num >= sync_last_requested_num && sync_last_requested_num < sync_known_froot_num) {
          // do not allow to get too far ahead (sync_fetch_span) of chain head
          // use chain head instead of fork head so we do not get too far ahead of applied blocks
          uint32_t head_num = my_impl->get_chain_head_num();
          block_num_type num_blocks_not_applied = blk_num > head_num ? blk_num - head_num : 0;
          if (num_blocks_not_applied < sync_fetch_span) {
-            fc_dlog(logger, "sync ahead allowed past sync-fetch-span ${sp}, block ${bn} chain_lib ${cl}, forkdb size ${s}",
-                    ("bn", blk_num)("sp", sync_fetch_span)("cl", head_num)("s", my_impl->chain_plug->chain().fork_db_size()));
+            fc_dlog(logger, "sync ahead allowed past sync-fetch-span ${sp}, block ${bn} head ${h}, forkdb size ${s}",
+                    ("bn", blk_num)("sp", sync_fetch_span)("h", head_num)("s", my_impl->chain_plug->chain().fork_db_size()));
             return true;
          }
 
@@ -2127,8 +2127,8 @@ namespace eosio {
             num_blocks_that_can_be_applied += blk_num > forkdb_head.block_num() ? blk_num - forkdb_head.block_num() : 0;
             if (num_blocks_that_can_be_applied < sync_fetch_span) {
                if (head_num )
-                  fc_ilog(logger, "sync ahead allowed past sync-fetch-span ${sp}, block ${bn} for paused LIB ${l}, chain_lib ${cl}, forkdb size ${s}",
-                          ("bn", blk_num)("sp", sync_fetch_span)("l", calculated_lib)("cl", head_num)("s", cc.fork_db_size()));
+                  fc_ilog(logger, "sync ahead allowed past sync-fetch-span ${sp}, block ${bn} for paused lib ${l}, head ${h}, forkdb size ${s}",
+                          ("bn", blk_num)("sp", sync_fetch_span)("l", calculated_lib)("h", head_num)("s", cc.fork_db_size()));
                return true;
             }
          }
@@ -2146,14 +2146,14 @@ namespace eosio {
    // called from c's connection strand
    void sync_manager::start_sync(const connection_ptr& c, uint32_t target) {
       fc::unique_lock g_sync( sync_mtx );
-      if( target > sync_known_lib_num) {
-         sync_known_lib_num = target;
+      if( target > sync_known_froot_num) {
+         sync_known_froot_num = target;
       }
 
       auto chain_info = my_impl->get_chain_info();
-      if( !is_sync_required( chain_info.fork_head_num ) || target <= chain_info.lib_num ) {
+      if( !is_sync_required( chain_info.fork_head_num ) || target <= chain_info.fork_root_num ) {
          peer_dlog( c, "We are already caught up, my irr = ${b}, fhead = ${h}, target = ${t}",
-                  ("b", chain_info.lib_num)( "h", chain_info.fork_head_num )( "t", target ) );
+                  ("b", chain_info.fork_root_num)( "h", chain_info.fork_head_num )( "t", target ) );
          c->send_handshake(); // let peer know it is not syncing from us
          return;
       }
@@ -2164,7 +2164,7 @@ namespace eosio {
                    ("s", stage_str(current_sync_state))("nen", sync_next_expected_num));
          set_state( lib_catchup );
          sync_last_requested_num = 0;
-         sync_next_expected_num = chain_info.lib_num + 1;
+         sync_next_expected_num = chain_info.fork_root_num + 1;
          request_next_chunk( c );
       } else if (sync_last_requested_num > 0 && is_sync_request_ahead_allowed(sync_next_expected_num-1)) {
          request_next_chunk();
@@ -2211,9 +2211,9 @@ namespace eosio {
          peer_ilog(c, "reassign_fetch, our last req is ${cc}, next expected is ${ne}",
                    ("cc", sync_last_requested_num)("ne", sync_next_expected_num));
          c->cancel_sync();
-         auto lib = my_impl->get_chain_lib_num();
+         auto froot_num = my_impl->get_fork_root_num();
          sync_last_requested_num = 0;
-         sync_next_expected_num = std::max(sync_next_expected_num, lib + 1);
+         sync_next_expected_num = std::max(sync_next_expected_num, froot_num + 1);
          sync_source.reset();
          request_next_chunk();
       }
@@ -2233,10 +2233,10 @@ namespace eosio {
 
       auto chain_info = my_impl->get_chain_info();
 
-      sync_reset_lib_num(c, false);
+      sync_reset_froot_num(c, false);
 
       //--------------------------------
-      // sync need checks; (lib == last irreversible block)
+      // sync need checks; (lib == fork database root)
       //
       // 0. my head block id == peer head id means we are all caught up block wise
       // 1. my head block num < peer lib - start sync locally
@@ -2250,29 +2250,30 @@ namespace eosio {
       //-----------------------------
 
       if (chain_info.fork_head_id == msg.fork_head_id) {
-         peer_dlog( c, "handshake lib ${lib}, fhead ${h}, id ${id}.. sync 0, lib ${l}",
-                    ("lib", msg.last_irreversible_block_num)("h", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))("l", chain_info.lib_num) );
+         peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 0, fhead ${h}, froot ${r}",
+                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
          c->peer_syncing_from_us = false;
          return;
       }
-      if (chain_info.fork_head_num < msg.last_irreversible_block_num) {
-         peer_dlog( c, "handshake lib ${lib}, fhead ${mh}, id ${id}.. sync 1, fhead ${h}, lib ${l}",
-                    ("lib", msg.last_irreversible_block_num)("mh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("l", chain_info.lib_num) );
+      if (chain_info.fork_head_num < msg.fork_root_num) {
+         peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 1, fhead ${h}, froot ${r}",
+                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
          c->peer_syncing_from_us = false;
          if (c->sent_handshake_count > 0) {
             c->send_handshake();
          }
          return;
       }
-      if (chain_info.lib_num > msg.fork_head_num + nblk_combined_latency + min_blocks_distance) {
-         peer_dlog( c, "handshake lib ${lib}, fhead ${mh}, id ${id}.. sync 2, fhead ${h}, lib ${l}",
-                    ("lib", msg.last_irreversible_block_num)("mh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("l", chain_info.lib_num) );
+      if (chain_info.fork_root_num > msg.fork_head_num + nblk_combined_latency + min_blocks_distance) {
+         peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 2, fhead ${h}, froot ${r}",
+                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
          if (msg.generation > 1 || c->protocol_version > proto_base) {
             controller& cc = my_impl->chain_plug->chain();
             notice_message note;
-            note.known_trx.pending = chain_info.lib_num;
+            note.known_trx.pending = chain_info.fork_root_num;
             note.known_trx.mode = last_irr_catch_up;
             note.known_blocks.mode = last_irr_catch_up;
             note.known_blocks.pending = chain_info.fork_head_num;
@@ -2288,16 +2289,16 @@ namespace eosio {
       }
 
       if (chain_info.fork_head_num + nblk_combined_latency < msg.fork_head_num ) {
-         peer_dlog( c, "handshake lib ${lib}, fhead ${mh}, id ${id}.. sync 3, fhead ${h}, lib ${l}",
-                    ("lib", msg.last_irreversible_block_num)("mh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("l", chain_info.lib_num) );
+         peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 3, fhead ${h}, froot ${r}",
+                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
          c->peer_syncing_from_us = false;
          verify_catchup(c, msg.fork_head_num, msg.fork_head_id);
          return;
       } else if(chain_info.fork_head_num >= msg.fork_head_num + nblk_combined_latency) {
-         peer_dlog( c, "handshake lib ${lib}, fhead ${mh}, id ${id}.. sync 4, fhead ${h}, lib ${l}",
-                    ("lib", msg.last_irreversible_block_num)("mh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("l", chain_info.lib_num) );
+         peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 4, fhead ${h}, froot ${r}",
+                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
          if (msg.generation > 1 ||  c->protocol_version > proto_base) {
             controller& cc = my_impl->chain_plug->chain();
             notice_message note;
@@ -2315,7 +2316,7 @@ namespace eosio {
          try {
             controller& cc = my_impl->chain_plug->chain();
             std::optional<block_id_type> fork_head_id = cc.fork_block_id_for_num( msg.fork_head_num ); // thread-safe
-            if (fork_head_id && fork_head_id != msg.fork_head_id) { // possible for LIB to move and fork_head_num not be found if running with no block-log
+            if (fork_head_id && fork_head_id != msg.fork_head_id) { // possible for froot to move and fork_head_num not be found if running with no block-log
                peer_dlog(c, "Sending catch_up request_message sync 4, fhead ${fh} != msg.fhead ${mfh}",
                          ("fh", *fork_head_id)("mfh", msg.fork_head_id));
                request_message req;
@@ -2350,12 +2351,12 @@ namespace eosio {
          {
             fc::lock_guard g( sync_mtx );
             peer_ilog( c, "catch_up while in ${s}, fhead = ${hn} "
-                          "target LIB = ${lib} next_expected = ${ne}, id ${id}...",
-                     ("s", stage_str( sync_state ))("hn", num)("lib", sync_known_lib_num)
+                          "target froot = ${fr} next_expected = ${ne}, id ${id}...",
+                     ("s", stage_str( sync_state ))("hn", num)("fr", sync_known_froot_num)
                      ("ne", sync_next_expected_num)("id", id.str().substr( 8, 16 )) );
          }
          auto chain_info = my_impl->get_chain_info();
-         if( sync_state == lib_catchup || num < chain_info.lib_num ) {
+         if( sync_state == lib_catchup || num < chain_info.fork_root_num ) {
             c->send_handshake();
             return false;
          }
@@ -2401,11 +2402,11 @@ namespace eosio {
          }
       } else if (msg.known_blocks.mode == last_irr_catch_up) {
          {
-            c->peer_lib_num = msg.known_trx.pending;
+            c->peer_froot_num = msg.known_trx.pending;
             fc::lock_guard g_conn( c->conn_mtx );
-            c->last_handshake_recv.last_irreversible_block_num = msg.known_trx.pending;
+            c->last_handshake_recv.fork_root_num = msg.known_trx.pending;
          }
-         sync_reset_lib_num(c, false);
+         sync_reset_froot_num(c, false);
          start_sync(c, msg.known_trx.pending);
       }
    }
@@ -2416,7 +2417,7 @@ namespace eosio {
       // reset sync on rejected block
       fc::unique_lock g( sync_mtx );
       sync_last_requested_num = 0;
-      sync_next_expected_num = my_impl->get_chain_lib_num() + 1;
+      sync_next_expected_num = my_impl->get_fork_root_num() + 1;
       g.unlock();
       if( mode == closing_mode::immediately || c->block_status_monitor_.max_events_violated()) {
          peer_wlog(c, "block ${bn} not accepted, closing connection ${d}",
@@ -2495,9 +2496,9 @@ namespace eosio {
          }
       } else if( state == lib_catchup ) {
          fc::unique_lock g_sync( sync_mtx );
-         if( blk_applied && blk_num >= sync_known_lib_num ) {
-            fc_dlog(logger, "All caught up ${b} with last known lib ${l} resending handshake",
-                    ("b", blk_num)("l", sync_known_lib_num));
+         if( blk_applied && blk_num >= sync_known_froot_num ) {
+            fc_dlog(logger, "All caught up ${b} with last known froot ${r} resending handshake",
+                    ("b", blk_num)("r", sync_known_froot_num));
             set_state( head_catchup );
             g_sync.unlock();
             send_handshakes();
@@ -2514,16 +2515,16 @@ namespace eosio {
                }
 
                if (sync_last_requested_num == 0) { // block was rejected
-                  sync_next_expected_num = my_impl->get_chain_lib_num() + 1;
+                  sync_next_expected_num = my_impl->get_fork_root_num() + 1;
                   peer_dlog(c, "Reset sync_next_expected_num to ${n}", ("n", sync_next_expected_num));
                } else {
                   if (blk_num == sync_next_expected_num) {
                      ++sync_next_expected_num;
                   }
                }
-               if (blk_num >= sync_known_lib_num) {
+               if (blk_num >= sync_known_froot_num) {
                   peer_dlog(c, "received non-applied block ${bn} >= ${kn}, will send handshakes when caught up",
-                            ("bn", blk_num)("kn", sync_known_lib_num));
+                            ("bn", blk_num)("kn", sync_known_froot_num));
                   send_handshakes_when_synced = true;
                } else {
                   if (is_sync_request_ahead_allowed(blk_num)) {
@@ -2645,10 +2646,10 @@ namespace eosio {
       fc_dlog( logger, "expire_local_txns size ${s} removed ${r}", ("s", start_size)( "r", start_size - end_size ) );
    }
 
-   void dispatch_manager::expire_blocks( uint32_t lib_num ) {
+   void dispatch_manager::expire_blocks( uint32_t froot_num ) {
       fc::lock_guard g( blk_state_mtx );
       auto& stale_blk = blk_state.get<by_connection_id>();
-      stale_blk.erase( stale_blk.lower_bound( 1 ), stale_blk.upper_bound( lib_num ) );
+      stale_blk.erase( stale_blk.lower_bound( 1 ), stale_blk.upper_bound( froot_num ) );
    }
 
    // thread safe
@@ -2673,7 +2674,7 @@ namespace eosio {
 
          boost::asio::post(cp->strand, [cp, bnum, sb{std::move(sb)}]() {
             cp->latest_blk_time = std::chrono::steady_clock::now();
-            bool has_block = cp->peer_lib_num >= bnum;
+            bool has_block = cp->peer_froot_num >= bnum;
             if( !has_block ) {
                peer_dlog( cp, "bcast block ${b}", ("b", bnum) );
                cp->enqueue_buffer( sb, no_reason );
@@ -3030,14 +3031,14 @@ namespace eosio {
                  ("num", bh.block_num())("id", blk_id.str().substr(8,16))("l", age.count()/1000)
                  ("h", my_impl->get_chain_head_num())("f", my_impl->get_fork_head_num()));
       if( !my_impl->sync_master->syncing_from_peer() ) { // guard against peer thinking it needs to send us old blocks
-         uint32_t lib_num = my_impl->get_chain_lib_num();
-         if( blk_num <= lib_num ) {
+         uint32_t froot_num = my_impl->get_fork_root_num();
+         if( blk_num <= froot_num ) {
             fc::unique_lock g( conn_mtx );
-            const auto last_sent_lib = last_handshake_sent.last_irreversible_block_num;
+            const auto last_sent_fork_root_num = last_handshake_sent.fork_root_num;
             g.unlock();
-            peer_ilog( this, "received block ${n} less than ${which}lib ${lib}",
-                       ("n", blk_num)("which", blk_num < last_sent_lib ? "sent " : "")
-                       ("lib", blk_num < last_sent_lib ? last_sent_lib : lib_num) );
+            peer_ilog( this, "received block ${n} less than ${which}froot ${fr}",
+                       ("n", blk_num)("which", blk_num < last_sent_fork_root_num ? "sent " : "")
+                       ("fr", blk_num < last_sent_fork_root_num ? last_sent_fork_root_num : froot_num) );
             enqueue( (sync_request_message) {0, 0} );
             send_handshake();
             cancel_sync_wait();
@@ -3047,10 +3048,10 @@ namespace eosio {
          }
       } else {
          block_sync_bytes_received += message_length;
-         uint32_t lib_num = my_impl->get_chain_lib_num();
+         uint32_t froot_num = my_impl->get_fork_root_num();
          my_impl->sync_master->sync_recv_block(shared_from_this(), blk_id, blk_num, age);
-         if( blk_num <= lib_num ) {
-            peer_dlog( this, "received block ${n} less than lib ${lib} while syncing", ("n", blk_num)("lib", lib_num) );
+         if( blk_num <= froot_num ) {
+            peer_dlog( this, "received block ${n} less than froot ${fr} while syncing", ("n", blk_num)("fr", froot_num) );
             pending_message_buffer.advance_read_ptr( message_length );
             return true;
          }
@@ -3158,33 +3159,33 @@ namespace eosio {
    // call only from main application thread
    void net_plugin_impl::update_chain_info() {
       controller& cc = chain_plug->chain();
-      uint32_t lib_num = 0, head_num = 0, fork_head_num = 0;
+      uint32_t froot_num = 0, head_num = 0, fork_head_num = 0;
       {
          fc::lock_guard g( chain_info_mtx );
-         chain_info.lib_id = cc.last_irreversible_block_id();
-         chain_info.lib_num = lib_num = block_header::num_from_id(chain_info.lib_id);
+         chain_info.fork_root_id = cc.fork_db_root_block_id();
+         chain_info.fork_root_num = froot_num = block_header::num_from_id(chain_info.fork_root_id);
          chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
          chain_info.fork_head_id = cc.fork_db_head().id();
          chain_info.fork_head_num = fork_head_num = block_header::num_from_id(chain_info.fork_head_id);
       }
-      fc_dlog( logger, "updating chain info lib ${lib}, head ${h} fhead ${f}", ("lib", lib_num)("h", head_num)("f", fork_head_num) );
+      fc_dlog( logger, "updating chain info froot ${fr} head ${h} fhead ${f}", ("fr", froot_num)("h", head_num)("f", fork_head_num) );
    }
 
    // call only from main application thread
-   void net_plugin_impl::update_chain_info(const block_id_type& lib) {
+   void net_plugin_impl::update_chain_info(const block_id_type& froot_id) {
       controller& cc = chain_plug->chain();
-      uint32_t lib_num = 0, head_num = 0, fork_head_num = 0;
+      uint32_t froot_num = 0, head_num = 0, fork_head_num = 0;
       {
          fc::lock_guard g( chain_info_mtx );
-         chain_info.lib_id = lib;
-         chain_info.lib_num = lib_num = block_header::num_from_id(lib);
+         chain_info.fork_root_id = froot_id;
+         chain_info.fork_root_num = froot_num = block_header::num_from_id(froot_id);
          chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
          chain_info.fork_head_id = cc.fork_db_head().id();
          chain_info.fork_head_num = fork_head_num = block_header::num_from_id(chain_info.fork_head_id);
       }
-      fc_dlog( logger, "updating chain info lib ${lib}, head ${h} fhead ${f}", ("lib", lib_num)("h", head_num)("f", fork_head_num) );
+      fc_dlog( logger, "updating chain info froot ${fr} head ${h} fhead ${f}", ("fr", froot_num)("h", head_num)("f", fork_head_num) );
    }
 
 
@@ -3193,9 +3194,9 @@ namespace eosio {
       return chain_info;
    }
 
-   uint32_t net_plugin_impl::get_chain_lib_num() const {
+   uint32_t net_plugin_impl::get_fork_root_num() const {
       fc::lock_guard g( chain_info_mtx );
-      return chain_info.lib_num;
+      return chain_info.fork_root_num;
    }
 
    uint32_t net_plugin_impl::get_chain_head_num() const {
@@ -3213,9 +3214,9 @@ namespace eosio {
       // that really aren't handshake messages can be quickly discarded without
       // affecting state.
       bool valid = true;
-      if (msg.last_irreversible_block_num > msg.fork_head_num) {
+      if (msg.fork_root_num > msg.fork_head_num) {
          peer_wlog( this, "Handshake message validation: last irreversible (${i}) is greater than fhead (${h})",
-                  ("i", msg.last_irreversible_block_num)("h", msg.fork_head_num) );
+                  ("i", msg.fork_root_num)("h", msg.fork_head_num) );
          valid = false;
       }
       if (msg.p2p_address.empty()) {
@@ -3259,10 +3260,10 @@ namespace eosio {
          enqueue( go_away_message( fatal_other ) );
          return;
       }
-      peer_dlog( this, "received handshake gen ${g}, lib ${lib}, fhead ${head}",
-                 ("g", msg.generation)("lib", msg.last_irreversible_block_num)("head", msg.fork_head_num) );
+      peer_dlog( this, "received handshake gen ${g}, froot ${fr}, fhead ${fh}",
+                 ("g", msg.generation)("fr", msg.fork_root_num)("fh", msg.fork_head_num) );
 
-      peer_lib_num = msg.last_irreversible_block_num;
+      peer_froot_num = msg.fork_root_num;
       peer_fork_head_block_num = msg.fork_head_num;
       fc::unique_lock g_conn( conn_mtx );
       last_handshake_recv = msg;
@@ -3374,25 +3375,25 @@ namespace eosio {
             return;
          }
 
-         uint32_t peer_lib = msg.last_irreversible_block_num;
-         uint32_t lib_num = my_impl->get_chain_lib_num();
+         uint32_t peer_froot_num = msg.fork_root_num;
+         uint32_t froot_num = my_impl->get_fork_root_num();
 
-         peer_dlog( this, "handshake check lib_num = ${ln}, peer_lib = ${pl}", ("ln", lib_num)("pl", peer_lib) );
+         peer_dlog( this, "handshake check froot ${n}, peer_froot ${pn}", ("n", froot_num)("pn", peer_froot_num) );
 
-         if( peer_lib <= lib_num && peer_lib > 0 ) {
+         if( peer_froot_num <= froot_num && peer_froot_num > 0 ) {
             try {
                controller& cc = my_impl->chain_plug->chain();
-               std::optional<block_id_type> peer_lib_id = cc.fork_block_id_for_num( peer_lib ); // thread-safe
-               if (!peer_lib_id) {
+               std::optional<block_id_type> peer_froot_id = cc.fork_block_id_for_num( peer_froot_num ); // thread-safe
+               if (!peer_froot_id) {
                   // can be not found if running with a truncated block log
-                  peer_dlog( this, "peer last irreversible block ${pl} is unknown", ("pl", peer_lib) );
-               } else if (msg.last_irreversible_block_id != peer_lib_id) {
+                  peer_dlog( this, "peer froot block ${n} is unknown", ("n", peer_froot_num) );
+               } else if (msg.fork_root_id != peer_froot_id) {
                   peer_wlog( this, "Peer chain is forked, sending: forked go away" );
                   no_retry = go_away_reason::forked;
                   enqueue( go_away_message( go_away_reason::forked ) );
                }
             } catch( ... ) {
-               peer_wlog( this, "caught an exception getting block id for ${pl}", ("pl", peer_lib) );
+               peer_wlog( this, "caught an exception getting block id for ${pl}", ("pl", peer_froot_num) );
             }
          }
 
@@ -3695,10 +3696,10 @@ namespace eosio {
       my_impl->dispatcher.strand.post([id, c{shared_from_this()}, ptr{std::move(ptr)}, cid=connection_id]() mutable {
          controller& cc = my_impl->chain_plug->chain();
 
-         auto lib_num = my_impl->get_chain_lib_num();
+         auto froot_num = my_impl->get_fork_root_num();
 
          // may have come in on a different connection and posted into dispatcher strand before this one
-         if( block_header::num_from_id(id) <= lib_num || my_impl->dispatcher.have_block( id ) || cc.block_exists( id ) ) { // thread-safe
+         if( block_header::num_from_id(id) <= froot_num || my_impl->dispatcher.have_block( id ) || cc.block_exists( id ) ) { // thread-safe
             my_impl->dispatcher.add_peer_block( id, c->connection_id );
             boost::asio::post(c->strand, [c, id, ptr{std::move(ptr)}]() {
                const fc::microseconds age(fc::time_point::now() - ptr->timestamp);
@@ -3834,8 +3835,8 @@ namespace eosio {
 
    void net_plugin_impl::expire() {
       auto now = time_point::now();
-      uint32_t lib_num = get_chain_lib_num();
-      dispatcher.expire_blocks( lib_num );
+      uint32_t froot_num = get_fork_root_num();
+      dispatcher.expire_blocks( froot_num );
       dispatcher.expire_txns();
       fc_dlog( logger, "expire_txns ${n}us", ("n", time_point::now() - now) );
 
@@ -4033,8 +4034,8 @@ namespace eosio {
       if (chain_info.fork_head_id == hello.fork_head_id && (hello.time + hs_delay > now))
          return false;
       hello.network_version = net_version_base + net_version;
-      hello.last_irreversible_block_num = chain_info.lib_num;
-      hello.last_irreversible_block_id = chain_info.lib_id;
+      hello.fork_root_num = chain_info.fork_root_num;
+      hello.fork_root_id = chain_info.fork_root_id;
       hello.fork_head_num = chain_info.fork_head_num;
       hello.fork_head_id = chain_info.fork_head_id;
       hello.chain_id = my_impl->chain_id;
@@ -4165,7 +4166,7 @@ namespace eosio {
                      "p2p-keepalive_interval-ms must be greater than 0" );
 
          // To avoid unnecessary transitions between LIB <-> head catchups,
-         // min_blocks_distance between LIB and head must be reached.
+         // min_blocks_distance between froot and head must be reached.
          // Set it to the number of blocks produced during half of keep alive
          // interval.
          const uint32_t min_blocks_distance = (keepalive_interval.count() / config::block_interval_ms) / 2;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2236,13 +2236,13 @@ namespace eosio {
       sync_reset_froot_num(c, false);
 
       //--------------------------------
-      // sync need checks; (lib == fork database root)
+      // sync need checks; (froot == fork database root)
       //
       // 0. my head block id == peer head id means we are all caught up block wise
-      // 1. my head block num < peer lib - start sync locally
-      // 2. my lib > peer head num + nblk_combined_latency - send last_irr_catch_up notice if not the first generation
+      // 1. my head block num < peer froot then start sync locally by sending handshake
+      // 2. my froot > peer head num + nblk_combined_latency then send last_irr_catch_up notice if not the first generation
       //
-      // 3  my head block num + nblk_combined_latency < peer head block num - update sync state and send a catchup request
+      // 3  my head block num + nblk_combined_latency < peer head block num then update sync state and send a catchup request
       // 4  my head block num >= peer block num + nblk_combined_latency send a notice catchup if this is not the first generation
       //    4.1 if peer appears to be on a different fork ( our_id_for( msg.head_num ) != msg.head_id )
       //        then request peer's blocks

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3162,7 +3162,7 @@ namespace eosio {
       uint32_t froot_num = 0, head_num = 0, fork_head_num = 0;
       {
          fc::lock_guard g( chain_info_mtx );
-         chain_info.fork_root_id = cc.fork_db_root_block_id();
+         chain_info.fork_root_id = cc.fork_db_root().id();
          chain_info.fork_root_num = froot_num = block_header::num_from_id(chain_info.fork_root_id);
          chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -145,10 +145,10 @@ namespace eosio {
 
       alignas(hardware_destructive_interference_sz)
       fc::mutex      sync_mtx;
-      uint32_t       sync_known_fork_root_num GUARDED_BY(sync_mtx) {0};  // highest known fork_db root num from currently connected peers
-      uint32_t       sync_last_requested_num  GUARDED_BY(sync_mtx) {0};  // end block number of the last requested range, inclusive
-      uint32_t       sync_next_expected_num   GUARDED_BY(sync_mtx) {0};  // the next block number we need from peer
-      connection_ptr sync_source              GUARDED_BY(sync_mtx);      // connection we are currently syncing from
+      uint32_t       sync_known_fork_db_root_num GUARDED_BY(sync_mtx) {0};  // highest known fork_db root num from currently connected peers
+      uint32_t       sync_last_requested_num     GUARDED_BY(sync_mtx) {0};  // end block number of the last requested range, inclusive
+      uint32_t       sync_next_expected_num      GUARDED_BY(sync_mtx) {0};  // the next block number we need from peer
+      connection_ptr sync_source                 GUARDED_BY(sync_mtx);      // connection we are currently syncing from
 
       const uint32_t sync_fetch_span {0};
       const uint32_t sync_peer_limit {0};
@@ -162,16 +162,16 @@ namespace eosio {
       // applied the blocks and our controller head is updated
       std::atomic<bool> send_handshakes_when_synced{false};
 
-      // Instant finality makes it likely peers think their fork_root and head are
+      // Instant finality makes it likely peers think their fork_db_root and head are
       // not in sync but in reality they are only within small difference.
       // To avoid unnecessary catchups, a margin of min_blocks_distance
-      // between fork_root and head must be reached before catchup starts.
+      // between fork_db_root and head must be reached before catchup starts.
       const uint32_t min_blocks_distance{0};
 
    private:
       constexpr static auto stage_str( stages s );
       bool set_state( stages newstate );
-      bool is_sync_required( uint32_t fork_head_block_num ) const REQUIRES(sync_mtx);
+      bool is_sync_required( uint32_t fork_db_head_block_num ) const REQUIRES(sync_mtx);
       bool is_sync_request_ahead_allowed(block_num_type blk_num) const REQUIRES(sync_mtx);
       void request_next_chunk( const connection_ptr& conn = connection_ptr() ) REQUIRES(sync_mtx);
       connection_ptr find_next_sync_node(); // call with locked mutex
@@ -187,7 +187,7 @@ namespace eosio {
       static void send_handshakes();
       bool syncing_from_peer() const { return sync_state == lib_catchup; }
       bool is_in_sync() const { return sync_state == in_sync; }
-      void sync_reset_fork_root_num( const connection_ptr& conn, bool closing );
+      void sync_reset_fork_db_root_num( const connection_ptr& conn, bool closing );
       void sync_timeout(const connection_ptr& c, const boost::system::error_code& ec);
       void sync_wait(const connection_ptr& c);
       void sync_reassign_fetch( const connection_ptr& c );
@@ -218,7 +218,7 @@ namespace eosio {
       void rejected_transaction(const packed_transaction_ptr& trx);
       void bcast_block( const signed_block_ptr& b, const block_id_type& id );
 
-      void expire_blocks( uint32_t fork_root_num );
+      void expire_blocks( uint32_t fork_db_root_num );
       void recv_notice(const connection_ptr& conn, const notice_message& msg, bool generated);
 
       bool add_peer_block( const block_id_type& blkid, uint32_t connection_id );
@@ -420,12 +420,12 @@ namespace eosio {
 
 
       struct chain_info_t {
-         block_id_type fork_root_id;
-         uint32_t      fork_root_num = 0;
+         block_id_type fork_db_root_id;
+         uint32_t      fork_db_root_num = 0;
          block_id_type head_id;
          uint32_t      head_num = 0;
-         block_id_type fork_head_id;
-         uint32_t      fork_head_num = 0;
+         block_id_type fork_db_head_id;
+         uint32_t      fork_db_head_num = 0;
       };
 
       
@@ -439,11 +439,11 @@ namespace eosio {
 
    public:
       void update_chain_info();
-      void update_chain_info(const block_id_type& fork_root_id);
+      void update_chain_info(const block_id_type& fork_db_root_id);
       chain_info_t get_chain_info() const;
-      uint32_t get_fork_root_num() const;
+      uint32_t get_fork_db_root_num() const;
       uint32_t get_chain_head_num() const;
-      uint32_t get_fork_head_num() const;
+      uint32_t get_fork_db_head_num() const;
 
       void on_accepted_block_header( const signed_block_ptr& block, const block_id_type& id );
       void on_accepted_block( const signed_block_ptr& block, const block_id_type& id );
@@ -771,7 +771,7 @@ namespace eosio {
       bool is_transactions_connection() const { return connection_type != blocks_only; } // thread safe, atomic
       bool is_blocks_connection() const { return connection_type != transactions_only; } // thread safe, atomic
       uint32_t get_peer_start_block_num() const { return peer_start_block_num.load(); }
-      uint32_t get_peer_fork_head_block_num() const { return peer_fork_head_block_num.load(); }
+      uint32_t get_peer_fork_db_head_block_num() const { return peer_fork_db_head_block_num.load(); }
       uint32_t get_last_received_block_num() const { return last_received_block_num.load(); }
       uint32_t get_unique_blocks_rcvd_count() const { return unique_blocks_rcvd_count.load(); }
       size_t get_bytes_received() const { return bytes_received.load(); }
@@ -811,7 +811,7 @@ namespace eosio {
 
       std::atomic<connection_types>   connection_type{both};
       std::atomic<uint32_t>           peer_start_block_num{0};
-      std::atomic<uint32_t>           peer_fork_head_block_num{0};
+      std::atomic<uint32_t>           peer_fork_db_head_block_num{0};
       std::atomic<uint32_t>           last_received_block_num{0};
       std::atomic<uint32_t>           unique_blocks_rcvd_count{0};
       std::atomic<size_t>             bytes_received{0};
@@ -842,8 +842,8 @@ namespace eosio {
       string                  log_remote_endpoint_port;
       string                  local_endpoint_ip;
       string                  local_endpoint_port;
-      // kept in sync with last_handshake_recv.fork_root_num, only accessed from connection strand
-      uint32_t                peer_fork_root_num = 0;
+      // kept in sync with last_handshake_recv.fork_db_root_num, only accessed from connection strand
+      uint32_t                peer_fork_db_root_num = 0;
 
       std::atomic<uint32_t>   sync_ordinal{0};
       // when syncing from a peer, the last block expected of the current range
@@ -875,14 +875,14 @@ namespace eosio {
 
       alignas(hardware_destructive_interference_sz)
       mutable fc::mutex                conn_mtx; //< mtx for last_handshake_recv .. remote_endpoint_ip
-      handshake_message                last_handshake_recv GUARDED_BY(conn_mtx);
-      handshake_message                last_handshake_sent GUARDED_BY(conn_mtx);
-      block_id_type                    conn_fork_head      GUARDED_BY(conn_mtx);
-      uint32_t                         conn_fork_head_num  GUARDED_BY(conn_mtx) {0};
-      fc::time_point                   last_close          GUARDED_BY(conn_mtx);
-      std::string                      p2p_address         GUARDED_BY(conn_mtx);
-      std::string                      unique_conn_node_id GUARDED_BY(conn_mtx);
-      std::string                      remote_endpoint_ip  GUARDED_BY(conn_mtx);
+      handshake_message                last_handshake_recv    GUARDED_BY(conn_mtx);
+      handshake_message                last_handshake_sent    GUARDED_BY(conn_mtx);
+      block_id_type                    conn_fork_db_head      GUARDED_BY(conn_mtx);
+      uint32_t                         conn_fork_db_head_num  GUARDED_BY(conn_mtx) {0};
+      fc::time_point                   last_close             GUARDED_BY(conn_mtx);
+      std::string                      p2p_address            GUARDED_BY(conn_mtx);
+      std::string                      unique_conn_node_id    GUARDED_BY(conn_mtx);
+      std::string                      remote_endpoint_ip     GUARDED_BY(conn_mtx);
       boost::asio::ip::address_v6::bytes_type remote_endpoint_ip_array GUARDED_BY(conn_mtx);
 
       std::chrono::nanoseconds         connection_start_time{0};
@@ -907,7 +907,7 @@ namespace eosio {
       bool connected() const;
       bool closed() const; // socket is not open or is closed or closing, thread safe
       bool current() const;
-      bool should_sync_from(uint32_t sync_next_expected_num, uint32_t sync_known_fork_root_num, uint32_t sync_fetch_span) const;
+      bool should_sync_from(uint32_t sync_next_expected_num, uint32_t sync_known_fork_db_root_num, uint32_t sync_fetch_span) const;
 
       /// @param reconnect true if we should try and reconnect immediately after close
       /// @param shutdown true only if plugin is shutting down
@@ -967,7 +967,7 @@ namespace eosio {
       /** @} */
 
       void blk_send_branch( const block_id_type& msg_head_id );
-      void blk_send_branch( uint32_t msg_head_num, uint32_t fork_root_num, uint32_t head_num );
+      void blk_send_branch( uint32_t msg_head_num, uint32_t fork_db_root_num, uint32_t head_num );
 
       void enqueue( const net_message &msg );
       size_t enqueue_block( const std::vector<char>& sb, uint32_t block_num, bool to_sync_queue = false);
@@ -1331,16 +1331,16 @@ namespace eosio {
    }
 
    // thread safe
-   bool connection::should_sync_from(uint32_t sync_next_expected_num, uint32_t sync_known_fork_root_num, uint32_t sync_fetch_span) const {
+   bool connection::should_sync_from(uint32_t sync_next_expected_num, uint32_t sync_known_fork_db_root_num, uint32_t sync_fetch_span) const {
       fc_dlog(logger, "id: ${id} blocks conn: ${t} current: ${c} socket_open: ${so} syncing from us: ${s} state: ${con} peer_start_block: ${sb} peer_fhead: ${h} ping: ${p}us no_retry: ${g}",
               ("id", connection_id)("t", is_blocks_connection())
               ("c", current())("so", socket_is_open())("s", peer_syncing_from_us.load())("con", state_str(state()))
-              ("sb", peer_start_block_num.load())("h", peer_fork_head_block_num.load())("p", get_peer_ping_time_ns()/1000)("g", reason_str(no_retry)));
+              ("sb", peer_start_block_num.load())("h", peer_fork_db_head_block_num.load())("p", get_peer_ping_time_ns()/1000)("g", reason_str(no_retry)));
       if (is_blocks_connection() && current()) {
          if (no_retry == go_away_reason::no_reason) {
             if (peer_start_block_num <= sync_next_expected_num) { // has blocks we want
-               auto needed_end = std::min(sync_next_expected_num + sync_fetch_span, sync_known_fork_root_num);
-               if (peer_fork_head_block_num >= needed_end) { // has blocks
+               auto needed_end = std::min(sync_next_expected_num + sync_fetch_span, sync_known_fork_db_root_num);
+               if (peer_fork_db_head_block_num >= needed_end) { // has blocks
                   return true;
                }
             }
@@ -1382,11 +1382,11 @@ namespace eosio {
          last_close = fc::time_point::now();
          conn_node_id = fc::sha256();
       }
-      peer_fork_root_num = 0;
+      peer_fork_db_root_num = 0;
       peer_ping_time_ns = std::numeric_limits<decltype(peer_ping_time_ns)::value_type>::max();
       peer_requested.reset();
       sent_handshake_count = 0;
-      if( !shutdown) my_impl->sync_master->sync_reset_fork_root_num( shared_from_this(), true );
+      if( !shutdown) my_impl->sync_master->sync_reset_fork_db_root_num( shared_from_this(), true );
       cancel_sync_wait();
       sync_last_requested_block = 0;
       org = std::chrono::nanoseconds{0};
@@ -1422,11 +1422,11 @@ namespace eosio {
          fc::unique_lock g_conn( conn_mtx );
          if( last_handshake_recv.generation >= 1 ) {
             peer_dlog( this, "maybe truncating branch at = ${h}:${id}",
-                       ("h", block_header::num_from_id(last_handshake_recv.fork_head_id))("id", last_handshake_recv.fork_head_id) );
+                       ("h", block_header::num_from_id(last_handshake_recv.fork_db_head_id))("id", last_handshake_recv.fork_db_head_id) );
          }
       }
-      const auto fork_root_num = peer_fork_root_num;
-      if( fork_root_num == 0 ) return; // if fork_root_id is null (we have not received handshake or reset)
+      const auto fork_db_root_num = peer_fork_db_root_num;
+      if( fork_db_root_num == 0 ) return; // if fork_db_root_id is null (we have not received handshake or reset)
 
       auto msg_head_num = block_header::num_from_id(msg_head_id);
       bool on_fork = msg_head_num == 0;
@@ -1447,18 +1447,18 @@ namespace eosio {
          enqueue( go_away_message( benign_other ) );
       } else {
          if( on_fork ) msg_head_num = 0;
-         // if peer on fork, start at their last fork_root_num, otherwise we can start at msg_head+1
-         blk_send_branch( msg_head_num, fork_root_num, head_num );
+         // if peer on fork, start at their last fork_db_root_num, otherwise we can start at msg_head+1
+         blk_send_branch( msg_head_num, fork_db_root_num, head_num );
       }
    }
 
    // called from connection strand
-   void connection::blk_send_branch( uint32_t msg_head_num, uint32_t fork_root_num, uint32_t head_num ) {
+   void connection::blk_send_branch( uint32_t msg_head_num, uint32_t fork_db_root_num, uint32_t head_num ) {
       if( !peer_requested ) {
-         auto last = msg_head_num != 0 ? msg_head_num : fork_root_num;
+         auto last = msg_head_num != 0 ? msg_head_num : fork_db_root_num;
          peer_requested = peer_sync_state( last+1, head_num, last );
       } else {
-         auto last = msg_head_num != 0 ? msg_head_num : std::min( peer_requested->last, fork_root_num );
+         auto last = msg_head_num != 0 ? msg_head_num : std::min( peer_requested->last, fork_db_root_num );
          uint32_t end   = std::max( peer_requested->end_block, head_num );
          peer_requested = peer_sync_state( last+1, end, last );
       }
@@ -1484,8 +1484,8 @@ namespace eosio {
             g_conn.unlock();
             peer_dlog( c, "Sending handshake generation ${g}, froot ${r}, fhead ${h}, id ${id}",
                        ("g", last_handshake.generation)
-                       ("r", last_handshake.fork_root_num)
-                       ("h", last_handshake.fork_head_num)("id", last_handshake.fork_head_id.str().substr(8,16)) );
+                       ("r", last_handshake.fork_db_root_num)
+                       ("h", last_handshake.fork_db_head_num)("id", last_handshake.fork_db_head_id.str().substr(8,16)) );
             c->enqueue( last_handshake );
          }
       });
@@ -1912,7 +1912,7 @@ namespace eosio {
    //-----------------------------------------------------------
 
     sync_manager::sync_manager( uint32_t span, uint32_t sync_peer_limit, uint32_t min_blocks_distance )
-      :sync_known_fork_root_num( 0 )
+      :sync_known_fork_db_root_num( 0 )
       ,sync_last_requested_num( 0 )
       ,sync_next_expected_num( 1 )
       ,sync_source()
@@ -1942,34 +1942,34 @@ namespace eosio {
    }
 
    // called from c's connection strand
-   void sync_manager::sync_reset_fork_root_num(const connection_ptr& c, bool closing) {
+   void sync_manager::sync_reset_fork_db_root_num(const connection_ptr& c, bool closing) {
       fc::unique_lock g( sync_mtx );
       if( sync_state == in_sync ) {
          sync_source.reset();
       }
       if( !c ) return;
       if( !closing ) {
-         if( c->peer_fork_root_num > sync_known_fork_root_num ) {
-            sync_known_fork_root_num = c->peer_fork_root_num;
+         if( c->peer_fork_db_root_num > sync_known_fork_db_root_num ) {
+            sync_known_fork_db_root_num = c->peer_fork_db_root_num;
          }
       } else {
-         // Closing connection, therefore its view of fork_root can no longer be considered as we will no longer be connected.
-         // Determine current fork_root of remaining peers as our sync_known_fork_root_num.
-         uint32_t highest_fork_root_num = 0;
-         my_impl->connections.for_each_block_connection( [&highest_fork_root_num]( const auto& cc ) {
+         // Closing connection, therefore its view of fork_db_root can no longer be considered as we will no longer be connected.
+         // Determine current fork_db_root of remaining peers as our sync_known_fork_db_root_num.
+         uint32_t highest_fork_db_root_num = 0;
+         my_impl->connections.for_each_block_connection( [&highest_fork_db_root_num]( const auto& cc ) {
             fc::lock_guard g_conn( cc->conn_mtx );
-            if( cc->current() && cc->last_handshake_recv.fork_root_num > highest_fork_root_num ) {
-               highest_fork_root_num = cc->last_handshake_recv.fork_root_num;
+            if( cc->current() && cc->last_handshake_recv.fork_db_root_num > highest_fork_db_root_num ) {
+               highest_fork_db_root_num = cc->last_handshake_recv.fork_db_root_num;
             }
          } );
-         sync_known_fork_root_num = highest_fork_root_num;
+         sync_known_fork_db_root_num = highest_fork_db_root_num;
 
          // if closing the connection we are currently syncing from then request from a diff peer
          if( c == sync_source ) {
-            // if starting to sync need to always start from fork_root as we might be on our own fork
-            uint32_t fork_root_num = my_impl->get_fork_root_num();
+            // if starting to sync need to always start from fork_db_root as we might be on our own fork
+            uint32_t fork_db_root_num = my_impl->get_fork_db_root_num();
             sync_last_requested_num = 0;
-            sync_next_expected_num = std::max( fork_root_num + 1, sync_next_expected_num );
+            sync_next_expected_num = std::max( fork_db_root_num + 1, sync_next_expected_num );
             sync_source.reset();
             request_next_chunk();
          }
@@ -1977,11 +1977,11 @@ namespace eosio {
    }
 
    connection_ptr sync_manager::find_next_sync_node() REQUIRES(sync_mtx) {
-      fc_dlog(logger, "Number connections ${s}, sync_next_expected_num: ${e}, sync_known_fork_root_num: ${l}",
-              ("s", my_impl->connections.number_connections())("e", sync_next_expected_num)("l", sync_known_fork_root_num));
+      fc_dlog(logger, "Number connections ${s}, sync_next_expected_num: ${e}, sync_known_fork_db_root_num: ${l}",
+              ("s", my_impl->connections.number_connections())("e", sync_next_expected_num)("l", sync_known_fork_db_root_num));
       deque<connection_ptr> conns;
       my_impl->connections.for_each_block_connection([sync_next_expected_num = sync_next_expected_num,
-                                                      sync_known_froot_num = sync_known_fork_root_num,
+                                                      sync_known_froot_num = sync_known_fork_db_root_num,
                                                       sync_fetch_span = sync_fetch_span,
                                                       &conns](const auto& c) {
          if (c->should_sync_from(sync_next_expected_num, sync_known_froot_num, sync_fetch_span)) {
@@ -2031,13 +2031,13 @@ namespace eosio {
    void sync_manager::request_next_chunk( const connection_ptr& conn ) REQUIRES(sync_mtx) {
       auto chain_info = my_impl->get_chain_info();
 
-      fc_dlog( logger, "sync_last_requested_num: ${r}, sync_next_expected_num: ${e}, sync_known_fork_root_num: ${k}, sync-fetch-span: ${s}, fhead: ${h}, froot: ${fr}",
-               ("r", sync_last_requested_num)("e", sync_next_expected_num)("k", sync_known_fork_root_num)("s", sync_fetch_span)("h", chain_info.fork_head_num)("fr", chain_info.fork_root_num) );
+      fc_dlog( logger, "sync_last_requested_num: ${r}, sync_next_expected_num: ${e}, sync_known_fork_db_root_num: ${k}, sync-fetch-span: ${s}, fhead: ${h}, froot: ${fr}",
+               ("r", sync_last_requested_num)("e", sync_next_expected_num)("k", sync_known_fork_db_root_num)("s", sync_fetch_span)("h", chain_info.fork_db_head_num)("fr", chain_info.fork_db_root_num) );
 
       if (conn) {
          // p2p_high_latency_test.py test depends on this exact log statement.
          peer_ilog(conn, "Catching up with chain, our last req is ${cc}, theirs is ${t}, next expected ${n}, fhead ${h}",
-                   ("cc", sync_last_requested_num)("t", sync_known_fork_root_num)("n", sync_next_expected_num)("h", chain_info.fork_head_num));
+                   ("cc", sync_last_requested_num)("t", sync_known_fork_db_root_num)("n", sync_next_expected_num)("h", chain_info.fork_db_head_num));
       }
 
       /* ----------
@@ -2049,9 +2049,9 @@ namespace eosio {
 
       auto reset_on_failure = [&]() REQUIRES(sync_mtx) {
          sync_source.reset();
-         sync_known_fork_root_num = chain_info.fork_root_num;
+         sync_known_fork_db_root_num = chain_info.fork_db_root_num;
          sync_last_requested_num = 0;
-         sync_next_expected_num = std::max( sync_known_fork_root_num + 1, sync_next_expected_num );
+         sync_next_expected_num = std::max( sync_known_fork_db_root_num + 1, sync_next_expected_num );
          // not in sync, but need to be out of lib_catchup for start_sync to work
          set_state( in_sync );
          send_handshakes();
@@ -2065,18 +2065,18 @@ namespace eosio {
       }
 
       bool request_sent = false;
-      if( sync_last_requested_num != sync_known_fork_root_num ) {
+      if( sync_last_requested_num != sync_known_fork_db_root_num ) {
          uint32_t start = sync_next_expected_num;
          uint32_t end = start + sync_fetch_span - 1;
-         if( end > sync_known_fork_root_num )
-            end = sync_known_fork_root_num;
+         if( end > sync_known_fork_db_root_num )
+            end = sync_known_fork_db_root_num;
          if( end > 0 && end >= start ) {
             sync_last_requested_num = end;
             sync_source = new_sync_source;
             request_sent = true;
             sync_active_time = std::chrono::steady_clock::now();
-            boost::asio::post(new_sync_source->strand, [new_sync_source, start, end, fork_head_num=chain_info.fork_head_num, fork_root_num=chain_info.fork_root_num]() {
-               peer_ilog( new_sync_source, "requesting range ${s} to ${e}, fhead ${h}, froot ${r}", ("s", start)("e", end)("h", fork_head_num)("r", fork_root_num) );
+            boost::asio::post(new_sync_source->strand, [new_sync_source, start, end, fork_db_head_num=chain_info.fork_db_head_num, fork_db_root_num=chain_info.fork_db_root_num]() {
+               peer_ilog( new_sync_source, "requesting range ${s} to ${e}, fhead ${h}, froot ${r}", ("s", start)("e", end)("h", fork_db_head_num)("r", fork_db_root_num) );
                new_sync_source->request_sync_blocks( start, end );
             } );
          }
@@ -2096,18 +2096,18 @@ namespace eosio {
       } );
    }
 
-   bool sync_manager::is_sync_required( uint32_t fork_head_block_num ) const REQUIRES(sync_mtx) {
+   bool sync_manager::is_sync_required( uint32_t fork_db_head_block_num ) const REQUIRES(sync_mtx) {
       fc_dlog( logger, "last req = ${req}, last recv = ${recv} known = ${known} our fhead = ${h}",
-               ("req", sync_last_requested_num)( "recv", sync_next_expected_num-1 )( "known", sync_known_fork_root_num )
-               ("h", fork_head_block_num ) );
+               ("req", sync_last_requested_num)( "recv", sync_next_expected_num-1 )( "known", sync_known_fork_db_root_num )
+               ("h", fork_db_head_block_num ) );
 
-      return( sync_last_requested_num < sync_known_fork_root_num ||
+      return( sync_last_requested_num < sync_known_fork_db_root_num ||
               sync_next_expected_num < sync_last_requested_num );
    }
 
    // called from c's connection strand
    bool sync_manager::is_sync_request_ahead_allowed(block_num_type blk_num) const REQUIRES(sync_mtx) {
-      if (blk_num >= sync_last_requested_num && sync_last_requested_num < sync_known_fork_root_num) {
+      if (blk_num >= sync_last_requested_num && sync_last_requested_num < sync_known_fork_db_root_num) {
          // do not allow to get too far ahead (sync_fetch_span) of chain head
          // use chain head instead of fork head so we do not get too far ahead of applied blocks
          uint32_t head_num = my_impl->get_chain_head_num();
@@ -2146,14 +2146,14 @@ namespace eosio {
    // called from c's connection strand
    void sync_manager::start_sync(const connection_ptr& c, uint32_t target) {
       fc::unique_lock g_sync( sync_mtx );
-      if( target > sync_known_fork_root_num) {
-         sync_known_fork_root_num = target;
+      if( target > sync_known_fork_db_root_num) {
+         sync_known_fork_db_root_num = target;
       }
 
       auto chain_info = my_impl->get_chain_info();
-      if( !is_sync_required( chain_info.fork_head_num ) || target <= chain_info.fork_root_num ) {
+      if( !is_sync_required( chain_info.fork_db_head_num ) || target <= chain_info.fork_db_root_num ) {
          peer_dlog( c, "We are already caught up, my irr = ${b}, fhead = ${h}, target = ${t}",
-                  ("b", chain_info.fork_root_num)( "h", chain_info.fork_head_num )( "t", target ) );
+                  ("b", chain_info.fork_db_root_num)( "h", chain_info.fork_db_head_num )( "t", target ) );
          c->send_handshake(); // let peer know it is not syncing from us
          return;
       }
@@ -2164,7 +2164,7 @@ namespace eosio {
                    ("s", stage_str(current_sync_state))("nen", sync_next_expected_num));
          set_state( lib_catchup );
          sync_last_requested_num = 0;
-         sync_next_expected_num = chain_info.fork_root_num + 1;
+         sync_next_expected_num = chain_info.fork_db_root_num + 1;
          request_next_chunk( c );
       } else if (sync_last_requested_num > 0 && is_sync_request_ahead_allowed(sync_next_expected_num-1)) {
          request_next_chunk();
@@ -2211,9 +2211,9 @@ namespace eosio {
          peer_ilog(c, "reassign_fetch, our last req is ${cc}, next expected is ${ne}",
                    ("cc", sync_last_requested_num)("ne", sync_next_expected_num));
          c->cancel_sync();
-         auto fork_root_num = my_impl->get_fork_root_num();
+         auto fork_db_root_num = my_impl->get_fork_db_root_num();
          sync_last_requested_num = 0;
-         sync_next_expected_num = std::max(sync_next_expected_num, fork_root_num + 1);
+         sync_next_expected_num = std::max(sync_next_expected_num, fork_db_root_num + 1);
          sync_source.reset();
          request_next_chunk();
       }
@@ -2233,7 +2233,7 @@ namespace eosio {
 
       auto chain_info = my_impl->get_chain_info();
 
-      sync_reset_fork_root_num(c, false);
+      sync_reset_fork_db_root_num(c, false);
 
       //--------------------------------
       // sync need checks; (froot == fork database root)
@@ -2249,35 +2249,35 @@ namespace eosio {
       //
       //-----------------------------
 
-      if (chain_info.fork_head_id == msg.fork_head_id) {
+      if (chain_info.fork_db_head_id == msg.fork_db_head_id) {
          peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 0, fhead ${h}, froot ${r}",
-                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
+                    ("fr", msg.fork_db_root_num)("fh", msg.fork_db_head_num)("id", msg.fork_db_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_db_head_num)("r", chain_info.fork_db_root_num) );
          c->peer_syncing_from_us = false;
          return;
       }
-      if (chain_info.fork_head_num < msg.fork_root_num) {
+      if (chain_info.fork_db_head_num < msg.fork_db_root_num) {
          peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 1, fhead ${h}, froot ${r}",
-                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
+                    ("fr", msg.fork_db_root_num)("fh", msg.fork_db_head_num)("id", msg.fork_db_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_db_head_num)("r", chain_info.fork_db_root_num) );
          c->peer_syncing_from_us = false;
          if (c->sent_handshake_count > 0) {
             c->send_handshake();
          }
          return;
       }
-      if (chain_info.fork_root_num > msg.fork_head_num + nblk_combined_latency + min_blocks_distance) {
+      if (chain_info.fork_db_root_num > msg.fork_db_head_num + nblk_combined_latency + min_blocks_distance) {
          peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 2, fhead ${h}, froot ${r}",
-                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
+                    ("fr", msg.fork_db_root_num)("fh", msg.fork_db_head_num)("id", msg.fork_db_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_db_head_num)("r", chain_info.fork_db_root_num) );
          if (msg.generation > 1 || c->protocol_version > proto_base) {
             controller& cc = my_impl->chain_plug->chain();
             notice_message note;
-            note.known_trx.pending = chain_info.fork_root_num;
+            note.known_trx.pending = chain_info.fork_db_root_num;
             note.known_trx.mode = last_irr_catch_up;
             note.known_blocks.mode = last_irr_catch_up;
-            note.known_blocks.pending = chain_info.fork_head_num;
-            note.known_blocks.ids.push_back(chain_info.fork_head_id);
+            note.known_blocks.pending = chain_info.fork_db_head_num;
+            note.known_blocks.ids.push_back(chain_info.fork_db_head_id);
             if (c->protocol_version >= proto_block_range) {
                // begin, more efficient to encode a block num instead of retrieving actual block id
                note.known_blocks.ids.push_back(make_block_id(cc.earliest_available_block_num()));
@@ -2288,24 +2288,24 @@ namespace eosio {
          return;
       }
 
-      if (chain_info.fork_head_num + nblk_combined_latency < msg.fork_head_num ) {
+      if (chain_info.fork_db_head_num + nblk_combined_latency < msg.fork_db_head_num ) {
          peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 3, fhead ${h}, froot ${r}",
-                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
+                    ("fr", msg.fork_db_root_num)("fh", msg.fork_db_head_num)("id", msg.fork_db_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_db_head_num)("r", chain_info.fork_db_root_num) );
          c->peer_syncing_from_us = false;
-         verify_catchup(c, msg.fork_head_num, msg.fork_head_id);
+         verify_catchup(c, msg.fork_db_head_num, msg.fork_db_head_id);
          return;
-      } else if(chain_info.fork_head_num >= msg.fork_head_num + nblk_combined_latency) {
+      } else if(chain_info.fork_db_head_num >= msg.fork_db_head_num + nblk_combined_latency) {
          peer_dlog( c, "handshake msg.froot ${fr}, msg.fhead ${fh}, msg.id ${id}.. sync 4, fhead ${h}, froot ${r}",
-                    ("fr", msg.fork_root_num)("fh", msg.fork_head_num)("id", msg.fork_head_id.str().substr(8,16))
-                    ("h", chain_info.fork_head_num)("r", chain_info.fork_root_num) );
+                    ("fr", msg.fork_db_root_num)("fh", msg.fork_db_head_num)("id", msg.fork_db_head_id.str().substr(8,16))
+                    ("h", chain_info.fork_db_head_num)("r", chain_info.fork_db_root_num) );
          if (msg.generation > 1 ||  c->protocol_version > proto_base) {
             controller& cc = my_impl->chain_plug->chain();
             notice_message note;
             note.known_trx.mode = none;
             note.known_blocks.mode = catch_up;
-            note.known_blocks.pending = chain_info.fork_head_num;
-            note.known_blocks.ids.push_back(chain_info.fork_head_id);
+            note.known_blocks.pending = chain_info.fork_db_head_num;
+            note.known_blocks.ids.push_back(chain_info.fork_db_head_id);
             if (c->protocol_version >= proto_block_range) {
                // begin, more efficient to encode a block num instead of retrieving actual block id
                note.known_blocks.ids.push_back(make_block_id(cc.earliest_available_block_num()));
@@ -2315,10 +2315,10 @@ namespace eosio {
          c->peer_syncing_from_us = false;
          try {
             controller& cc = my_impl->chain_plug->chain();
-            std::optional<block_id_type> fork_head_id = cc.fork_block_id_for_num( msg.fork_head_num ); // thread-safe
-            if (fork_head_id && fork_head_id != msg.fork_head_id) { // possible for fork_root to move and fork_head_num not be found if running with no block-log
+            std::optional<block_id_type> fork_db_head_id = cc.fork_block_id_for_num( msg.fork_db_head_num ); // thread-safe
+            if (fork_db_head_id && fork_db_head_id != msg.fork_db_head_id) { // possible for fork_db_root to move and fork_db_head_num not be found if running with no block-log
                peer_dlog(c, "Sending catch_up request_message sync 4, fhead ${fh} != msg.fhead ${mfh}",
-                         ("fh", *fork_head_id)("mfh", msg.fork_head_id));
+                         ("fh", *fork_db_head_id)("mfh", msg.fork_db_head_id));
                request_message req;
                req.req_blocks.mode = catch_up;
                req.req_trx.mode = none;
@@ -2336,15 +2336,15 @@ namespace eosio {
    bool sync_manager::verify_catchup(const connection_ptr& c, uint32_t num, const block_id_type& id) {
       request_message req;
       req.req_blocks.mode = catch_up;
-      auto is_fork_head_greater = [num, &id, &req]( const auto& cc ) {
+      auto is_fork_db_head_greater = [num, &id, &req]( const auto& cc ) {
          fc::lock_guard g_conn( cc->conn_mtx );
-         if( cc->conn_fork_head_num > num || cc->conn_fork_head == id ) {
+         if( cc->conn_fork_db_head_num > num || cc->conn_fork_db_head == id ) {
             req.req_blocks.mode = none;
             return true;
          }
          return false;
       };
-      if (my_impl->connections.any_of_block_connections(is_fork_head_greater)) {
+      if (my_impl->connections.any_of_block_connections(is_fork_db_head_greater)) {
          req.req_blocks.mode = none;
       }
       if( req.req_blocks.mode == catch_up ) {
@@ -2352,28 +2352,28 @@ namespace eosio {
             fc::lock_guard g( sync_mtx );
             peer_ilog( c, "catch_up while in ${s}, fhead = ${hn} "
                           "target froot = ${fr} next_expected = ${ne}, id ${id}...",
-                     ("s", stage_str( sync_state ))("hn", num)("fr", sync_known_fork_root_num)
+                     ("s", stage_str( sync_state ))("hn", num)("fr", sync_known_fork_db_root_num)
                      ("ne", sync_next_expected_num)("id", id.str().substr( 8, 16 )) );
          }
          auto chain_info = my_impl->get_chain_info();
-         if( sync_state == lib_catchup || num < chain_info.fork_root_num ) {
+         if( sync_state == lib_catchup || num < chain_info.fork_db_root_num ) {
             c->send_handshake();
             return false;
          }
          set_state( head_catchup );
          {
             fc::lock_guard g_conn( c->conn_mtx );
-            c->conn_fork_head = id;
-            c->conn_fork_head_num = num;
+            c->conn_fork_db_head = id;
+            c->conn_fork_db_head_num = num;
          }
 
-         req.req_blocks.ids.emplace_back( chain_info.fork_head_id );
+         req.req_blocks.ids.emplace_back( chain_info.fork_db_head_id );
       } else {
          peer_ilog( c, "none notice while in ${s}, fhead = ${hn}, id ${id}...",
                   ("s", stage_str( sync_state ))("hn", num)("id", id.str().substr(8,16)) );
          fc::lock_guard g_conn( c->conn_mtx );
-         c->conn_fork_head = block_id_type();
-         c->conn_fork_head_num = 0;
+         c->conn_fork_db_head = block_id_type();
+         c->conn_fork_db_head_num = 0;
       }
       req.req_trx.mode = none;
       c->enqueue( req );
@@ -2402,11 +2402,11 @@ namespace eosio {
          }
       } else if (msg.known_blocks.mode == last_irr_catch_up) {
          {
-            c->peer_fork_root_num = msg.known_trx.pending;
+            c->peer_fork_db_root_num = msg.known_trx.pending;
             fc::lock_guard g_conn( c->conn_mtx );
-            c->last_handshake_recv.fork_root_num = msg.known_trx.pending;
+            c->last_handshake_recv.fork_db_root_num = msg.known_trx.pending;
          }
-         sync_reset_fork_root_num(c, false);
+         sync_reset_fork_db_root_num(c, false);
          start_sync(c, msg.known_trx.pending);
       }
    }
@@ -2417,7 +2417,7 @@ namespace eosio {
       // reset sync on rejected block
       fc::unique_lock g( sync_mtx );
       sync_last_requested_num = 0;
-      sync_next_expected_num = my_impl->get_fork_root_num() + 1;
+      sync_next_expected_num = my_impl->get_fork_db_root_num() + 1;
       g.unlock();
       if( mode == closing_mode::immediately || c->block_status_monitor_.max_events_violated()) {
          peer_wlog(c, "block ${bn} not accepted, closing connection ${d}",
@@ -2470,15 +2470,15 @@ namespace eosio {
          bool set_state_to_head_catchup = false;
          my_impl->connections.for_each_block_connection( [&null_id, blk_num, &blk_id, &c, &set_state_to_head_catchup]( const auto& cp ) {
             fc::unique_lock g_cp_conn( cp->conn_mtx );
-            uint32_t fork_head_num = cp->conn_fork_head_num;
-            block_id_type fork_head_id = cp->conn_fork_head;
+            uint32_t fork_db_head_num = cp->conn_fork_db_head_num;
+            block_id_type fork_db_head_id = cp->conn_fork_db_head;
             g_cp_conn.unlock();
-            if( fork_head_id == null_id ) {
+            if( fork_db_head_id == null_id ) {
                // continue
-            } else if( c && (fork_head_num < blk_num || fork_head_id == blk_id) ) {
+            } else if( c && (fork_db_head_num < blk_num || fork_db_head_id == blk_id) ) {
                fc::lock_guard g_conn( c->conn_mtx );
-               c->conn_fork_head = null_id;
-               c->conn_fork_head_num = 0;
+               c->conn_fork_db_head = null_id;
+               c->conn_fork_db_head_num = 0;
             } else {
                set_state_to_head_catchup = true;
             }
@@ -2496,9 +2496,9 @@ namespace eosio {
          }
       } else if( state == lib_catchup ) {
          fc::unique_lock g_sync( sync_mtx );
-         if( blk_applied && blk_num >= sync_known_fork_root_num ) {
+         if( blk_applied && blk_num >= sync_known_fork_db_root_num ) {
             fc_dlog(logger, "All caught up ${b} with last known froot ${r} resending handshake",
-                    ("b", blk_num)("r", sync_known_fork_root_num));
+                    ("b", blk_num)("r", sync_known_fork_db_root_num));
             set_state( head_catchup );
             g_sync.unlock();
             send_handshakes();
@@ -2515,23 +2515,23 @@ namespace eosio {
                }
 
                if (sync_last_requested_num == 0) { // block was rejected
-                  sync_next_expected_num = my_impl->get_fork_root_num() + 1;
+                  sync_next_expected_num = my_impl->get_fork_db_root_num() + 1;
                   peer_dlog(c, "Reset sync_next_expected_num to ${n}", ("n", sync_next_expected_num));
                } else {
                   if (blk_num == sync_next_expected_num) {
                      ++sync_next_expected_num;
                   }
                }
-               if (blk_num >= sync_known_fork_root_num) {
+               if (blk_num >= sync_known_fork_db_root_num) {
                   peer_dlog(c, "received non-applied block ${bn} >= ${kn}, will send handshakes when caught up",
-                            ("bn", blk_num)("kn", sync_known_fork_root_num));
+                            ("bn", blk_num)("kn", sync_known_fork_db_root_num));
                   send_handshakes_when_synced = true;
                } else {
                   if (is_sync_request_ahead_allowed(blk_num)) {
                      // block was not applied, possibly because we already have the block
                      fc_dlog(logger, "Requesting ${fs} blocks ahead, head: ${h} fhead ${fh} blk_num: ${bn} sync_next_expected_num ${nen} "
                                      "sync_last_requested_num: ${lrn}, sync_last_requested_block: ${lrb}",
-                             ("fs", sync_fetch_span)("h", my_impl->get_chain_head_num())("fh", my_impl->get_fork_head_num())
+                             ("fs", sync_fetch_span)("h", my_impl->get_chain_head_num())("fh", my_impl->get_fork_db_head_num())
                              ("bn", blk_num)("nen", sync_next_expected_num)
                              ("lrn", sync_last_requested_num)("lrb", c->sync_last_requested_block));
                      request_next_chunk();
@@ -2547,7 +2547,7 @@ namespace eosio {
                if (is_sync_request_ahead_allowed(blk_num)) {
                   fc_dlog(logger, "Requesting blocks, head: ${h} fhead ${fh} blk_num: ${bn} sync_next_expected_num ${nen} "
                                   "sync_last_requested_num: ${lrn}",
-                          ("h", my_impl->get_chain_head_num())("fh", my_impl->get_fork_head_num())
+                          ("h", my_impl->get_chain_head_num())("fh", my_impl->get_fork_db_head_num())
                           ("bn", blk_num)("nen", sync_next_expected_num)("lrn", sync_last_requested_num));
                   request_next_chunk();
                }
@@ -2646,10 +2646,10 @@ namespace eosio {
       fc_dlog( logger, "expire_local_txns size ${s} removed ${r}", ("s", start_size)( "r", start_size - end_size ) );
    }
 
-   void dispatch_manager::expire_blocks( uint32_t fork_root_num ) {
+   void dispatch_manager::expire_blocks( uint32_t fork_db_root_num ) {
       fc::lock_guard g( blk_state_mtx );
       auto& stale_blk = blk_state.get<by_connection_id>();
-      stale_blk.erase( stale_blk.lower_bound( 1 ), stale_blk.upper_bound( fork_root_num ) );
+      stale_blk.erase( stale_blk.lower_bound( 1 ), stale_blk.upper_bound( fork_db_root_num ) );
    }
 
    // thread safe
@@ -2674,7 +2674,7 @@ namespace eosio {
 
          boost::asio::post(cp->strand, [cp, bnum, sb{std::move(sb)}]() {
             cp->latest_blk_time = std::chrono::steady_clock::now();
-            bool has_block = cp->peer_fork_root_num >= bnum;
+            bool has_block = cp->peer_fork_db_root_num >= bnum;
             if( !has_block ) {
                peer_dlog( cp, "bcast block ${b}", ("b", bnum) );
                cp->enqueue_buffer( sb, no_reason );
@@ -3029,16 +3029,16 @@ namespace eosio {
       }
       peer_dlog( this, "received block ${num}, id ${id}..., latency: ${l}ms, head ${h}, fhead ${f}",
                  ("num", bh.block_num())("id", blk_id.str().substr(8,16))("l", age.count()/1000)
-                 ("h", my_impl->get_chain_head_num())("f", my_impl->get_fork_head_num()));
+                 ("h", my_impl->get_chain_head_num())("f", my_impl->get_fork_db_head_num()));
       if( !my_impl->sync_master->syncing_from_peer() ) { // guard against peer thinking it needs to send us old blocks
-         uint32_t fork_root_num = my_impl->get_fork_root_num();
-         if( blk_num <= fork_root_num ) {
+         uint32_t fork_db_root_num = my_impl->get_fork_db_root_num();
+         if( blk_num <= fork_db_root_num ) {
             fc::unique_lock g( conn_mtx );
-            const auto last_sent_fork_root_num = last_handshake_sent.fork_root_num;
+            const auto last_sent_fork_db_root_num = last_handshake_sent.fork_db_root_num;
             g.unlock();
             peer_ilog( this, "received block ${n} less than ${which}froot ${fr}",
-                       ("n", blk_num)("which", blk_num < last_sent_fork_root_num ? "sent " : "")
-                       ("fr", blk_num < last_sent_fork_root_num ? last_sent_fork_root_num : fork_root_num) );
+                       ("n", blk_num)("which", blk_num < last_sent_fork_db_root_num ? "sent " : "")
+                       ("fr", blk_num < last_sent_fork_db_root_num ? last_sent_fork_db_root_num : fork_db_root_num) );
             enqueue( (sync_request_message) {0, 0} );
             send_handshake();
             cancel_sync_wait();
@@ -3048,10 +3048,10 @@ namespace eosio {
          }
       } else {
          block_sync_bytes_received += message_length;
-         uint32_t fork_root_num = my_impl->get_fork_root_num();
+         uint32_t fork_db_root_num = my_impl->get_fork_db_root_num();
          my_impl->sync_master->sync_recv_block(shared_from_this(), blk_id, blk_num, age);
-         if( blk_num <= fork_root_num ) {
-            peer_dlog( this, "received block ${n} less than froot ${fr} while syncing", ("n", blk_num)("fr", fork_root_num) );
+         if( blk_num <= fork_db_root_num ) {
+            peer_dlog( this, "received block ${n} less than froot ${fr} while syncing", ("n", blk_num)("fr", fork_db_root_num) );
             pending_message_buffer.advance_read_ptr( message_length );
             return true;
          }
@@ -3159,33 +3159,33 @@ namespace eosio {
    // call only from main application thread
    void net_plugin_impl::update_chain_info() {
       controller& cc = chain_plug->chain();
-      uint32_t fork_root_num = 0, head_num = 0, fork_head_num = 0;
+      uint32_t fork_db_root_num = 0, head_num = 0, fork_db_head_num = 0;
       {
          fc::lock_guard g( chain_info_mtx );
-         chain_info.fork_root_id = cc.fork_db_root().id();
-         chain_info.fork_root_num = fork_root_num = block_header::num_from_id(chain_info.fork_root_id);
+         chain_info.fork_db_root_id = cc.fork_db_root().id();
+         chain_info.fork_db_root_num = fork_db_root_num = block_header::num_from_id(chain_info.fork_db_root_id);
          chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
-         chain_info.fork_head_id = cc.fork_db_head().id();
-         chain_info.fork_head_num = fork_head_num = block_header::num_from_id(chain_info.fork_head_id);
+         chain_info.fork_db_head_id = cc.fork_db_head().id();
+         chain_info.fork_db_head_num = fork_db_head_num = block_header::num_from_id(chain_info.fork_db_head_id);
       }
-      fc_dlog( logger, "updating chain info froot ${fr} head ${h} fhead ${f}", ("fr", fork_root_num)("h", head_num)("f", fork_head_num) );
+      fc_dlog( logger, "updating chain info froot ${fr} head ${h} fhead ${f}", ("fr", fork_db_root_num)("h", head_num)("f", fork_db_head_num) );
    }
 
    // call only from main application thread
-   void net_plugin_impl::update_chain_info(const block_id_type& fork_root_id) {
+   void net_plugin_impl::update_chain_info(const block_id_type& fork_db_root_id) {
       controller& cc = chain_plug->chain();
-      uint32_t fork_root_num = 0, head_num = 0, fork_head_num = 0;
+      uint32_t fork_db_root_num = 0, head_num = 0, fork_db_head_num = 0;
       {
          fc::lock_guard g( chain_info_mtx );
-         chain_info.fork_root_id = fork_root_id;
-         chain_info.fork_root_num = fork_root_num = block_header::num_from_id(fork_root_id);
+         chain_info.fork_db_root_id = fork_db_root_id;
+         chain_info.fork_db_root_num = fork_db_root_num = block_header::num_from_id(fork_db_root_id);
          chain_info.head_id = cc.head().id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
-         chain_info.fork_head_id = cc.fork_db_head().id();
-         chain_info.fork_head_num = fork_head_num = block_header::num_from_id(chain_info.fork_head_id);
+         chain_info.fork_db_head_id = cc.fork_db_head().id();
+         chain_info.fork_db_head_num = fork_db_head_num = block_header::num_from_id(chain_info.fork_db_head_id);
       }
-      fc_dlog( logger, "updating chain info froot ${fr} head ${h} fhead ${f}", ("fr", fork_root_num)("h", head_num)("f", fork_head_num) );
+      fc_dlog( logger, "updating chain info froot ${fr} head ${h} fhead ${f}", ("fr", fork_db_root_num)("h", head_num)("f", fork_db_head_num) );
    }
 
 
@@ -3194,9 +3194,9 @@ namespace eosio {
       return chain_info;
    }
 
-   uint32_t net_plugin_impl::get_fork_root_num() const {
+   uint32_t net_plugin_impl::get_fork_db_root_num() const {
       fc::lock_guard g( chain_info_mtx );
-      return chain_info.fork_root_num;
+      return chain_info.fork_db_root_num;
    }
 
    uint32_t net_plugin_impl::get_chain_head_num() const {
@@ -3204,9 +3204,9 @@ namespace eosio {
       return chain_info.head_num;
    }
 
-   uint32_t net_plugin_impl::get_fork_head_num() const {
+   uint32_t net_plugin_impl::get_fork_db_head_num() const {
       fc::lock_guard g( chain_info_mtx );
-      return chain_info.fork_head_num;
+      return chain_info.fork_db_head_num;
    }
 
    bool connection::is_valid( const handshake_message& msg ) const {
@@ -3214,9 +3214,9 @@ namespace eosio {
       // that really aren't handshake messages can be quickly discarded without
       // affecting state.
       bool valid = true;
-      if (msg.fork_root_num > msg.fork_head_num) {
+      if (msg.fork_db_root_num > msg.fork_db_head_num) {
          peer_wlog( this, "Handshake message validation: last irreversible (${i}) is greater than fhead (${h})",
-                  ("i", msg.fork_root_num)("h", msg.fork_head_num) );
+                  ("i", msg.fork_db_root_num)("h", msg.fork_db_head_num) );
          valid = false;
       }
       if (msg.p2p_address.empty()) {
@@ -3261,10 +3261,10 @@ namespace eosio {
          return;
       }
       peer_dlog( this, "received handshake gen ${g}, froot ${fr}, fhead ${fh}",
-                 ("g", msg.generation)("fr", msg.fork_root_num)("fh", msg.fork_head_num) );
+                 ("g", msg.generation)("fr", msg.fork_db_root_num)("fh", msg.fork_db_head_num) );
 
-      peer_fork_root_num = msg.fork_root_num;
-      peer_fork_head_block_num = msg.fork_head_num;
+      peer_fork_db_root_num = msg.fork_db_root_num;
+      peer_fork_db_head_block_num = msg.fork_db_head_num;
       fc::unique_lock g_conn( conn_mtx );
       last_handshake_recv = msg;
       auto c_time = last_handshake_sent.time;
@@ -3375,25 +3375,25 @@ namespace eosio {
             return;
          }
 
-         uint32_t peer_fork_root_num = msg.fork_root_num;
-         uint32_t fork_root_num = my_impl->get_fork_root_num();
+         uint32_t peer_fork_db_root_num = msg.fork_db_root_num;
+         uint32_t fork_db_root_num = my_impl->get_fork_db_root_num();
 
-         peer_dlog( this, "handshake check froot ${n}, peer_froot ${pn}", ("n", fork_root_num)("pn", peer_fork_root_num) );
+         peer_dlog( this, "handshake check froot ${n}, peer_froot ${pn}", ("n", fork_db_root_num)("pn", peer_fork_db_root_num) );
 
-         if( peer_fork_root_num <= fork_root_num && peer_fork_root_num > 0 ) {
+         if( peer_fork_db_root_num <= fork_db_root_num && peer_fork_db_root_num > 0 ) {
             try {
                controller& cc = my_impl->chain_plug->chain();
-               std::optional<block_id_type> peer_fork_root_id = cc.fork_block_id_for_num( peer_fork_root_num ); // thread-safe
-               if (!peer_fork_root_id) {
+               std::optional<block_id_type> peer_fork_db_root_id = cc.fork_block_id_for_num( peer_fork_db_root_num ); // thread-safe
+               if (!peer_fork_db_root_id) {
                   // can be not found if running with a truncated block log
-                  peer_dlog( this, "peer froot block ${n} is unknown", ("n", peer_fork_root_num) );
-               } else if (msg.fork_root_id != peer_fork_root_id) {
+                  peer_dlog( this, "peer froot block ${n} is unknown", ("n", peer_fork_db_root_num) );
+               } else if (msg.fork_db_root_id != peer_fork_db_root_id) {
                   peer_wlog( this, "Peer chain is forked, sending: forked go away" );
                   no_retry = go_away_reason::forked;
                   enqueue( go_away_message( go_away_reason::forked ) );
                }
             } catch( ... ) {
-               peer_wlog( this, "caught an exception getting block id for ${pl}", ("pl", peer_fork_root_num) );
+               peer_wlog( this, "caught an exception getting block id for ${pl}", ("pl", peer_fork_db_root_num) );
             }
          }
 
@@ -3545,7 +3545,7 @@ namespace eosio {
       case none:
       case last_irr_catch_up: {
          fc::unique_lock g_conn( conn_mtx );
-         last_handshake_recv.fork_head_num = std::max(msg.known_blocks.pending, last_handshake_recv.fork_head_num);
+         last_handshake_recv.fork_db_head_num = std::max(msg.known_blocks.pending, last_handshake_recv.fork_db_head_num);
          g_conn.unlock();
          break;
       }
@@ -3570,7 +3570,7 @@ namespace eosio {
             peer_start_block_num = block_header::num_from_id(msg.known_blocks.ids[1]);
          }
          if (msg.known_blocks.ids.size() > 0) {
-            peer_fork_head_block_num = block_header::num_from_id(msg.known_blocks.ids[0]);
+            peer_fork_db_head_block_num = block_header::num_from_id(msg.known_blocks.ids[0]);
          }
          my_impl->sync_master->sync_recv_notice( shared_from_this(), msg );
          break;
@@ -3696,10 +3696,10 @@ namespace eosio {
       my_impl->dispatcher.strand.post([id, c{shared_from_this()}, ptr{std::move(ptr)}, cid=connection_id]() mutable {
          controller& cc = my_impl->chain_plug->chain();
 
-         auto fork_root_num = my_impl->get_fork_root_num();
+         auto fork_db_root_num = my_impl->get_fork_db_root_num();
 
          // may have come in on a different connection and posted into dispatcher strand before this one
-         if( block_header::num_from_id(id) <= fork_root_num || my_impl->dispatcher.have_block( id ) || cc.block_exists( id ) ) { // thread-safe
+         if( block_header::num_from_id(id) <= fork_db_root_num || my_impl->dispatcher.have_block( id ) || cc.block_exists( id ) ) { // thread-safe
             my_impl->dispatcher.add_peer_block( id, c->connection_id );
             boost::asio::post(c->strand, [c, id, ptr{std::move(ptr)}]() {
                const fc::microseconds age(fc::time_point::now() - ptr->timestamp);
@@ -3835,8 +3835,8 @@ namespace eosio {
 
    void net_plugin_impl::expire() {
       auto now = time_point::now();
-      uint32_t fork_root_num = get_fork_root_num();
-      dispatcher.expire_blocks( fork_root_num );
+      uint32_t fork_db_root_num = get_fork_db_root_num();
+      dispatcher.expire_blocks( fork_db_root_num );
       dispatcher.expire_txns();
       fc_dlog( logger, "expire_txns ${n}us", ("n", time_point::now() - now) );
 
@@ -4031,13 +4031,13 @@ namespace eosio {
       auto now = sc::duration_cast<sc::nanoseconds>(sc::system_clock::now().time_since_epoch()).count();
       constexpr int64_t hs_delay = sc::duration_cast<sc::nanoseconds>(sc::milliseconds(50)).count();
       // nothing as changed since last handshake and one was sent recently, so skip sending
-      if (chain_info.fork_head_id == hello.fork_head_id && (hello.time + hs_delay > now))
+      if (chain_info.fork_db_head_id == hello.fork_db_head_id && (hello.time + hs_delay > now))
          return false;
       hello.network_version = net_version_base + net_version;
-      hello.fork_root_num = chain_info.fork_root_num;
-      hello.fork_root_id = chain_info.fork_root_id;
-      hello.fork_head_num = chain_info.fork_head_num;
-      hello.fork_head_id = chain_info.fork_head_id;
+      hello.fork_db_root_num = chain_info.fork_db_root_num;
+      hello.fork_db_root_id = chain_info.fork_db_root_id;
+      hello.fork_db_head_num = chain_info.fork_db_head_num;
+      hello.fork_db_head_id = chain_info.fork_db_head_id;
       hello.chain_id = my_impl->chain_id;
       hello.node_id = my_impl->node_id;
       hello.key = my_impl->get_authentication_key();
@@ -4166,7 +4166,7 @@ namespace eosio {
                      "p2p-keepalive_interval-ms must be greater than 0" );
 
          // To avoid unnecessary transitions between LIB <-> head catchups,
-         // min_blocks_distance between fork_root and head must be reached.
+         // min_blocks_distance between fork_db_root and head must be reached.
          // Set it to the number of blocks produced during half of keep alive
          // interval.
          const uint32_t min_blocks_distance = (keepalive_interval.count() / config::block_interval_ms) / 2;
@@ -4812,7 +4812,7 @@ namespace eosio {
             , .accepting_blocks = c->is_blocks_connection()
             , .last_received_block = c->get_last_received_block_num()
             , .first_available_block = c->get_peer_start_block_num()
-            , .last_available_block = c->get_peer_fork_head_block_num()
+            , .last_available_block = c->get_peer_fork_db_head_block_num()
             , .unique_first_block_count = c->get_unique_blocks_rcvd_count()
             , .latency = c->get_peer_ping_time_ns()
             , .bytes_received = c->get_bytes_received()

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1573,10 +1573,10 @@ void producer_plugin_impl::plugin_startup() {
             _vote_block_connection.emplace(chain.voted_block().connect(on_vote_signal));
          }
 
-         const auto fork_root_num = chain.fork_db_root().block_num();
-         const auto fork_root     = chain.fetch_block_by_number(fork_root_num);
-         if (fork_root) {
-            on_irreversible_block(fork_root);
+         const auto fork_db_root_num = chain.fork_db_root().block_num();
+         const auto fork_db_root     = chain.fetch_block_by_number(fork_db_root_num);
+         if (fork_db_root) {
+            on_irreversible_block(fork_db_root);
          } else {
             _irreversible_block_time = fc::time_point::maximum();
          }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1573,10 +1573,10 @@ void producer_plugin_impl::plugin_startup() {
             _vote_block_connection.emplace(chain.voted_block().connect(on_vote_signal));
          }
 
-         const auto froot_num = chain.fork_db_root_block_num();
-         const auto froot     = chain.fetch_block_by_number(froot_num);
-         if (froot) {
-            on_irreversible_block(froot);
+         const auto fork_root_num = chain.fork_db_root().block_num();
+         const auto fork_root     = chain.fetch_block_by_number(fork_root_num);
+         if (fork_root) {
+            on_irreversible_block(fork_root);
          } else {
             _irreversible_block_time = fc::time_point::maximum();
          }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1573,10 +1573,10 @@ void producer_plugin_impl::plugin_startup() {
             _vote_block_connection.emplace(chain.voted_block().connect(on_vote_signal));
          }
 
-         const auto lib_num = chain.last_irreversible_block_num();
-         const auto lib     = chain.fetch_block_by_number(lib_num);
-         if (lib) {
-            on_irreversible_block(lib);
+         const auto froot_num = chain.fork_db_root_block_num();
+         const auto froot     = chain.fetch_block_by_number(froot_num);
+         if (froot) {
+            on_irreversible_block(froot);
          } else {
             _irreversible_block_time = fc::time_point::maximum();
          }

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -177,7 +177,7 @@ private:
       get_status_result_v1 ret;
 
       ret.head              = {controller.head().block_num(), controller.head().id()};
-      ret.last_irreversible = {controller.fork_db_root_block_num(), controller.fork_db_root_block_id()};
+      ret.last_irreversible = {controller.fork_db_root().block_num(), controller.fork_db_root().id()};
       ret.chain_id          = controller.get_chain_id();
       if(trace_log)
          std::tie(ret.trace_begin_block, ret.trace_end_block) = trace_log->block_range();
@@ -237,12 +237,12 @@ private:
 
                //decide what block -- if any -- to send out
                const chain::block_num_type latest_to_consider = self.current_blocks_request.irreversible_only ?
-                                                                self.controller.fork_db_root_block_num() : self.controller.head().block_num();
+                                                                self.controller.fork_db_root().block_num() : self.controller.head().block_num();
                if(self.send_credits && self.next_block_cursor <= latest_to_consider && self.next_block_cursor < self.current_blocks_request.end_block_num) {
                   block_to_send.emplace( block_package{
                      .blocks_result_base = {
                         .head = {self.controller.head().block_num(), self.controller.head().id()},
-                        .last_irreversible = {self.controller.fork_db_root_block_num(), self.controller.fork_db_root_block_id()}
+                        .last_irreversible = {self.controller.fork_db_root().block_num(), self.controller.fork_db_root().id()}
                      },
                      .is_v1_request = self.current_blocks_request_v1_finality.has_value()
                   });

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -177,7 +177,7 @@ private:
       get_status_result_v1 ret;
 
       ret.head              = {controller.head().block_num(), controller.head().id()};
-      ret.last_irreversible = {controller.last_irreversible_block_num(), controller.last_irreversible_block_id()};
+      ret.last_irreversible = {controller.fork_db_root_block_num(), controller.fork_db_root_block_id()};
       ret.chain_id          = controller.get_chain_id();
       if(trace_log)
          std::tie(ret.trace_begin_block, ret.trace_end_block) = trace_log->block_range();
@@ -237,12 +237,12 @@ private:
 
                //decide what block -- if any -- to send out
                const chain::block_num_type latest_to_consider = self.current_blocks_request.irreversible_only ?
-                                                                self.controller.last_irreversible_block_num() : self.controller.head().block_num();
+                                                                self.controller.fork_db_root_block_num() : self.controller.head().block_num();
                if(self.send_credits && self.next_block_cursor <= latest_to_consider && self.next_block_cursor < self.current_blocks_request.end_block_num) {
                   block_to_send.emplace( block_package{
                      .blocks_result_base = {
                         .head = {self.controller.head().block_num(), self.controller.head().id()},
-                        .last_irreversible = {self.controller.last_irreversible_block_num(), self.controller.last_irreversible_block_id()}
+                        .last_irreversible = {self.controller.fork_db_root_block_num(), self.controller.fork_db_root_block_id()}
                      },
                      .is_v1_request = self.current_blocks_request_v1_finality.has_value()
                   });

--- a/programs/spring-util/actions/blocklog.cpp
+++ b/programs/spring-util/actions/blocklog.cpp
@@ -268,7 +268,7 @@ int blocklog_actions::read_log() {
 
    block_branch_t fork_db_branch;
 
-   if(std::filesystem::exists(std::filesystem::path(opt->blocks_dir) / config::reversible_blocks_dir_name / config::forkdb_filename)) {
+   if(std::filesystem::exists(std::filesystem::path(opt->blocks_dir) / config::reversible_blocks_dir_name / config::fork_db_filename)) {
       ilog("opening fork_db");
       fork_database fork_db(std::filesystem::path(opt->blocks_dir) / config::reversible_blocks_dir_name);
 

--- a/unittests/blocks_log_replay_tests.cpp
+++ b/unittests/blocks_log_replay_tests.cpp
@@ -137,8 +137,8 @@ BOOST_FIXTURE_TEST_CASE(replay_stop_in_middle, blog_replay_fixture) try {
    stop_and_resume_replay(last_irreversible_block_num - 1);
 } FC_LOG_AND_RETHROW()
 
-// Test replay stopping in the middle of blocks log and resuming without forkdb
-BOOST_FIXTURE_TEST_CASE(replay_stop_in_middle_rm_forkdb, blog_replay_fixture) try {
+// Test replay stopping in the middle of blocks log and resuming without fork_db
+BOOST_FIXTURE_TEST_CASE(replay_stop_in_middle_rm_fork_db, blog_replay_fixture) try {
    // block `last_irreversible_block_num - 1` is within blocks log
    stop_and_resume_replay(last_irreversible_block_num - 1, true);
 } FC_LOG_AND_RETHROW()

--- a/unittests/finalizer_vote_tests.cpp
+++ b/unittests/finalizer_vote_tests.cpp
@@ -114,7 +114,7 @@ struct simulator_t {
 
    bls_keys_t           keys;
    finalizer            my_finalizer;
-   fork_database_if_t   forkdb;
+   fork_database_if_t   fork_db;
    finalizer_policy_ptr finpol;
    std::vector<bsp>     bsp_vec;
 
@@ -141,7 +141,7 @@ struct simulator_t {
 
       auto genesis = make_bsp(proposal_t{0, "n0"}, bsp(), finpol);
       bsp_vec.push_back(genesis);
-      forkdb.reset_root(genesis);
+      fork_db.reset_root(genesis);
 
       block_ref genesis_ref(genesis->id(), genesis->timestamp(), genesis->id(), 1, 0);
       my_finalizer.fsi = fsi_t{genesis_ref, genesis_ref, {}};
@@ -153,7 +153,7 @@ struct simulator_t {
    }
 
    vote_result propose(const proposal_t& p, std::optional<qc_claim_t> _claim = {}) {
-      bsp h = forkdb.head(include_root_t::yes);
+      bsp h = fork_db.head(include_root_t::yes);
       qc_claim_t old_claim = _claim ? *_claim : h->core.latest_qc_claim();
       bsp new_bsp = make_bsp(p, h, finpol, old_claim);
       bsp_vec.push_back(new_bsp);
@@ -162,12 +162,12 @@ struct simulator_t {
    }
 
    result add(const proposal_t& p, std::optional<qc_claim_t> _claim = {}, const bsp& parent = {}) {
-      bsp h = parent ? parent : forkdb.head(include_root_t::yes);
+      bsp h = parent ? parent : fork_db.head(include_root_t::yes);
       qc_claim_t old_claim = _claim ? *_claim : h->core.latest_qc_claim();
       bsp new_bsp = make_bsp(p, h, finpol, old_claim);
       bsp_vec.push_back(new_bsp);
       test_block_state_accessor::set_valid(new_bsp, true);
-      forkdb.add(new_bsp, ignore_duplicate_t::no);
+      fork_db.add(new_bsp, ignore_duplicate_t::no);
 
       auto v = vote(new_bsp);
       return { new_bsp, v };

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
       offset = fc::milliseconds(config::block_interval_ms);
    }
 
-   // forkdb is sorted on block id which can cause fork switch on the second to last block or last block depending
+   // fork_db is sorted on block id which can cause fork switch on the second to last block or last block depending
    // on block id. Allow exception on either one so that test is not sensitive to block id hash.
    auto push_last_two = [&](const fork_tracker& fork) {
       if (fork.blocks.size() > 1) {
@@ -507,9 +507,9 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
 
 } FC_LOG_AND_RETHROW()
 
-// ---------------------------- reopen_forkdb ---------------------------------
+// ---------------------------- reopen_fork_db ---------------------------------
 template <class TESTER>
-void test_reopen_forkdb() try {
+void test_reopen_fork_db() try {
    TESTER c1;
 
    c1.create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
@@ -566,9 +566,9 @@ void test_reopen_forkdb() try {
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_AUTO_TEST_CASE( reopen_forkdb ) {
-   test_reopen_forkdb<legacy_tester>();
-   test_reopen_forkdb<tester>();
+BOOST_AUTO_TEST_CASE( reopen_fork_db ) {
+   test_reopen_fork_db<legacy_tester>();
+   test_reopen_fork_db<tester>();
 }
 
 // ---------------------------- push_block_returns_forked_transactions ---------------------------------

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -515,7 +515,7 @@ namespace savanna_cluster {
 
       // Push new blocks from src_idx node to all nodes in partition of dst_idx.
       // This is used when pushing one fork from a node to another node which has
-      // another fork, so we can't use `dst.forkdb_head_num() + 1` for start_block_num
+      // another fork, so we can't use `dst.fork_db_head_num() + 1` for start_block_num
       // -----------------------------------------------------------------------------
       void push_blocks(size_t src_idx, size_t dst_idx, uint32_t start_block_num) {
          auto& src = _nodes[src_idx];

--- a/unittests/savanna_misc_tests.cpp
+++ b/unittests/savanna_misc_tests.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_SUITE(savanna_misc_tests)
 // Verify that we can restart a node from a snapshot without state or blocks (reversible
 // or not)
 // ------------------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(snapshot_startup_without_forkdb, savanna_cluster::cluster_t) try {
+BOOST_FIXTURE_TEST_CASE(snapshot_startup_without_fork_db, savanna_cluster::cluster_t) try {
    auto& A=_nodes[0]; auto& B=_nodes[1];
 
    auto snapshot = B.snapshot();
@@ -29,7 +29,7 @@ BOOST_FIXTURE_TEST_CASE(snapshot_startup_without_forkdb, savanna_cluster::cluste
 // Verify that we cannot restart a node from a snapshot without state and blocks log,
 // but with a fork database
 // ------------------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(snapshot_startup_with_forkdb, savanna_cluster::cluster_t) try {
+BOOST_FIXTURE_TEST_CASE(snapshot_startup_with_fork_db, savanna_cluster::cluster_t) try {
    auto& A=_nodes[0]; auto& B=_nodes[1];
 
    auto snapshot = B.snapshot();
@@ -1111,7 +1111,7 @@ BOOST_FIXTURE_TEST_CASE(finality_advancing_past_block_claimed_on_alternate_branc
 // (the cluster starts with 9 final blocks and 1 reversible block after the transition
 // to Savanna)
 // ------------------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) try {
+BOOST_FIXTURE_TEST_CASE(replay_fork_db_at_startup, savanna_cluster::cluster_t) try {
    auto& A=_nodes[0]; auto& C=_nodes[2]; auto& D=_nodes[3];
 
    // at this point we have 9 final blocks and 1 reversible block
@@ -1124,8 +1124,8 @@ BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) tr
    for (size_t i=0; i<num_blocks; ++i)
       blocks.push_back(A.produce_block());
 
-   const size_t num_forkdb_blocks = A.control->fork_db_size();;
-   BOOST_REQUIRE_GT(num_forkdb_blocks, num_blocks);        // A should have 20+ unfinalized blocks in its fork_db (actually 21)
+   const size_t num_fork_db_blocks = A.control->fork_db_size();;
+   BOOST_REQUIRE_GT(num_fork_db_blocks, num_blocks);        // A should have 20+ unfinalized blocks in its fork_db (actually 21)
 
    controller::config copied_config = A.get_config();
    auto               genesis       = block_log::extract_genesis_state(A.get_config().blocks_dir);
@@ -1147,7 +1147,7 @@ BOOST_FIXTURE_TEST_CASE(replay_forkdb_at_startup, savanna_cluster::cluster_t) tr
    A.open();                                              // open() the node again to make sure it restarts correctly
                                                           // after being interrupted.
 
-   BOOST_REQUIRE_EQUAL(A.control->fork_db_size(), num_forkdb_blocks);
+   BOOST_REQUIRE_EQUAL(A.control->fork_db_size(), num_fork_db_blocks);
 
 } FC_LOG_AND_RETHROW()
 

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -814,7 +814,7 @@ bool test_fork(uint32_t stride, uint32_t max_retained_files) {
       // Produce one more block; do not vote it such that it won't become final when
       // the first block from chain2 is pushed to chain1. This is to ensure LIBs
       // on chain1 and chain2 are the same, and further blocks from chain2 can be
-      // pushed into chain1's forkdb.
+      // pushed into chain1's fork_db.
       chain1.control->testing_allow_voting(false);
       chain1.produce_block();
    }


### PR DESCRIPTION
Most of the changes involve using `froot` instead of `lib`.

Did not change the interface of `tester` to avoid uses having to update their tests.
`get_info` was unchanged; it still reports `last_irreversible_block_num` and `last_irreversible_block_id` for `forkdb_root_block_num` and `forkdb_root_block_id`.

Resolves #806 