### PR TITLE
Move get_info off main thread and run in http thread

### DIFF
--- a/libraries/chain/include/eosio/chain/chain_id_type.hpp
+++ b/libraries/chain/include/eosio/chain/chain_id_type.hpp
@@ -8,7 +8,7 @@ namespace eosio {
    struct handshake_message;
 
    namespace chain_apis {
-      class read_only;
+      class get_info_db;
    }
 
    class chain_plugin;
@@ -49,7 +49,7 @@ namespace chain {
          template<typename T>
          friend T fc::variant::as()const;
 
-         friend class eosio::chain_apis::read_only;
+         friend class eosio::chain_apis::get_info_db;
 
          friend class eosio::net_plugin_impl;
          friend struct eosio::handshake_message;

--- a/libraries/libfc/include/fc/crypto/hex.hpp
+++ b/libraries/libfc/include/fc/crypto/hex.hpp
@@ -12,4 +12,16 @@ namespace fc {
      *  @return the number of bytes decoded
      */
     size_t from_hex( const std::string& hex_str, char* out_data, size_t out_data_len );
+
+    /**
+     *  @return the hex string of `n`
+     */
+   template<typename I>
+   std::string itoh(I n, size_t hlen = sizeof(I)<<1) {
+       static const char* digits = "0123456789abcdef";
+       std::string r(hlen, '0');
+       for(size_t i = 0, j = (hlen - 1) * 4 ; i < hlen; ++i, j -= 4)
+           r[i] = digits[(n>>j) & 0x0f];
+       return r;
+   }
 } 

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -125,9 +125,11 @@ void chain_api_plugin::plugin_startup() {
 
    ro_api.set_shorten_abi_errors( !http_plugin::verbose_errors() );
 
-   _http_plugin.add_api( {
-      CALL_WITH_400(chain, node, ro_api, chain_apis::read_only, get_info, 200, http_params_types::no_params)
-      }, appbase::exec_queue::read_only, appbase::priority::medium_high);
+   // Run get_info on http thread only
+   _http_plugin.add_async_api({
+      CHAIN_RO_CALL_WITH_400(get_info, 200, http_params_types::no_params)
+   });
+
    _http_plugin.add_api({
       CHAIN_RO_CALL(get_activated_protocol_features, 200, http_params_types::possible_no_params),
       CHAIN_RO_CALL_POST(get_block, fc::variant, 200, http_params_types::params_required), // _POST because get_block() returns a lambda to be executed on the http thread pool

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library( chain_plugin
              chain_plugin.cpp
              trx_retry_db.cpp
              tracked_votes.cpp
+             get_info_db.cpp
              ${HEADERS} )
 
 if(EOSIO_ENABLE_DEVELOPER_OPTIONS)

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1078,6 +1078,10 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
             _trx_finality_status_processing->signal_irreversible_block(block, id);
          }
 
+         if (_get_info_db) {
+            _get_info_db->on_irreversible_block();
+         }
+
          irreversible_block_channel.publish( priority::low, t );
       } );
       

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1079,7 +1079,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          }
 
          if (_get_info_db) {
-            _get_info_db->on_irreversible_block();
+            _get_info_db->on_irreversible_block(block, id);
          }
 
          irreversible_block_channel.publish( priority::low, t );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -193,6 +193,7 @@ public:
    std::optional<scoped_connection>                                   applied_transaction_connection;
    std::optional<scoped_connection>                                   block_start_connection;
 
+   std::optional<chain_apis::get_info_db>                             _get_info_db;
    std::optional<chain_apis::account_query_db>                        _account_query_db;
    std::optional<chain_apis::trx_retry_db>                            _trx_retry_db;
    chain_apis::trx_finality_status_processing_ptr                     _trx_finality_status_processing;
@@ -976,12 +977,14 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
       }
 
       // only enable last tracked votes if chain_api_plugin enabled, if no http endpoint, no reason to track
-      bool last_tracked_votes_enabled = false;
+      bool chain_api_plugin_configured = false;
       if (options.count("plugin")) {
          const auto& v = options.at("plugin").as<std::vector<std::string>>();
-         last_tracked_votes_enabled = std::ranges::any_of(v, [](const std::string& p) { return p.find("eosio::chain_api_plugin") != std::string::npos; });
+         chain_api_plugin_configured = std::ranges::any_of(v, [](const std::string& p) { return p.find("eosio::chain_api_plugin") != std::string::npos; });
       }
-      _last_tracked_votes.emplace(*chain, last_tracked_votes_enabled);
+      _last_tracked_votes.emplace(*chain, chain_api_plugin_configured);
+
+      _get_info_db.emplace(*chain, chain_api_plugin_configured);
 
       // initialize deep mind logging
       if ( options.at( "deep-mind" ).as<bool>() ) {
@@ -1055,6 +1058,10 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
          if (_last_tracked_votes) {
             _last_tracked_votes->on_accepted_block(block, id);
+         }
+
+         if (_get_info_db) {
+            _get_info_db->on_accepted_block();
          }
 
          accepted_block_channel.publish( priority::high, t );
@@ -1202,9 +1209,8 @@ chain_apis::read_write chain_plugin::get_read_write_api(const fc::microseconds& 
 }
 
 chain_apis::read_only chain_plugin::get_read_only_api(const fc::microseconds& http_max_response_time) const {
-   return chain_apis::read_only(chain(), my->_account_query_db, my->_last_tracked_votes, get_abi_serializer_max_time(), http_max_response_time, my->_trx_finality_status_processing.get());
+   return chain_apis::read_only(chain(), my->_get_info_db, my->_account_query_db, my->_last_tracked_votes, get_abi_serializer_max_time(), http_max_response_time, my->_trx_finality_status_processing.get());
 }
-
 
 void chain_plugin::accept_transaction(const chain::packed_transaction_ptr& trx, next_function<chain::transaction_trace_ptr> next) {
    my->incoming_transaction_async_method(trx, false, transaction_metadata::trx_type::input, false, std::move(next));
@@ -1287,37 +1293,12 @@ namespace chain_apis {
 
 const string read_only::KEYi64 = "i64";
 
-read_only::get_info_results read_only::get_info(const read_only::get_info_params&, const fc::time_point&) const {
-   const auto& rm = db.get_resource_limits_manager();
+get_info_db::get_info_results read_only::get_info(const read_only::get_info_params&, const fc::time_point&) const {
+   EOS_ASSERT(gidb, plugin_config_exception, "get_info being accessed when not enabled");
 
-   auto head_id = db.head().id();
-   auto lib_id = db.last_irreversible_block_id();
-   auto fhead_id = db.fork_db_head().id();
-
-   return {
-      itoh(static_cast<uint32_t>(app().version())),
-      db.get_chain_id(),
-      block_header::num_from_id(head_id),
-      block_header::num_from_id(lib_id),
-      lib_id,
-      head_id,
-      db.head().block_time(),
-      db.head().producer(),
-      rm.get_virtual_block_cpu_limit(),
-      rm.get_virtual_block_net_limit(),
-      rm.get_block_cpu_limit(),
-      rm.get_block_net_limit(),
-      //std::bitset<64>(db.get_dynamic_global_properties().recent_slots_filled).to_string(),
-      //__builtin_popcountll(db.get_dynamic_global_properties().recent_slots_filled) / 64.0,
-      app().version_string(),
-      block_header::num_from_id(fhead_id),
-      fhead_id,
-      app().full_version_string(),
-      rm.get_total_cpu_weight(),
-      rm.get_total_net_weight(),
-      db.earliest_available_block_num(),
-      db.last_irreversible_block_time()
-   };
+   // To be able to run get_info on an http thread, get_info results are stored
+   // in get_info_db and updated whenever accepted_block signal is received.
+   return gidb->get_info();
 }
 
 read_only::get_transaction_status_results

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -15,7 +15,11 @@ namespace eosio::chain_apis {
    struct get_info_db_impl {
       get_info_db_impl(const chain::controller& controller, bool get_info_enabled)
          : controller(controller)
-         , get_info_enabled(get_info_enabled) {}
+         , get_info_enabled(get_info_enabled)
+         , chain_id(controller.get_chain_id())
+         , version_hex(itoh(static_cast<uint32_t>(app().version())))
+         , version_string(app().version_string())
+         , full_version_string(app().full_version_string()) {}
 
       // A handle to the controller.
       const chain::controller& controller;
@@ -26,6 +30,12 @@ namespace eosio::chain_apis {
       // Cache to store the current get_info results in respect to latest accepted block.
       mutable std::shared_mutex      rw_mutex;
       get_info_db::get_info_results  cached_results;
+
+      // Values are never changed
+      const chain_id_type chain_id;
+      const std::string   version_hex;
+      const std::string   version_string;
+      const std::string   full_version_string;
 
       // Called on accepted_block signal.
       void on_accepted_block() {
@@ -52,8 +62,8 @@ namespace eosio::chain_apis {
 
             // cache get_info results
             cached_results = get_info_db::get_info_results {
-               itoh(static_cast<uint32_t>(app().version())),
-               controller.get_chain_id(),
+               version_hex,
+               chain_id,
                chain::block_header::num_from_id(head_id),
                chain::block_header::num_from_id(lib_id),
                lib_id,
@@ -64,10 +74,10 @@ namespace eosio::chain_apis {
                rm.get_virtual_block_net_limit(),
                rm.get_block_cpu_limit(),
                rm.get_block_net_limit(),
-               app().version_string(),
+               version_string,
                chain::block_header::num_from_id(fhead_id),
                fhead_id,
-               app().full_version_string(),
+               full_version_string,
                rm.get_total_cpu_weight(),
                rm.get_total_net_weight(),
                controller.earliest_available_block_num(),

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -48,7 +48,7 @@ namespace eosio::chain_apis {
          // safely load the info_cache pointer
          std::shared_ptr<get_info_db::get_info_results> info = std::atomic_load(&info_cache);
 
-         if (info && is_valid(info)) {
+         if (info && info->contains_full_data()) {
             return *info;
          }
 
@@ -137,12 +137,6 @@ namespace eosio::chain_apis {
          info->last_irreversible_block_time = block->timestamp;
 
          std::atomic_store(&info_cache, info);  // replace current cache safely
-      }
-
-      // Returns true if data held by info is valid
-      bool is_valid(const std::shared_ptr<get_info_db::get_info_results>& info) {
-         return (info->head_block_num > 0) && (info->last_irreversible_block_num > 0)
-                 && (info->fork_db_head_block_num > 0);
       }
    }; // get_info_db_impl
 

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -97,9 +97,10 @@ namespace eosio::chain_apis {
          }
 
          // fork_db part
-         bool fork_db_has_root = controller.fork_db_has_root();
+         const auto& fork_db_head = controller.fork_db_head();
+         bool fork_db_has_root = fork_db_head.is_valid(); // a valid head implies fork_db has root
          if (fork_db_has_root) {
-            info->fork_db_head_block_id        = controller.fork_db_head().id();
+            info->fork_db_head_block_id        = fork_db_head.id();
             info->fork_db_head_block_num       = block_header::num_from_id(*info->fork_db_head_block_id);
             info->earliest_available_block_num = controller.earliest_available_block_num();
          }

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -21,7 +21,7 @@ namespace eosio::chain_apis {
       const chain::controller& controller;
 
       // Indication whether get_info RPC is enabled.
-      bool get_info_enabled = false;
+      const bool get_info_enabled = false;
 
       // Cache to store the current get_info results in respect to latest accepted block.
       get_info_db::get_info_results  cached_results;

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -48,7 +48,7 @@ namespace eosio::chain_apis {
          // safely load the info_cache pointer
          std::shared_ptr<get_info_db::get_info_results> info = std::atomic_load(&info_cache);
 
-         if (info && info->head_block_num > 0 && info->last_irreversible_block_num > 0 && info->fork_db_head_block_num > 0) {
+         if (info && is_valid(info)) {
             return *info;
          }
 
@@ -137,6 +137,12 @@ namespace eosio::chain_apis {
          info->last_irreversible_block_time = block->timestamp;
 
          std::atomic_store(&info_cache, info);  // replace current cache safely
+      }
+
+      // Returns true if data held by info is valid
+      bool is_valid(const std::shared_ptr<get_info_db::get_info_results>& info) {
+         return (info->head_block_num > 0) && (info->last_irreversible_block_num > 0)
+                 && (info->fork_db_head_block_num > 0);
       }
    }; // get_info_db_impl
 

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -56,8 +56,7 @@ namespace eosio::chain_apis {
             }
 
             std::unique_lock write_lock(rw_mutex);
-            store_fork_db_part();
-            store_resource_limits_part();
+            store_all_parts();
          } FC_LOG_AND_DROP(("get_info_db_impl on_irreversible_block ERROR"));
       }
 

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -24,8 +24,8 @@ namespace eosio::chain_apis {
       const bool get_info_enabled = false;
 
       // Cache to store the current get_info results in respect to latest accepted block.
-      get_info_db::get_info_results  cached_results;
       mutable std::shared_mutex      rw_mutex;
+      get_info_db::get_info_results  cached_results;
 
       // Called on accepted_block signal.
       void on_accepted_block() {

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -17,7 +17,7 @@ namespace eosio::chain_apis {
          : controller(controller)
          , get_info_enabled(get_info_enabled)
          , chain_id(controller.get_chain_id())
-         , version_hex(itoh(static_cast<uint32_t>(app().version())))
+         , version_hex(fc::itoh(static_cast<uint32_t>(app().version())))
          , version_string(app().version_string())
          , full_version_string(app().full_version_string()) {}
 

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -117,9 +117,10 @@ namespace eosio::chain_apis {
          store_info_common(info);
 
          if (controller.fork_db_has_root()) {
-            info->last_irreversible_block_id   = controller.fork_db_root().id();
+            const auto& root = controller.fork_db_root(); // avoid multiple mutexes in fork db
+            info->last_irreversible_block_id   = root.id();
             info->last_irreversible_block_num  = block_header::num_from_id(info->last_irreversible_block_id);
-            info->last_irreversible_block_time = controller.fork_db_root().block_time();
+            info->last_irreversible_block_time = root.block_time();
          }
 
          std::atomic_store(&info_cache, info);  // replace current cache safely

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -114,9 +114,9 @@ namespace eosio::chain_apis {
       // caller holds a mutex
       void store_lib_part() {
          if (controller.fork_db_has_root()) {
-            cached_results.last_irreversible_block_id   = controller.last_irreversible_block_id();
+            cached_results.last_irreversible_block_id   = controller.fork_db_root().id();
             cached_results.last_irreversible_block_num  = block_header::num_from_id(cached_results.last_irreversible_block_id);
-            cached_results.last_irreversible_block_time = controller.last_irreversible_block_time();
+            cached_results.last_irreversible_block_time = controller.fork_db_root().block_time();
          }
       }
 

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -2,8 +2,6 @@
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/application.hpp>
 
-#include <shared_mutex>
-
 using namespace eosio;
 using namespace eosio::chain;
 using namespace appbase;

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -1,0 +1,89 @@
+#include <eosio/chain_plugin/get_info_db.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/application.hpp>
+
+#include <shared_mutex>
+
+using namespace eosio;
+using namespace appbase;
+
+namespace eosio::chain_apis {
+   /**
+    * Implementation details of the get_info results
+    */
+   struct get_info_db_impl {
+      get_info_db_impl(const chain::controller& controller, bool get_info_enabled)
+         : controller(controller)
+         , get_info_enabled(get_info_enabled) {}
+
+      // A handle to the controller.
+      const chain::controller& controller;
+
+      // Indication whether get_info RPC is enabled.
+      bool get_info_enabled = false;
+
+      // Cache to store the current get_info results in respect to latest accepted block.
+      get_info_db::get_info_results  cached_results;
+      mutable std::shared_mutex      rw_mutex;
+
+      // Called on accepted_block signal.
+      void on_accepted_block() {
+         try {
+            if (!get_info_enabled) {
+               return;
+            }
+
+            std::unique_lock write_lock(rw_mutex);
+
+            const auto& rm       = controller.get_resource_limits_manager();
+            auto        head_id  = controller.head().id();
+            auto        lib_id   = controller.last_irreversible_block_id();
+            auto        fhead_id = controller.fork_db_head().id();
+
+            // cache get_info results
+            cached_results = get_info_db::get_info_results {
+               itoh(static_cast<uint32_t>(app().version())),
+               controller.get_chain_id(),
+               chain::block_header::num_from_id(head_id),
+               chain::block_header::num_from_id(lib_id),
+               lib_id,
+               head_id,
+               controller.head().block_time(),
+               controller.head().producer(),
+               rm.get_virtual_block_cpu_limit(),
+               rm.get_virtual_block_net_limit(),
+               rm.get_block_cpu_limit(),
+               rm.get_block_net_limit(),
+               app().version_string(),
+               chain::block_header::num_from_id(fhead_id),
+               fhead_id,
+               app().full_version_string(),
+               rm.get_total_cpu_weight(),
+               rm.get_total_net_weight(),
+               controller.earliest_available_block_num(),
+               controller.last_irreversible_block_time()
+            };
+         } FC_LOG_AND_DROP(("get_info_db_impl on_accepted_block ERROR"));
+      }
+
+      // Returns cached get_info results
+      get_info_db::get_info_results get_info() const {
+         std::shared_lock read_lock(rw_mutex);
+
+         return cached_results;
+      }
+   }; // get_info_db_impl
+
+   get_info_db::get_info_db( const chain::controller& controller, bool get_info_enabled )
+      :_impl(std::make_unique<get_info_db_impl>(controller, get_info_enabled)) {}
+
+   get_info_db::~get_info_db() = default;
+
+   void get_info_db::on_accepted_block() {
+      _impl->on_accepted_block();
+   }
+
+   get_info_db::get_info_results get_info_db::get_info() const {
+      return _impl->get_info();
+   }
+} // namespace eosio::chain_apis

--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -15,7 +15,11 @@ namespace eosio::chain_apis {
    struct get_info_db_impl {
       get_info_db_impl(const chain::controller& controller, bool get_info_enabled)
          : controller(controller)
-         , get_info_enabled(get_info_enabled) {}
+         , get_info_enabled(get_info_enabled)
+         , server_version(fc::itoh(static_cast<uint32_t>(app().version())))
+         , chain_id(controller.get_chain_id())
+         , server_version_string(app().version_string())
+         , server_full_version_string(app().full_version_string()) {}
 
       // Called on accepted_block signal.
       void on_accepted_block() {
@@ -68,14 +72,20 @@ namespace eosio::chain_apis {
       // Lock free by using std::atomic_load and std::atomic_store.
       std::shared_ptr<get_info_db::get_info_results> info_cache = nullptr;
 
+      // Fixed data
+      std::string           server_version;
+      chain::chain_id_type  chain_id;
+      std::string           server_version_string;
+      std::string           server_full_version_string;
+
       void store_info_common(const std::shared_ptr<get_info_db::get_info_results>& info) {
          assert(info);
 
          // fixed part
-         info->server_version             = fc::itoh(static_cast<uint32_t>(app().version()));
-         info->chain_id                   = controller.get_chain_id();
-         info->server_version_string      = app().version_string();
-         info->server_full_version_string = app().full_version_string();
+         info->server_version             = server_version;
+         info->chain_id                   = chain_id;
+         info->server_version_string      = server_version_string;
+         info->server_full_version_string = server_full_version_string;
 
          // chain head part
          const auto& head = controller.head();

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -4,6 +4,7 @@
 #include <eosio/chain_plugin/trx_retry_db.hpp>
 #include <eosio/chain_plugin/trx_finality_status_processing.hpp>
 #include <eosio/chain_plugin/tracked_votes.hpp>
+#include <eosio/chain_plugin/get_info_db.hpp>
 
 #include <eosio/chain/application.hpp>
 #include <eosio/chain/asset.hpp>
@@ -139,6 +140,7 @@ protected:
    
 class read_only : public api_base {
    const controller& db;
+   const std::optional<get_info_db>& gidb;
    const std::optional<account_query_db>& aqdb;
    const std::optional<tracked_votes>& last_tracked_votes;
    const fc::microseconds abi_serializer_max_time;
@@ -150,11 +152,15 @@ class read_only : public api_base {
 public:
    static const string KEYi64;
 
-   read_only(const controller& db, const std::optional<account_query_db>& aqdb,
-             const std::optional<tracked_votes>& last_tracked_votes,
-             const fc::microseconds& abi_serializer_max_time, const fc::microseconds& http_max_response_time,
-             const trx_finality_status_processing* trx_finality_status_proc)
+   read_only(const controller&                      db,
+             const std::optional<get_info_db>&      gidb,
+             const std::optional<account_query_db>& aqdb,
+             const std::optional<tracked_votes>&    last_tracked_votes,
+             const fc::microseconds&                abi_serializer_max_time,
+             const fc::microseconds&                http_max_response_time,
+             const trx_finality_status_processing*  trx_finality_status_proc)
       : db(db)
+      , gidb(gidb)
       , aqdb(aqdb)
       , last_tracked_votes(last_tracked_votes)
       , abi_serializer_max_time(abi_serializer_max_time)
@@ -174,33 +180,7 @@ public:
 
    using get_info_params = empty;
 
-   struct get_info_results {
-      string                               server_version;
-      chain::chain_id_type                 chain_id;
-      uint32_t                             head_block_num = 0;
-      uint32_t                             last_irreversible_block_num = 0;
-      chain::block_id_type                 last_irreversible_block_id;
-      chain::block_id_type                 head_block_id;
-      fc::time_point                       head_block_time;
-      account_name                         head_block_producer;
-
-      uint64_t                             virtual_block_cpu_limit = 0;
-      uint64_t                             virtual_block_net_limit = 0;
-
-      uint64_t                             block_cpu_limit = 0;
-      uint64_t                             block_net_limit = 0;
-      //string                               recent_slots;
-      //double                               participation_rate = 0;
-      std::optional<string>                server_version_string;
-      std::optional<uint32_t>              fork_db_head_block_num;
-      std::optional<chain::block_id_type>  fork_db_head_block_id;
-      std::optional<string>                server_full_version_string;
-      std::optional<uint64_t>              total_cpu_weight;
-      std::optional<uint64_t>              total_net_weight;
-      std::optional<uint32_t>              earliest_available_block_num;
-      std::optional<fc::time_point>        last_irreversible_block_time;
-   };
-   get_info_results get_info(const get_info_params&, const fc::time_point& deadline) const;
+   get_info_db::get_info_results get_info(const get_info_params&, const fc::time_point& deadline) const;
 
    struct get_transaction_status_params {
       chain::transaction_id_type           id;
@@ -970,15 +950,6 @@ public:
      }
  };
 
- template<typename I>
- std::string itoh(I n, size_t hlen = sizeof(I)<<1) {
-     static const char* digits = "0123456789abcdef";
-     std::string r(hlen, '0');
-     for(size_t i = 0, j = (hlen - 1) * 4 ; i < hlen; ++i, j -= 4)
-         r[i] = digits[(n>>j) & 0x0f];
-     return r;
- }
-
 } // namespace chain_apis
 
 class chain_plugin : public plugin<chain_plugin> {
@@ -1036,12 +1007,6 @@ private:
 FC_REFLECT( eosio::chain_apis::linked_action, (account)(action) )
 FC_REFLECT( eosio::chain_apis::permission, (perm_name)(parent)(required_auth)(linked_actions) )
 FC_REFLECT(eosio::chain_apis::empty, )
-FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
-           (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
-           (head_block_id)(head_block_time)(head_block_producer)
-           (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
-           (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)
-           (total_cpu_weight)(total_net_weight)(earliest_available_block_num)(last_irreversible_block_time))
 FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_params, (id) )
 FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_results, (state)(block_number)(block_id)(block_timestamp)(expiration)(head_number)(head_id)
            (head_timestamp)(irreversible_number)(irreversible_id)(irreversible_timestamp)(earliest_tracked_block_id)(earliest_tracked_block_number) )

--- a/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
@@ -55,6 +55,9 @@ namespace eosio::chain_apis {
       // Called on accepted_block signal
       void on_accepted_block();
 
+      // Called on irreversible_block signal
+      void on_irreversible_block();
+
       // Returns the cached get_info results
       get_info_results get_info() const;
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <eosio/chain/controller.hpp>
+
+namespace eosio::chain_apis {
+   /**
+    * This class manages the ephemeral data that is needed by `get_info` RPC call.
+    * There is no persistence and the data is recreated when the class is instantiated
+    * based on the current state of the chain.
+    */
+
+   class get_info_db {
+   public:
+
+      /**
+       * Instantiate a get_info results cache from the given chain controller.
+       * The caller is expected to manage lifetimes such that this controller
+       * reference does not go stale for the life of the cache.
+       * The cache is updated whenever accepted_block signal is received.
+       *
+       * @param chain            - controller to read data from
+       * @param get_info_enabled - true if get_info RPC endpoint is enabled
+       */
+      get_info_db( const class eosio::chain::controller& chain, bool get_info_enabled );
+      ~get_info_db();
+
+      /**
+       * get_info results
+       */
+      struct get_info_results {
+         std::string                          server_version;
+         chain::chain_id_type                 chain_id;
+         uint32_t                             head_block_num = 0;
+         uint32_t                             last_irreversible_block_num = 0;
+         chain::block_id_type                 last_irreversible_block_id;
+         chain::block_id_type                 head_block_id;
+         fc::time_point                       head_block_time;
+         chain::account_name                  head_block_producer;
+
+         uint64_t                             virtual_block_cpu_limit = 0;
+         uint64_t                             virtual_block_net_limit = 0;
+
+         uint64_t                             block_cpu_limit = 0;
+         uint64_t                             block_net_limit = 0;
+         std::optional<std::string>           server_version_string;
+         std::optional<uint32_t>              fork_db_head_block_num;
+         std::optional<chain::block_id_type>  fork_db_head_block_id;
+         std::optional<std::string>           server_full_version_string;
+         std::optional<uint64_t>              total_cpu_weight;
+         std::optional<uint64_t>              total_net_weight;
+         std::optional<uint32_t>              earliest_available_block_num;
+         std::optional<fc::time_point>        last_irreversible_block_time;
+      };
+
+      // Called on accepted_block signal
+      void on_accepted_block();
+
+      // Returns the cached get_info results
+      get_info_results get_info() const;
+
+   private:
+      std::unique_ptr<struct get_info_db_impl> _impl;
+   }; // get_info_db
+
+   template<typename I>
+   std::string itoh(I n, size_t hlen = sizeof(I)<<1) {
+       static const char* digits = "0123456789abcdef";
+       std::string r(hlen, '0');
+       for(size_t i = 0, j = (hlen - 1) * 4 ; i < hlen; ++i, j -= 4)
+           r[i] = digits[(n>>j) & 0x0f];
+       return r;
+   }
+} // namespace eosio::chain_apis
+
+FC_REFLECT(eosio::chain_apis::get_info_db::get_info_results,
+           (server_version)(chain_id)(head_block_num)(last_irreversible_block_num)(last_irreversible_block_id)
+           (head_block_id)(head_block_time)(head_block_producer)
+           (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
+           (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)
+           (total_cpu_weight)(total_net_weight)(earliest_available_block_num)(last_irreversible_block_time))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
@@ -50,6 +50,11 @@ namespace eosio::chain_apis {
          std::optional<uint64_t>              total_net_weight;
          std::optional<uint32_t>              earliest_available_block_num;
          std::optional<fc::time_point>        last_irreversible_block_time;
+
+         // Returns true if the struct contains full data for using.
+         bool contains_full_data() {
+            return (head_block_num > 0) && (last_irreversible_block_num > 0) && (fork_db_head_block_num > 0);
+         }
       };
 
       // Called on accepted_block signal

--- a/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
@@ -52,7 +52,7 @@ namespace eosio::chain_apis {
          std::optional<fc::time_point>        last_irreversible_block_time;
 
          // Returns true if the struct contains full data for using.
-         bool contains_full_data() {
+         bool contains_full_data() const {
             return (head_block_num > 0) && (last_irreversible_block_num > 0) && (fork_db_head_block_num > 0);
          }
       };

--- a/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
@@ -61,15 +61,6 @@ namespace eosio::chain_apis {
    private:
       std::unique_ptr<struct get_info_db_impl> _impl;
    }; // get_info_db
-
-   template<typename I>
-   std::string itoh(I n, size_t hlen = sizeof(I)<<1) {
-       static const char* digits = "0123456789abcdef";
-       std::string r(hlen, '0');
-       for(size_t i = 0, j = (hlen - 1) * 4 ; i < hlen; ++i, j -= 4)
-           r[i] = digits[(n>>j) & 0x0f];
-       return r;
-   }
 } // namespace eosio::chain_apis
 
 FC_REFLECT(eosio::chain_apis::get_info_db::get_info_results,

--- a/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/get_info_db.hpp
@@ -56,7 +56,7 @@ namespace eosio::chain_apis {
       void on_accepted_block();
 
       // Called on irreversible_block signal
-      void on_irreversible_block();
+      void on_irreversible_block(const chain::signed_block_ptr& block, const chain::block_id_type& lib);
 
       // Returns the cached get_info results
       get_info_results get_info() const;

--- a/plugins/prometheus_plugin/metrics.hpp
+++ b/plugins/prometheus_plugin/metrics.hpp
@@ -4,6 +4,7 @@
 #include <eosio/net_plugin/net_plugin.hpp>
 #include <eosio/producer_plugin/producer_plugin.hpp>
 #include <eosio/chain_plugin/tracked_votes.hpp>
+#include <eosio/chain_plugin/get_info_db.hpp>  // for itoh
 
 #include <prometheus/counter.h>
 #include <prometheus/info.h>

--- a/plugins/prometheus_plugin/metrics.hpp
+++ b/plugins/prometheus_plugin/metrics.hpp
@@ -4,7 +4,6 @@
 #include <eosio/net_plugin/net_plugin.hpp>
 #include <eosio/producer_plugin/producer_plugin.hpp>
 #include <eosio/chain_plugin/tracked_votes.hpp>
-#include <eosio/chain_plugin/get_info_db.hpp>  // for itoh
 
 #include <prometheus/counter.h>
 #include <prometheus/info.h>
@@ -284,7 +283,7 @@ struct catalog_type {
 
    void update_prometheus_info() {
       info_details = info.Add({
-            {"server_version", chain_apis::itoh(static_cast<uint32_t>(app().version()))},
+            {"server_version", fc::itoh(static_cast<uint32_t>(app().version()))},
             {"chain_id", app().get_plugin<chain_plugin>().get_chain_id()},
             {"server_version_string", app().version_string()},
             {"server_full_version_string", app().full_version_string()},

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -342,8 +342,8 @@ eosio::chain_apis::read_only::get_consensus_parameters_results get_consensus_par
    return call(::default_url, get_consensus_parameters_func).as<eosio::chain_apis::read_only::get_consensus_parameters_results>();
 }
 
-eosio::chain_apis::read_only::get_info_results get_info() {
-   return call(::default_url, get_info_func).as<eosio::chain_apis::read_only::get_info_results>();
+eosio::chain_apis::get_info_db::get_info_results get_info() {
+   return call(::default_url, get_info_func).as<eosio::chain_apis::get_info_db::get_info_results>();
 }
 
 string generate_nonce_string() {

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
    chain_apis::read_only::get_raw_block_params param{headnumstr};
-   chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
 
    // block should be decoded successfully
    auto block = plugin.get_raw_block(param, fc::time_point::maximum());
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
    tester t{setup_policy::old_wasm_parser};
    t.produce_block();
 
-   chain_apis::read_only plugin(*(t.control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
+   chain_apis::read_only plugin(*(t.control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
 
    auto parms = plugin.get_consensus_parameters({}, fc::time_point::maximum());
 
@@ -190,7 +190,7 @@ BOOST_FIXTURE_TEST_CASE( get_account, validating_tester ) try {
 
    produce_block();
 
-   chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
+   chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
 
    chain_apis::read_only::get_account_params p{"alice"_n};
 

--- a/tests/get_producers_tests.cpp
+++ b/tests/get_producers_tests.cpp
@@ -16,7 +16,7 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, T, testers ) { try {
       T chain;
 
-      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
       eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
       auto results = plugin.get_producers(params, fc::time_point::maximum());
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers_from_table, T, eosio_system::eosio_
       // ensure that enough voting is occurring so that producer1111 is elected as the producer
       chain.cross_15_percent_threshold();
 
-      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
       eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
       auto results = plugin.get_producers(params, fc::time_point::maximum());

--- a/tests/get_table_seckey_tests.cpp
+++ b/tests/get_table_seckey_tests.cpp
@@ -43,7 +43,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    set_abi( "test"_n, test_contracts::get_table_seckey_test_abi() );
    produce_block();
 
-   chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params = []{
       chain_apis::read_only::get_table_rows_params params{};
       params.json=true;

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -90,7 +90,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
    produce_block();
 
    // iterate over scope
-   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_by_scope_params param{"eosio.token"_n, "accounts"_n, "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param, fc::time_point::maximum());
 
@@ -195,7 +195,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    produce_block();
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio.token"_n;
    p.scope = "inita";
@@ -365,7 +365,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
    produce_block();
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio"_n;
    p.scope = "eosio";
@@ -517,7 +517,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    // }
 
 
-   chain_apis::read_only plugin(*(this->control), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params = []{
       chain_apis::read_only::get_table_rows_params params{};
       params.json=true;

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -226,7 +226,7 @@ public:
     read_only::get_account_results get_account_info(const account_name acct){
        auto account_object = control->get_account(acct);
        read_only::get_account_params params = { account_object.name };
-       chain_apis::read_only plugin(*(control.get()), {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+       chain_apis::read_only plugin(*(control.get()), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
        auto res =   plugin.get_account(params, fc::time_point::maximum())();
        BOOST_REQUIRE(!std::holds_alternative<fc::exception_ptr>(res));
        return std::get<chain_apis::read_only::get_account_results>(std::move(res));


### PR DESCRIPTION
`/v1/chain/get_info` is a top 1 or 2 used RPC endpoint (https://github.com/AntelopeIO/leap/issues/1212). It is currently processed on the `main` thread. Moving it off the main thread will reduce load on the `main` thread, and will shorten response time when the `main` thread is stuck (https://github.com/AntelopeIO/spring/issues/830).

This PR moves `get_info` off the `main` thread and runs it on `http` thread.  The data required by get_info is cached on `accept_block` signal  and is used to service `get_info` when needed.

Notably, the implementation is mutex free such that the `main` thread is never blocked by `get_info`.

Resolves https://github.com/AntelopeIO/spring/issues/527