### PR TITLE
Enable tracked_votes processing only if http chain_ro category is configured

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -183,6 +183,11 @@ void chain_api_plugin::plugin_startup() {
          CHAIN_RO_CALL_WITH_400(get_transaction_status, 200, http_params_types::params_required),
       }, appbase::exec_queue::read_only);
    }
+
+   // Let ro_api's tracked_votes know whether chain_ro category is enabled
+   // to avoid extra processing.
+   bool chain_ro_enabled = _http_plugin.is_enabled(api_category::chain_ro);
+   ro_api.set_tracked_votes_tracking_enabled(chain_ro_enabled);
 }
 
 void chain_api_plugin::plugin_shutdown() {}

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -975,14 +975,15 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          }
       }
 
-      // only enable last tracked votes if chain_api_plugin enabled, if no http endpoint, no reason to track
+      _last_tracked_votes.emplace(*chain);
+
       bool chain_api_plugin_configured = false;
       if (options.count("plugin")) {
          const auto& v = options.at("plugin").as<std::vector<std::string>>();
          chain_api_plugin_configured = std::ranges::any_of(v, [](const std::string& p) { return p.find("eosio::chain_api_plugin") != std::string::npos; });
       }
-      _last_tracked_votes.emplace(*chain, chain_api_plugin_configured);
 
+      // only enable _get_info_db if chain_api_plugin enabled.
       _get_info_db.emplace(*chain, chain_api_plugin_configured);
 
       // initialize deep mind logging

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -975,39 +975,14 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          }
       }
 
-      // Find if chain_api_plugin is configured
+      // only enable last tracked votes if chain_api_plugin enabled, if no http endpoint, no reason to track
       bool chain_api_plugin_configured = false;
       if (options.count("plugin")) {
          const auto& v = options.at("plugin").as<std::vector<std::string>>();
          chain_api_plugin_configured = std::ranges::any_of(v, [](const std::string& p) { return p.find("eosio::chain_api_plugin") != std::string::npos; });
       }
+      _last_tracked_votes.emplace(*chain, chain_api_plugin_configured);
 
-      // Find if chain_ro category is configured.
-      // Only required validation is performed here; http_plugin does a full
-      // validation of http-category-address configurations.
-      bool chain_ro_category_configured = true;  // default is true if no `http-category-address` is configured
-      if (options.count("http-category-address")) {
-         chain_ro_category_configured = false; // if `http-category-address` is configured, a category must be explicitly configured.
-
-         auto addresses = options["http-category-address"].as<vector<string>>();
-         for (const auto& addr : addresses) {
-            auto comma_pos = addr.find(',');
-            EOS_ASSERT(comma_pos > 0 && comma_pos != std::string_view::npos, chain::plugin_config_exception,
-                       "http-category-address '${addr}' does not contain a required comma to separate the category and address",
-                       ("addr", addr));
-            auto category_name = addr.substr(0, comma_pos);
-            if (category_name == "chain_ro") {
-               chain_ro_category_configured = true;
-               break;
-            }
-         }
-      }
-
-      // only enable last tracked votes if chain_api_plugin and chain_ro are enabled.
-      bool tracking_enabled = chain_api_plugin_configured && chain_ro_category_configured;
-      _last_tracked_votes.emplace(*chain, tracking_enabled);
-
-      // only enable last tracked votes if chain_api_plugin enabled.
       _get_info_db.emplace(*chain, chain_api_plugin_configured);
 
       // initialize deep mind logging

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -142,7 +142,7 @@ class read_only : public api_base {
    const controller& db;
    const std::optional<get_info_db>& gidb;
    const std::optional<account_query_db>& aqdb;
-   const std::optional<tracked_votes>& last_tracked_votes;
+   std::optional<tracked_votes>& last_tracked_votes;
    const fc::microseconds abi_serializer_max_time;
    const fc::microseconds http_max_response_time;
    bool  shorten_abi_errors = true;
@@ -155,7 +155,7 @@ public:
    read_only(const controller&                      db,
              const std::optional<get_info_db>&      gidb,
              const std::optional<account_query_db>& aqdb,
-             const std::optional<tracked_votes>&    last_tracked_votes,
+             std::optional<tracked_votes>&          last_tracked_votes, // tracking_enabled of last_tracked_votes is set after it is constructed. const cannot be used here.
              const fc::microseconds&                abi_serializer_max_time,
              const fc::microseconds&                http_max_response_time,
              const trx_finality_status_processing*  trx_finality_status_proc)
@@ -177,6 +177,12 @@ public:
    }
 
    void set_shorten_abi_errors( bool f ) { shorten_abi_errors = f; }
+
+   void set_tracked_votes_tracking_enabled( bool flag ) {
+      if (last_tracked_votes) {
+         last_tracked_votes->set_tracking_enabled(flag);
+      }
+   }
 
    using get_info_params = empty;
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
@@ -19,7 +19,7 @@ namespace eosio::chain_apis {
        * @param tracking_enabled true if get_last_vote_info() vote tracking enabled
        * @param chain - controller to read data from
        */
-      explicit tracked_votes( const class eosio::chain::controller& chain, bool tracking_enabled );
+      explicit tracked_votes(const class eosio::chain::controller& chain);
       ~tracked_votes();
 
       /**

--- a/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/tracked_votes.hpp
@@ -42,6 +42,9 @@ namespace eosio::chain_apis {
       // Returns last vote information by a given finalizer
       std::optional<vote_info> get_last_vote_info(const fc::crypto::blslib::bls_public_key& finalizer_pub_key) const;
 
+      // Sets tracking_enabled
+      void set_tracking_enabled(bool enabled);
+
    private:
       std::unique_ptr<struct tracked_votes_impl> _impl;
    };

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -96,6 +96,10 @@ namespace eosio::chain_apis {
          return {};
       }
 
+      void set_tracking_enabled(bool enabled) {
+         tracking_enabled = enabled;
+      }
+
       void log_missing_votes(const chain::signed_block_ptr& block, const chain::block_id_type& id,
                              const chain::qc_vote_metrics_t::fin_auth_set_t& missing_votes,
                              uint32_t missed_block_num) const {
@@ -133,6 +137,10 @@ namespace eosio::chain_apis {
 
    std::optional<tracked_votes::vote_info> tracked_votes::get_last_vote_info(const fc::crypto::blslib::bls_public_key& finalizer_pub_key) const {
       return _impl->get_last_vote_info(finalizer_pub_key);
+   }
+
+   void tracked_votes::set_tracking_enabled(bool enabled) {
+      _impl->set_tracking_enabled(enabled);
    }
 
 } // namespace eosio::chain_apis

--- a/plugins/chain_plugin/tracked_votes.cpp
+++ b/plugins/chain_plugin/tracked_votes.cpp
@@ -10,9 +10,8 @@ namespace eosio::chain_apis {
     * Implementation details of the last tracked cache
     */
    struct tracked_votes_impl {
-      explicit tracked_votes_impl(const chain::controller& controller, bool tracking_enabled)
-      : tracking_enabled(tracking_enabled)
-      , controller(controller)
+      explicit tracked_votes_impl(const chain::controller& controller)
+      : controller(controller)
       {}
 
       bool tracking_enabled = false;
@@ -124,8 +123,8 @@ namespace eosio::chain_apis {
 
    }; // tracked_votes_impl
 
-   tracked_votes::tracked_votes( const chain::controller& controller, bool tracking_enabled )
-   :_impl(std::make_unique<tracked_votes_impl>(controller, tracking_enabled))
+   tracked_votes::tracked_votes( const chain::controller& controller )
+   :_impl(std::make_unique<tracked_votes_impl>(controller))
    {
    }
 

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -610,6 +610,15 @@ namespace eosio {
                          });
    }
 
+   // returns true if `category` is enabled in http_plugin
+   bool http_plugin::is_enabled(api_category category) const {
+      return std::any_of(my->categories_by_address.begin(), my->categories_by_address.end(),
+                         [&category, this](const auto& entry) {
+                            const auto& [address, categories] = entry;
+                            return categories.contains(category);
+                         });
+   }
+
    bool http_plugin::verbose_errors() {
       return verbose_http_errors;
    }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -113,6 +113,9 @@ namespace eosio {
 
         bool is_on_loopback(api_category category) const;
 
+        // returns true if `category` is enabled in http_plugin
+        bool is_enabled(api_category category) const;
+
         static bool verbose_errors();
 
         struct get_supported_apis_result {

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -89,7 +89,8 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, validating_tester ) try {
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
    chain_apis::read_only::get_raw_block_params param{headnumstr};
-   chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
 
    // block should be decoded successfully
    auto block = plugin.get_raw_block(param, fc::time_point::maximum());
@@ -134,7 +135,8 @@ BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
    tester t{setup_policy::old_wasm_parser};
    t.produce_block();
 
-   chain_apis::read_only plugin(*(t.control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
+   std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(t.control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
 
    auto parms = plugin.get_consensus_parameters({}, fc::time_point::maximum());
 
@@ -190,7 +192,8 @@ BOOST_FIXTURE_TEST_CASE( get_account, validating_tester ) try {
 
    produce_block();
 
-   chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
+   std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), nullptr);
 
    chain_apis::read_only::get_account_params p{"alice"_n};
 

--- a/tests/get_producers_tests.cpp
+++ b/tests/get_producers_tests.cpp
@@ -16,7 +16,8 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers, T, testers ) { try {
       T chain;
 
-      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+      std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
       eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
       auto results = plugin.get_producers(params, fc::time_point::maximum());
@@ -58,7 +59,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( get_producers_from_table, T, eosio_system::eosio_
       // ensure that enough voting is occurring so that producer1111 is elected as the producer
       chain.cross_15_percent_threshold();
 
-      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+      std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+      eosio::chain_apis::read_only plugin(*(chain.control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
       eosio::chain_apis::read_only::get_producers_params params = { .json = true, .lower_bound = "", .limit = 21 };
 
       auto results = plugin.get_producers(params, fc::time_point::maximum());

--- a/tests/get_table_seckey_tests.cpp
+++ b/tests/get_table_seckey_tests.cpp
@@ -43,7 +43,8 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    set_abi( "test"_n, test_contracts::get_table_seckey_test_abi() );
    produce_block();
 
-   chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params = []{
       chain_apis::read_only::get_table_rows_params params{};
       params.json=true;

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -90,7 +90,8 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
    produce_block();
 
    // iterate over scope
-   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_by_scope_params param{"eosio.token"_n, "accounts"_n, "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param, fc::time_point::maximum());
 
@@ -195,7 +196,8 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, validating_tester ) try {
    produce_block();
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio.token"_n;
    p.scope = "inita";
@@ -365,7 +367,8 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, validating_tester ) try {
    produce_block();
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+   eosio::chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio"_n;
    p.scope = "eosio";
@@ -517,7 +520,8 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    // }
 
 
-   chain_apis::read_only plugin(*(this->control), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+   std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params = []{
       chain_apis::read_only::get_table_rows_params params{};
       params.json=true;

--- a/tests/test_chain_plugin.cpp
+++ b/tests/test_chain_plugin.cpp
@@ -226,7 +226,8 @@ public:
     read_only::get_account_results get_account_info(const account_name acct){
        auto account_object = control->get_account(acct);
        read_only::get_account_params params = { account_object.name };
-       chain_apis::read_only plugin(*(control.get()), {}, {}, {}, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+       std::optional<eosio::chain_apis::tracked_votes> _tracked_votes;
+       chain_apis::read_only plugin(*(control.get()), {}, {}, _tracked_votes, fc::microseconds::maximum(), fc::microseconds::maximum(), {});
        auto res =   plugin.get_account(params, fc::time_point::maximum())();
        BOOST_REQUIRE(!std::holds_alternative<fc::exception_ptr>(res));
        return std::get<chain_apis::read_only::get_account_results>(std::move(res));


### PR DESCRIPTION
The chain_api_plugin does extra processing to support `v1/chain/get_finalizer_info` http endpoint. If the http `chain_ro` category is not enabled then there is no need to do the extra processing.

Resolves https://github.com/AntelopeIO/spring/issues/515