### PR TITLE
silence atomic_*<shared_ptr> warnings in recent libstdc++

### DIFF
--- a/plugins/chain_plugin/get_info_db.cpp
+++ b/plugins/chain_plugin/get_info_db.cpp
@@ -2,6 +2,11 @@
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/application.hpp>
 
+//libstdc++ flags atomic_*<shared_ptr> as deprecated in c++20. while libstdc++ 12 adds atomic<shared_ptr>, it is
+// still missing in libc++ 19
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 using namespace eosio;
 using namespace eosio::chain;
 using namespace appbase;
@@ -162,3 +167,5 @@ namespace eosio::chain_apis {
       return _impl->get_info();
    }
 } // namespace eosio::chain_apis
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
at least libstdc++ 14 complains about usage of these deprecated in c++20 (and removed in c++26) functions. Since this file is small enough, just silence deprecations in it for now until libc++ adds this in the future.

```
plugins/chain_plugin/get_info_db.cpp:144:15: warning: 'atomic_store<eosio::chain_apis::get_info_db::get_info_results>' is deprecated: use 'std::atomic<std::shared_ptr<T>>' instead [-Wdeprecated-declarations]
  144 |          std::atomic_store(&info_cache, info);  // replace current cache safely
      |               ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_atomic.h:181:5: note: 'atomic_store<eosio::chain_apis::get_info_db::get_info_results>' has been explicitly marked deprecated here
  181 |     _GLIBCXX20_DEPRECATED_SUGGEST("std::atomic<std::shared_ptr<T>>")
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/x86_64-pc-linux-gnu/bits/c++config.h:132:45: note: expanded from macro '_GLIBCXX20_DEPRECATED_SUGGEST'
  132 | # define _GLIBCXX20_DEPRECATED_SUGGEST(ALT) _GLIBCXX_DEPRECATED_SUGGEST(ALT)
      |                                             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/x86_64-pc-linux-gnu/bits/c++config.h:100:19: note: expanded from macro '_GLIBCXX_DEPRECATED_SUGGEST'
  100 |   __attribute__ ((__deprecated__ ("use '" ALT "' instead")))

```