### PR TITLE
[1.0.3] Limit apply blocks

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4472,7 +4472,7 @@ struct controller_impl {
                   }
                   // Break every ~500ms to allow other tasks (e.g. get_info, SHiP) opportunity to run. There is a post
                   // for every incoming blocks; enough posted tasks to apply all blocks queued to the fork db.
-                  if (!replaying && fc::time_point::now() - start > fc::microseconds(500))
+                  if (!replaying && fc::time_point::now() - start > fc::milliseconds(500))
                      break;
 
                } catch ( const std::bad_alloc& ) {


### PR DESCRIPTION
- Interrupt processing of blocks in tight apply block loop.
  - Provides much quicker shutdown during syncing.
  - Allows `v1/chain/get_info` calls to return quickly during syncing.
- Restores logging every 1000 blocks during replay.

Resolves #284