### PR TITLE
Limit apply blocks

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -230,15 +230,19 @@ namespace eosio::chain {
          void set_async_voting(async_t val);
          void set_async_aggregation(async_t val);
 
-         /// Apply any blocks that are ready from the forkdb
-         void apply_blocks(const forked_callback_t& cb, const trx_meta_cache_lookup& trx_lookup);
-
          struct accepted_block_result {
             const bool is_new_best_head = false; // true if new best head
             std::optional<block_handle> block;   // empty optional if block is unlinkable
          };
          // thread-safe
          accepted_block_result accept_block( const block_id_type& id, const signed_block_ptr& b ) const;
+
+         /// Apply any blocks that are ready from the forkdb
+         enum class apply_blocks_result {
+            complete,  // all ready blocks in forkdb have been applied
+            incomplete // time limit reached, additional blocks may be available in forkdb to process
+         };
+         apply_blocks_result apply_blocks(const forked_callback_t& cb, const trx_meta_cache_lookup& trx_lookup);
 
          boost::asio::io_context& get_thread_pool();
 

--- a/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/plugin_interface.hpp
@@ -30,7 +30,7 @@ namespace eosio::chain::plugin_interface {
    namespace incoming {
       namespace methods {
          // synchronously push a block/trx to a single provider, block_state_legacy_ptr may be null
-         using block_sync            = method_decl<chain_plugin_interface, bool(const signed_block_ptr&, const block_id_type&, const block_handle&), first_provider_policy>;
+         using block_sync            = method_decl<chain_plugin_interface, controller::apply_blocks_result(const signed_block_ptr&, const block_id_type&, const block_handle&), first_provider_policy>;
          using transaction_async     = method_decl<chain_plugin_interface, void(const packed_transaction_ptr&, bool, transaction_metadata::trx_type, bool, next_function<transaction_trace_ptr>), first_provider_policy>;
       }
    }

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -81,7 +81,7 @@ public:
    virtual void plugin_shutdown();
    void handle_sighup() override;
 
-   bool on_incoming_block();
+   controller::apply_blocks_result on_incoming_block();
 
    void pause();
    void resume();


### PR DESCRIPTION
- Interrupt processing of blocks in tight apply block loop.
  - Provides much quicker shutdown during syncing.
  - Allows `v1/chain/get_info` calls to return quickly during syncing.
- Restores logging every 1000 blocks during replay.

Note this takes a different approach for `main` than #921 does for `release/1.0` because `main` has the optimization of not posting a `handler_id::process_incoming_block` if one already exists.

Resolves #284