### PR TITLE
Update CLI11 and rename LeapFormatter

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2784,7 +2784,7 @@ int main( int argc, char** argv ) {
    CLI::App app{"Command Line Interface to EOSIO Client"};
 
    // custom leap formatter
-   auto fmt = std::make_shared<CLI::LeapFormatter>();
+   auto fmt = std::make_shared<CLI::SpringFormatter>();
    app.formatter(fmt);
 
    // enable help-all, display help on error

--- a/programs/spring-util/main.cpp
+++ b/programs/spring-util/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
    CLI::App app{"Spring Command Line Utility"};
 
    // custom leap formatter
-   auto fmt = std::make_shared<CLI::LeapFormatter>();
+   auto fmt = std::make_shared<CLI::SpringFormatter>();
    app.formatter(fmt);
 
    app.set_help_all_flag("--help-all", "Show all help");


### PR DESCRIPTION
Rename `LeapFormatter` to `SpringFormatter`.

Requires https://github.com/AntelopeIO/CLI11/pull/8
Minimum changes made to `AntelopeIO/CLI11` as it has been modified to add auto-completion and to add support for `SpringFromatter`. 

Note: `AntelopeIO/CLI11` is a fork of https://github.com/hailo-ai/CLI11 not https://github.com/CLIUtils/CLI11. Doesn't seem worth the effort at this point to do more. 

Resolves #569 