### PR TITLE
Use constructor to construct `action` instead of assigning members after the fact.

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4665,11 +4665,8 @@ struct controller_impl {
     */
    signed_transaction get_on_block_transaction()
    {
-      action on_block_act;
-      on_block_act.account = config::system_account_name;
-      on_block_act.name = "onblock"_n;
-      on_block_act.authorization = vector<permission_level>{{config::system_account_name, config::active_name}};
-      on_block_act.data = fc::raw::pack(chain_head.header());
+      action on_block_act(vector<permission_level>{{config::system_account_name, config::active_name}},
+                          config::system_account_name, "onblock"_n, fc::raw::pack(chain_head.header()));
 
       signed_transaction trx;
       trx.actions.emplace_back(std::move(on_block_act));

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -816,8 +816,8 @@ namespace impl {
          const variant_object& vo = v.get_object();
          EOS_ASSERT(vo.contains("account"), packed_transaction_type_exception, "Missing account");
          EOS_ASSERT(vo.contains("name"), packed_transaction_type_exception, "Missing name");
-         from_variant(vo["account"], act.account);
-         from_variant(vo["name"], act.name);
+         from_variant(vo["account"], const_cast<account_name&>(act.account));
+         from_variant(vo["name"], const_cast<action_name&>(act.name));
 
          if (vo.contains("authorization")) {
             from_variant(vo["authorization"], act.authorization);

--- a/libraries/chain/include/eosio/chain/action.hpp
+++ b/libraries/chain/include/eosio/chain/action.hpp
@@ -3,7 +3,7 @@
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/exceptions.hpp>
 
-namespace eosio { namespace chain {
+namespace eosio::chain {
 
    struct permission_level {
       account_name    actor;
@@ -54,11 +54,29 @@ namespace eosio { namespace chain {
     *  were properly declared when it executes.
     */
    struct action_base {
-      account_name             account;
-      action_name              name;
+      const account_name             account;
+      const action_name              name;
       vector<permission_level> authorization;
 
       action_base() = default;
+
+      action_base(action_base&&) = default;
+      action_base& operator=(action_base&& o) {
+         if (this != &o) {
+            std::destroy_at(this);
+            std::construct_at(this, std::move(o));
+         }
+         return *this;
+      }
+
+      action_base(const action_base&) = default;
+      action_base& operator=(const action_base& o) {
+         if (this != &o) {
+            std::destroy_at(this);
+            std::construct_at(this, o);
+         }
+         return *this;
+      }
 
       action_base( account_name acnt, action_name act, const vector<permission_level>& auth )
          : account(acnt), name(act), authorization(auth) {}
@@ -70,6 +88,12 @@ namespace eosio { namespace chain {
       bytes                      data;
 
       action() = default;
+
+      action(action&&) = default;
+      action& operator=(action&&) = default;
+
+      action(const action&) = default;
+      action& operator=(const action&) = default;
 
       template<typename T, std::enable_if_t<std::is_base_of<bytes, T>::value, int> = 1>
       action( vector<permission_level> auth, const T& value )
@@ -131,7 +155,7 @@ namespace eosio { namespace chain {
       account_name receiver;
    };
 
-} } /// namespace eosio::chain
+} /// namespace eosio::chain
 
 FC_REFLECT( eosio::chain::permission_level, (actor)(permission) )
 FC_REFLECT( eosio::chain::action_base, (account)(name)(authorization) )

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -79,6 +79,12 @@ namespace eosio { namespace chain {
       vector<action>         actions;
       extensions_type        transaction_extensions;
 
+      transaction() = default;
+      transaction(transaction&&) = default;
+      transaction(const transaction&) = default;
+      transaction& operator=(transaction&&) = default;
+      transaction& operator=(const transaction&) = default;
+
       transaction_id_type        id()const;
       digest_type                sig_digest( const chain_id_type& chain_id, const vector<bytes>& cfd = vector<bytes>() )const;
       fc::microseconds           get_signature_keys( const vector<signature_type>& signatures,

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -963,14 +963,11 @@ void push_trx(Tester& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cpu
               bool explicit_bill, std::vector<char> payload = {}, name account = "testapi"_n, transaction_metadata::trx_type trx_type = transaction_metadata::trx_type::input ) {
    signed_transaction trx;
 
-   action act;
-   act.account = ac.get_account();
-   act.name = ac.get_name();
-   if ( trx_type != transaction_metadata::trx_type::read_only ) {
-      auto pl = vector<permission_level>{{account, config::active_name}};
-      act.authorization = pl;
-   }
-   act.data = payload;
+   auto pl = vector<permission_level>{};
+   if ( trx_type != transaction_metadata::trx_type::read_only )
+      pl = vector<permission_level>{{account, config::active_name}};
+
+   action act(std::move(pl), ac.get_account(), ac.get_name(), payload);
 
    trx.actions.push_back(act);
    test.set_transaction_headers(trx);

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( block_with_invalid_tx_mroot_test, T, testers )
    auto signed_tx = packed_trx.get_signed_transaction();
 
    // Change the transaction that will be run
-   signed_tx.actions[0].name = "something"_n;
+   const_cast<action_name&>(signed_tx.actions[0].name) = "something"_n;
    // Re-sign the transaction
    signed_tx.signatures.clear();
    signed_tx.sign(main.get_private_key(config::system_account_name, "active"), main.get_chain_id());

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -25,11 +25,8 @@ class currency_tester : public T {
       auto push_action(const account_name& signer, const action_name &name, const variant_object &data ) {
          string action_type_name = abi_ser.get_action_type(name);
 
-         action act;
-         act.account = "eosio.token"_n;
-         act.name = name;
-         act.authorization = vector<permission_level>{{signer, config::active_name}};
-         act.data = abi_ser.variant_to_binary(action_type_name, data, abi_serializer::create_yield_function( T::abi_serializer_max_time ));
+         action act(vector<permission_level>{{signer, config::active_name}}, "eosio.token"_n, name,
+                    abi_ser.variant_to_binary(action_type_name, data, abi_serializer::create_yield_function( T::abi_serializer_max_time )));
 
          signed_transaction trx;
          trx.actions.emplace_back(std::move(act));
@@ -422,15 +419,9 @@ BOOST_FIXTURE_TEST_CASE( test_proxy_deferred, pre_disable_deferred_trx_currency_
    // set up proxy owner
    {
       signed_transaction trx;
-      action setowner_act;
-      setowner_act.account = "proxy"_n;
-      setowner_act.name = "setowner"_n;
-      setowner_act.authorization = vector<permission_level>{{"proxy"_n, config::active_name}};
-      setowner_act.data = proxy_abi_ser.variant_to_binary("setowner", mutable_variant_object()
-         ("owner", "alice")
-         ("delay", 10),
-         abi_serializer::create_yield_function( abi_serializer_max_time )
-      );
+      action setowner_act(vector<permission_level>{{"proxy"_n, config::active_name}}, "proxy"_n, "setowner"_n,
+                          proxy_abi_ser.variant_to_binary("setowner", mutable_variant_object()("owner", "alice")("delay", 10),
+                                                          abi_serializer::create_yield_function( abi_serializer_max_time )));
       trx.actions.emplace_back(std::move(setowner_act));
 
       set_transaction_headers(trx);
@@ -478,15 +469,9 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, pre_disable_deferred_trx_currenc
    // set up proxy owner
    {
       signed_transaction trx;
-      action setowner_act;
-      setowner_act.account = "proxy"_n;
-      setowner_act.name = "setowner"_n;
-      setowner_act.authorization = vector<permission_level>{{"proxy"_n, config::active_name}};
-      setowner_act.data = proxy_abi_ser.variant_to_binary("setowner", mutable_variant_object()
-         ("owner", "bob")
-         ("delay", 10),
-         abi_serializer::create_yield_function( abi_serializer_max_time )
-      );
+      action setowner_act(vector<permission_level>{{"proxy"_n, config::active_name}}, "proxy"_n, "setowner"_n,
+                          proxy_abi_ser.variant_to_binary("setowner", mutable_variant_object()("owner", "bob")("delay", 10),
+                                                          abi_serializer::create_yield_function( abi_serializer_max_time )));
       trx.actions.emplace_back(std::move(setowner_act));
 
       set_transaction_headers(trx);
@@ -529,15 +514,11 @@ BOOST_FIXTURE_TEST_CASE( test_deferred_failure, pre_disable_deferred_trx_currenc
    // set up alice owner
    {
       signed_transaction trx;
-      action setowner_act;
-      setowner_act.account = "bob"_n;
-      setowner_act.name = "setowner"_n;
-      setowner_act.authorization = vector<permission_level>{{"bob"_n, config::active_name}};
-      setowner_act.data = proxy_abi_ser.variant_to_binary("setowner", mutable_variant_object()
-         ("owner", "alice")
-         ("delay", 0),
-         abi_serializer::create_yield_function( abi_serializer_max_time )
-      );
+
+      action setowner_act(vector<permission_level>{{"bob"_n, config::active_name}},
+                          "bob"_n, "setowner"_n,
+                          proxy_abi_ser.variant_to_binary("setowner", mutable_variant_object()("owner", "alice")("delay", 0),
+                                                          abi_serializer::create_yield_function(abi_serializer_max_time)));
       trx.actions.emplace_back(std::move(setowner_act));
 
       set_transaction_headers(trx);

--- a/unittests/dry_run_trx_tests.cpp
+++ b/unittests/dry_run_trx_tests.cpp
@@ -44,13 +44,8 @@ struct dry_run_trx_tester : T {
 
    auto send_db_api_transaction(action_name name, bytes data, const vector<permission_level>& auth={{"alice"_n, config::active_name}},
                                 transaction_metadata::trx_type type=transaction_metadata::trx_type::input, uint32_t delay_sec=0) {
-      action act;
+      action act(auth, "noauthtable"_n, name, data);
       signed_transaction trx;
-
-      act.account = "noauthtable"_n;
-      act.name = name;
-      act.authorization = auth;
-      act.data = data;
 
       trx.actions.push_back( act );
       T::set_transaction_headers( trx );

--- a/unittests/eosio.token_tests.cpp
+++ b/unittests/eosio.token_tests.cpp
@@ -41,10 +41,9 @@ public:
    T::action_result push_action( const account_name& signer, const action_name &name, const variant_object &data ) {
       string action_type_name = abi_ser.get_action_type(name);
 
-      action act;
-      act.account = "eosio.token"_n;
-      act.name    = name;
-      act.data    = abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function( T::abi_serializer_max_time ) );
+      action act({}, "eosio.token"_n, name,
+                 abi_ser.variant_to_binary( action_type_name, data,
+                                            abi_serializer::create_yield_function( T::abi_serializer_max_time )));
 
       return base_tester::push_action( std::move(act), signer.to_uint64_t() );
    }

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -879,13 +879,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(only_bill_to_first_authorizer, T, testers) { try {
    chain.produce_block();
 
    {
-      action act;
-      act.account = tester_account;
-      act.name = "null"_n;
-      act.authorization = vector<permission_level>{
-         {tester_account, config::active_name},
-         {tester_account2, config::active_name}
-      };
+      action act(vector<permission_level>{{tester_account, config::active_name},
+                                          {tester_account2, config::active_name}}, tester_account, "null"_n, {});
 
       signed_transaction trx;
       trx.actions.emplace_back(std::move(act));
@@ -924,13 +919,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(only_bill_to_first_authorizer, T, testers) { try {
    chain.produce_block();
 
    {
-      action act;
-      act.account = tester_account;
-      act.name = "null2"_n;
-      act.authorization = vector<permission_level>{
-         {tester_account, config::active_name},
-         {tester_account2, config::active_name}
-      };
+      action act(vector<permission_level>{{tester_account, config::active_name},
+                                          {tester_account2, config::active_name}}, tester_account, "null2"_n, {});
 
       signed_transaction trx;
       trx.actions.emplace_back(std::move(act));
@@ -1452,10 +1442,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(webauthn_recover_key, T, testers) { try {
    c.produce_block();
 
    signed_transaction trx;
-   action act;
-   act.account = "bob"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"bob"_n,config::active_name}};
+   action act(vector<permission_level>{{"bob"_n,config::active_name}}, "bob"_n, ""_n, {});
    trx.actions.push_back(act);
 
    c.set_transaction_headers(trx);
@@ -1500,10 +1487,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(webauthn_assert_recover_key, T, testers) { try {
    c.produce_block();
 
    signed_transaction trx;
-   action act;
-   act.account = "bob"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"bob"_n,config::active_name}};
+   action act(vector<permission_level>{{"bob"_n,config::active_name}}, "bob"_n, ""_n, {});
    trx.actions.push_back(act);
 
    c.set_transaction_headers(trx);

--- a/unittests/read_only_trx_tests.cpp
+++ b/unittests/read_only_trx_tests.cpp
@@ -42,13 +42,8 @@ struct read_only_trx_tester : T {
    }
 
    auto send_db_api_transaction( action_name name, bytes data, const vector<permission_level>& auth={{"alice"_n, config::active_name}}, transaction_metadata::trx_type type=transaction_metadata::trx_type::input, uint32_t delay_sec=0 ) {
-      action act;
+      action act(auth, "noauthtable"_n, name, data);
       signed_transaction trx;
-
-      act.account = "noauthtable"_n;
-      act.name = name;
-      act.authorization = auth;
-      act.data = data;
 
       trx.actions.push_back( act );
       T::set_transaction_headers( trx );

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -672,10 +672,7 @@ void jumbo_row_test()
    chain.produce_block();
 
    signed_transaction trx;
-   action act;
-   act.account = "jumbo"_n;
-   act.name = "jumbo"_n;
-   act.authorization = vector<permission_level>{{"jumbo"_n,config::active_name}};
+   action act(vector<permission_level>{{"jumbo"_n,config::active_name}}, "jumbo"_n, "jumbo"_n, {});
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx);

--- a/unittests/wasm-spec-tests/generated-tests/address.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/address.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(address_0_check_throw, boost::unit_test::data::xrange(0,11)
    tester.set_code("wasmtest"_n, wasm_address_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(address_0_pass, boost::unit_test::data::xrange(11,12), inde
    tester.set_code("wasmtest"_n, wasm_address_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -49,10 +43,7 @@ BOOST_DATA_TEST_CASE(address_2_check_throw, boost::unit_test::data::xrange(0,15)
    tester.set_code("wasmtest"_n, wasm_address_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -66,10 +57,7 @@ BOOST_DATA_TEST_CASE(address_2_pass, boost::unit_test::data::xrange(15,17), inde
    tester.set_code("wasmtest"_n, wasm_address_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -87,10 +75,7 @@ BOOST_DATA_TEST_CASE(address_3_check_throw, boost::unit_test::data::xrange(0,3),
    tester.set_code("wasmtest"_n, wasm_address_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -104,10 +89,7 @@ BOOST_DATA_TEST_CASE(address_3_pass, boost::unit_test::data::xrange(3,4), index)
    tester.set_code("wasmtest"_n, wasm_address_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -125,10 +107,7 @@ BOOST_DATA_TEST_CASE(address_4_check_throw, boost::unit_test::data::xrange(0,3),
    tester.set_code("wasmtest"_n, wasm_address_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -142,10 +121,7 @@ BOOST_DATA_TEST_CASE(address_4_pass, boost::unit_test::data::xrange(3,4), index)
    tester.set_code("wasmtest"_n, wasm_address_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/align.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/align.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(align_0_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(align_1_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(align_10_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_10);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(align_106_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_106);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -95,10 +83,7 @@ BOOST_DATA_TEST_CASE(align_107_check_throw, boost::unit_test::data::xrange(0,1),
    tester.set_code("wasmtest"_n, wasm_align_107);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -112,10 +97,7 @@ BOOST_DATA_TEST_CASE(align_107_pass, boost::unit_test::data::xrange(1,2), index)
    tester.set_code("wasmtest"_n, wasm_align_107);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -133,10 +115,7 @@ BOOST_DATA_TEST_CASE(align_11_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_11);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -154,10 +133,7 @@ BOOST_DATA_TEST_CASE(align_12_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_12);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -175,10 +151,7 @@ BOOST_DATA_TEST_CASE(align_13_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_13);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -196,10 +169,7 @@ BOOST_DATA_TEST_CASE(align_14_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_14);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -217,10 +187,7 @@ BOOST_DATA_TEST_CASE(align_15_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_15);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -238,10 +205,7 @@ BOOST_DATA_TEST_CASE(align_16_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_16);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -259,10 +223,7 @@ BOOST_DATA_TEST_CASE(align_17_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_17);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -280,10 +241,7 @@ BOOST_DATA_TEST_CASE(align_18_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_18);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -301,10 +259,7 @@ BOOST_DATA_TEST_CASE(align_19_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_19);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -322,10 +277,7 @@ BOOST_DATA_TEST_CASE(align_2_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -343,10 +295,7 @@ BOOST_DATA_TEST_CASE(align_20_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_20);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -364,10 +313,7 @@ BOOST_DATA_TEST_CASE(align_21_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_21);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -385,10 +331,7 @@ BOOST_DATA_TEST_CASE(align_22_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_align_22);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -406,10 +349,7 @@ BOOST_DATA_TEST_CASE(align_3_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -427,10 +367,7 @@ BOOST_DATA_TEST_CASE(align_4_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -448,10 +385,7 @@ BOOST_DATA_TEST_CASE(align_5_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_5);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -469,10 +403,7 @@ BOOST_DATA_TEST_CASE(align_6_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_6);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -490,10 +421,7 @@ BOOST_DATA_TEST_CASE(align_7_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_7);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -511,10 +439,7 @@ BOOST_DATA_TEST_CASE(align_8_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_8);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -532,10 +457,7 @@ BOOST_DATA_TEST_CASE(align_9_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_align_9);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/binary-leb128.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/binary-leb128.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_0_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_1_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_10_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_10);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_11_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_11);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -95,10 +83,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_12_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_12);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -116,10 +101,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_13_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_13);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -137,10 +119,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_14_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_14);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -158,10 +137,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_15_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_15);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -179,10 +155,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_16_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_16);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -200,10 +173,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_17_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_17);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -221,10 +191,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_18_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_18);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -242,10 +209,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_19_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_19);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -263,10 +227,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_2_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -284,10 +245,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_20_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_20);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -305,10 +263,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_21_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_21);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -326,10 +281,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_22_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_22);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -347,10 +299,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_23_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_23);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -368,10 +317,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_24_module, boost::unit_test::data::xrange(0,1
    tester.set_code("wasmtest"_n, wasm_binary_leb128_24);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -389,10 +335,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_3_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -410,10 +353,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_4_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -431,10 +371,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_5_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_5);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -452,10 +389,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_6_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_6);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -473,10 +407,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_7_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_7);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -494,10 +425,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_8_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_8);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -515,10 +443,7 @@ BOOST_DATA_TEST_CASE(binary_leb128_9_module, boost::unit_test::data::xrange(0,1)
    tester.set_code("wasmtest"_n, wasm_binary_leb128_9);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/binary.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/binary.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(binary_0_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_binary_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(binary_1_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_binary_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(binary_2_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_binary_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(binary_3_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_binary_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -95,10 +83,7 @@ BOOST_DATA_TEST_CASE(binary_48_module, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_binary_48);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -116,10 +101,7 @@ BOOST_DATA_TEST_CASE(binary_53_module, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_binary_53);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -137,10 +119,7 @@ BOOST_DATA_TEST_CASE(binary_54_module, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_binary_54);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/block.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/block.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(block_0_pass, boost::unit_test::data::xrange(0,1), index) {
    tester.set_code("wasmtest"_n, wasm_block_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/br.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/br.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(br_0_pass, boost::unit_test::data::xrange(0,1), index) { tr
    tester.set_code("wasmtest"_n, wasm_br_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/br_if.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/br_if.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(br_if_0_pass, boost::unit_test::data::xrange(0,1), index) {
    tester.set_code("wasmtest"_n, wasm_br_if_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/br_table.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/br_table.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(br_table_0_pass, boost::unit_test::data::xrange(0,2), index
    tester.set_code("wasmtest"_n, wasm_br_table_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/break-drop.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/break-drop.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(break_drop_0_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_break_drop_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/call.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/call.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(call_0_check_throw, boost::unit_test::data::xrange(0,3), in
    tester.set_code("wasmtest"_n, wasm_call_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(call_0_pass, boost::unit_test::data::xrange(3,4), index) { 
    tester.set_code("wasmtest"_n, wasm_call_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/call_indirect.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/call_indirect.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(call_indirect_0_check_throw, boost::unit_test::data::xrange
    tester.set_code("wasmtest"_n, wasm_call_indirect_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(call_indirect_0_pass, boost::unit_test::data::xrange(15,17)
    tester.set_code("wasmtest"_n, wasm_call_indirect_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/const.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/const.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(const_0_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(const_1_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(const_100_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_100);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(const_101_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_101);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -95,10 +83,7 @@ BOOST_DATA_TEST_CASE(const_102_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_102);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -116,10 +101,7 @@ BOOST_DATA_TEST_CASE(const_103_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_103);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -137,10 +119,7 @@ BOOST_DATA_TEST_CASE(const_104_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_104);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -158,10 +137,7 @@ BOOST_DATA_TEST_CASE(const_105_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_105);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -179,10 +155,7 @@ BOOST_DATA_TEST_CASE(const_106_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_106);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -200,10 +173,7 @@ BOOST_DATA_TEST_CASE(const_107_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_107);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -221,10 +191,7 @@ BOOST_DATA_TEST_CASE(const_108_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_108);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -242,10 +209,7 @@ BOOST_DATA_TEST_CASE(const_109_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_109);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -263,10 +227,7 @@ BOOST_DATA_TEST_CASE(const_110_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_110);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -284,10 +245,7 @@ BOOST_DATA_TEST_CASE(const_111_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_111);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -305,10 +263,7 @@ BOOST_DATA_TEST_CASE(const_112_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_112);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -326,10 +281,7 @@ BOOST_DATA_TEST_CASE(const_113_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_113);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -347,10 +299,7 @@ BOOST_DATA_TEST_CASE(const_114_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_114);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -368,10 +317,7 @@ BOOST_DATA_TEST_CASE(const_115_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_115);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -389,10 +335,7 @@ BOOST_DATA_TEST_CASE(const_116_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_116);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -410,10 +353,7 @@ BOOST_DATA_TEST_CASE(const_117_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_117);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -431,10 +371,7 @@ BOOST_DATA_TEST_CASE(const_118_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_118);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -452,10 +389,7 @@ BOOST_DATA_TEST_CASE(const_119_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_119);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -473,10 +407,7 @@ BOOST_DATA_TEST_CASE(const_12_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_12);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -494,10 +425,7 @@ BOOST_DATA_TEST_CASE(const_120_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_120);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -515,10 +443,7 @@ BOOST_DATA_TEST_CASE(const_121_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_121);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -536,10 +461,7 @@ BOOST_DATA_TEST_CASE(const_122_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_122);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -557,10 +479,7 @@ BOOST_DATA_TEST_CASE(const_123_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_123);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -578,10 +497,7 @@ BOOST_DATA_TEST_CASE(const_124_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_124);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -599,10 +515,7 @@ BOOST_DATA_TEST_CASE(const_125_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_125);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -620,10 +533,7 @@ BOOST_DATA_TEST_CASE(const_126_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_126);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -641,10 +551,7 @@ BOOST_DATA_TEST_CASE(const_127_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_127);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -662,10 +569,7 @@ BOOST_DATA_TEST_CASE(const_128_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_128);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -683,10 +587,7 @@ BOOST_DATA_TEST_CASE(const_129_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_129);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -704,10 +605,7 @@ BOOST_DATA_TEST_CASE(const_13_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_13);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -725,10 +623,7 @@ BOOST_DATA_TEST_CASE(const_130_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_130);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -746,10 +641,7 @@ BOOST_DATA_TEST_CASE(const_131_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_131);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -767,10 +659,7 @@ BOOST_DATA_TEST_CASE(const_132_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_132);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -788,10 +677,7 @@ BOOST_DATA_TEST_CASE(const_133_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_133);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -809,10 +695,7 @@ BOOST_DATA_TEST_CASE(const_134_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_134);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -830,10 +713,7 @@ BOOST_DATA_TEST_CASE(const_135_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_135);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -851,10 +731,7 @@ BOOST_DATA_TEST_CASE(const_136_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_136);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -872,10 +749,7 @@ BOOST_DATA_TEST_CASE(const_137_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_137);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -893,10 +767,7 @@ BOOST_DATA_TEST_CASE(const_138_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_138);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -914,10 +785,7 @@ BOOST_DATA_TEST_CASE(const_139_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_139);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -935,10 +803,7 @@ BOOST_DATA_TEST_CASE(const_140_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_140);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -956,10 +821,7 @@ BOOST_DATA_TEST_CASE(const_141_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_141);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -977,10 +839,7 @@ BOOST_DATA_TEST_CASE(const_142_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_142);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -998,10 +857,7 @@ BOOST_DATA_TEST_CASE(const_143_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_143);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1019,10 +875,7 @@ BOOST_DATA_TEST_CASE(const_144_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_144);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1040,10 +893,7 @@ BOOST_DATA_TEST_CASE(const_145_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_145);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1061,10 +911,7 @@ BOOST_DATA_TEST_CASE(const_146_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_146);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1082,10 +929,7 @@ BOOST_DATA_TEST_CASE(const_147_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_147);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1103,10 +947,7 @@ BOOST_DATA_TEST_CASE(const_148_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_148);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1124,10 +965,7 @@ BOOST_DATA_TEST_CASE(const_149_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_149);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1145,10 +983,7 @@ BOOST_DATA_TEST_CASE(const_150_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_150);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1166,10 +1001,7 @@ BOOST_DATA_TEST_CASE(const_151_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_151);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1187,10 +1019,7 @@ BOOST_DATA_TEST_CASE(const_152_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_152);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1208,10 +1037,7 @@ BOOST_DATA_TEST_CASE(const_153_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_153);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1229,10 +1055,7 @@ BOOST_DATA_TEST_CASE(const_154_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_154);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1250,10 +1073,7 @@ BOOST_DATA_TEST_CASE(const_155_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_155);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1271,10 +1091,7 @@ BOOST_DATA_TEST_CASE(const_156_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_156);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1292,10 +1109,7 @@ BOOST_DATA_TEST_CASE(const_157_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_157);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1313,10 +1127,7 @@ BOOST_DATA_TEST_CASE(const_158_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_158);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1334,10 +1145,7 @@ BOOST_DATA_TEST_CASE(const_159_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_159);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1355,10 +1163,7 @@ BOOST_DATA_TEST_CASE(const_16_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_16);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1376,10 +1181,7 @@ BOOST_DATA_TEST_CASE(const_160_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_160);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1397,10 +1199,7 @@ BOOST_DATA_TEST_CASE(const_161_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_161);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1418,10 +1217,7 @@ BOOST_DATA_TEST_CASE(const_162_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_162);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1439,10 +1235,7 @@ BOOST_DATA_TEST_CASE(const_163_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_163);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1460,10 +1253,7 @@ BOOST_DATA_TEST_CASE(const_164_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_164);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1481,10 +1271,7 @@ BOOST_DATA_TEST_CASE(const_165_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_165);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1502,10 +1289,7 @@ BOOST_DATA_TEST_CASE(const_166_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_166);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1523,10 +1307,7 @@ BOOST_DATA_TEST_CASE(const_167_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_167);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1544,10 +1325,7 @@ BOOST_DATA_TEST_CASE(const_168_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_168);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1565,10 +1343,7 @@ BOOST_DATA_TEST_CASE(const_169_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_169);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1586,10 +1361,7 @@ BOOST_DATA_TEST_CASE(const_17_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_17);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1607,10 +1379,7 @@ BOOST_DATA_TEST_CASE(const_170_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_170);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1628,10 +1397,7 @@ BOOST_DATA_TEST_CASE(const_171_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_171);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1649,10 +1415,7 @@ BOOST_DATA_TEST_CASE(const_172_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_172);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1670,10 +1433,7 @@ BOOST_DATA_TEST_CASE(const_173_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_173);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1691,10 +1451,7 @@ BOOST_DATA_TEST_CASE(const_174_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_174);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1712,10 +1469,7 @@ BOOST_DATA_TEST_CASE(const_175_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_175);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1733,10 +1487,7 @@ BOOST_DATA_TEST_CASE(const_176_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_176);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1754,10 +1505,7 @@ BOOST_DATA_TEST_CASE(const_177_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_177);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1775,10 +1523,7 @@ BOOST_DATA_TEST_CASE(const_178_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_178);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1796,10 +1541,7 @@ BOOST_DATA_TEST_CASE(const_179_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_179);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1817,10 +1559,7 @@ BOOST_DATA_TEST_CASE(const_18_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_18);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1838,10 +1577,7 @@ BOOST_DATA_TEST_CASE(const_180_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_180);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1859,10 +1595,7 @@ BOOST_DATA_TEST_CASE(const_181_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_181);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1880,10 +1613,7 @@ BOOST_DATA_TEST_CASE(const_182_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_182);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1901,10 +1631,7 @@ BOOST_DATA_TEST_CASE(const_183_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_183);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1922,10 +1649,7 @@ BOOST_DATA_TEST_CASE(const_184_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_184);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1943,10 +1667,7 @@ BOOST_DATA_TEST_CASE(const_185_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_185);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1964,10 +1685,7 @@ BOOST_DATA_TEST_CASE(const_186_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_186);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1985,10 +1703,7 @@ BOOST_DATA_TEST_CASE(const_187_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_187);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2006,10 +1721,7 @@ BOOST_DATA_TEST_CASE(const_188_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_188);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2027,10 +1739,7 @@ BOOST_DATA_TEST_CASE(const_189_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_189);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2048,10 +1757,7 @@ BOOST_DATA_TEST_CASE(const_19_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_19);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2069,10 +1775,7 @@ BOOST_DATA_TEST_CASE(const_190_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_190);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2090,10 +1793,7 @@ BOOST_DATA_TEST_CASE(const_191_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_191);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2111,10 +1811,7 @@ BOOST_DATA_TEST_CASE(const_192_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_192);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2132,10 +1829,7 @@ BOOST_DATA_TEST_CASE(const_193_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_193);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2153,10 +1847,7 @@ BOOST_DATA_TEST_CASE(const_194_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_194);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2174,10 +1865,7 @@ BOOST_DATA_TEST_CASE(const_195_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_195);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2195,10 +1883,7 @@ BOOST_DATA_TEST_CASE(const_196_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_196);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2216,10 +1901,7 @@ BOOST_DATA_TEST_CASE(const_197_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_197);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2237,10 +1919,7 @@ BOOST_DATA_TEST_CASE(const_198_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_198);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2258,10 +1937,7 @@ BOOST_DATA_TEST_CASE(const_199_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_199);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2279,10 +1955,7 @@ BOOST_DATA_TEST_CASE(const_20_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_20);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2300,10 +1973,7 @@ BOOST_DATA_TEST_CASE(const_200_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_200);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2321,10 +1991,7 @@ BOOST_DATA_TEST_CASE(const_201_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_201);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2342,10 +2009,7 @@ BOOST_DATA_TEST_CASE(const_202_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_202);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2363,10 +2027,7 @@ BOOST_DATA_TEST_CASE(const_203_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_203);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2384,10 +2045,7 @@ BOOST_DATA_TEST_CASE(const_204_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_204);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2405,10 +2063,7 @@ BOOST_DATA_TEST_CASE(const_205_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_205);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2426,10 +2081,7 @@ BOOST_DATA_TEST_CASE(const_206_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_206);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2447,10 +2099,7 @@ BOOST_DATA_TEST_CASE(const_207_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_207);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2468,10 +2117,7 @@ BOOST_DATA_TEST_CASE(const_208_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_208);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2489,10 +2135,7 @@ BOOST_DATA_TEST_CASE(const_209_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_209);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2510,10 +2153,7 @@ BOOST_DATA_TEST_CASE(const_21_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_21);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2531,10 +2171,7 @@ BOOST_DATA_TEST_CASE(const_210_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_210);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2552,10 +2189,7 @@ BOOST_DATA_TEST_CASE(const_211_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_211);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2573,10 +2207,7 @@ BOOST_DATA_TEST_CASE(const_212_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_212);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2594,10 +2225,7 @@ BOOST_DATA_TEST_CASE(const_213_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_213);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2615,10 +2243,7 @@ BOOST_DATA_TEST_CASE(const_214_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_214);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2636,10 +2261,7 @@ BOOST_DATA_TEST_CASE(const_215_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_215);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2657,10 +2279,7 @@ BOOST_DATA_TEST_CASE(const_216_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_216);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2678,10 +2297,7 @@ BOOST_DATA_TEST_CASE(const_217_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_217);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2699,10 +2315,7 @@ BOOST_DATA_TEST_CASE(const_218_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_218);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2720,10 +2333,7 @@ BOOST_DATA_TEST_CASE(const_219_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_219);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2741,10 +2351,7 @@ BOOST_DATA_TEST_CASE(const_22_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_22);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2762,10 +2369,7 @@ BOOST_DATA_TEST_CASE(const_220_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_220);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2783,10 +2387,7 @@ BOOST_DATA_TEST_CASE(const_221_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_221);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2804,10 +2405,7 @@ BOOST_DATA_TEST_CASE(const_222_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_222);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2825,10 +2423,7 @@ BOOST_DATA_TEST_CASE(const_223_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_223);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2846,10 +2441,7 @@ BOOST_DATA_TEST_CASE(const_224_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_224);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2867,10 +2459,7 @@ BOOST_DATA_TEST_CASE(const_225_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_225);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2888,10 +2477,7 @@ BOOST_DATA_TEST_CASE(const_226_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_226);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2909,10 +2495,7 @@ BOOST_DATA_TEST_CASE(const_227_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_227);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2930,10 +2513,7 @@ BOOST_DATA_TEST_CASE(const_228_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_228);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2951,10 +2531,7 @@ BOOST_DATA_TEST_CASE(const_229_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_229);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2972,10 +2549,7 @@ BOOST_DATA_TEST_CASE(const_23_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_23);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2993,10 +2567,7 @@ BOOST_DATA_TEST_CASE(const_230_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_230);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3014,10 +2585,7 @@ BOOST_DATA_TEST_CASE(const_231_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_231);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3035,10 +2603,7 @@ BOOST_DATA_TEST_CASE(const_232_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_232);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3056,10 +2621,7 @@ BOOST_DATA_TEST_CASE(const_233_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_233);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3077,10 +2639,7 @@ BOOST_DATA_TEST_CASE(const_234_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_234);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3098,10 +2657,7 @@ BOOST_DATA_TEST_CASE(const_235_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_235);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3119,10 +2675,7 @@ BOOST_DATA_TEST_CASE(const_236_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_236);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3140,10 +2693,7 @@ BOOST_DATA_TEST_CASE(const_237_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_237);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3161,10 +2711,7 @@ BOOST_DATA_TEST_CASE(const_238_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_238);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3182,10 +2729,7 @@ BOOST_DATA_TEST_CASE(const_239_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_239);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3203,10 +2747,7 @@ BOOST_DATA_TEST_CASE(const_24_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_24);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3224,10 +2765,7 @@ BOOST_DATA_TEST_CASE(const_240_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_240);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3245,10 +2783,7 @@ BOOST_DATA_TEST_CASE(const_241_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_241);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3266,10 +2801,7 @@ BOOST_DATA_TEST_CASE(const_242_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_242);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3287,10 +2819,7 @@ BOOST_DATA_TEST_CASE(const_243_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_243);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3308,10 +2837,7 @@ BOOST_DATA_TEST_CASE(const_244_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_244);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3329,10 +2855,7 @@ BOOST_DATA_TEST_CASE(const_245_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_245);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3350,10 +2873,7 @@ BOOST_DATA_TEST_CASE(const_246_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_246);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3371,10 +2891,7 @@ BOOST_DATA_TEST_CASE(const_247_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_247);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3392,10 +2909,7 @@ BOOST_DATA_TEST_CASE(const_248_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_248);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3413,10 +2927,7 @@ BOOST_DATA_TEST_CASE(const_249_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_249);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3434,10 +2945,7 @@ BOOST_DATA_TEST_CASE(const_25_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_25);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3455,10 +2963,7 @@ BOOST_DATA_TEST_CASE(const_250_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_250);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3476,10 +2981,7 @@ BOOST_DATA_TEST_CASE(const_251_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_251);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3497,10 +2999,7 @@ BOOST_DATA_TEST_CASE(const_252_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_252);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3518,10 +3017,7 @@ BOOST_DATA_TEST_CASE(const_253_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_253);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3539,10 +3035,7 @@ BOOST_DATA_TEST_CASE(const_254_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_254);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3560,10 +3053,7 @@ BOOST_DATA_TEST_CASE(const_255_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_255);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3581,10 +3071,7 @@ BOOST_DATA_TEST_CASE(const_256_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_256);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3602,10 +3089,7 @@ BOOST_DATA_TEST_CASE(const_257_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_257);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3623,10 +3107,7 @@ BOOST_DATA_TEST_CASE(const_258_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_258);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3644,10 +3125,7 @@ BOOST_DATA_TEST_CASE(const_259_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_259);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3665,10 +3143,7 @@ BOOST_DATA_TEST_CASE(const_260_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_260);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3686,10 +3161,7 @@ BOOST_DATA_TEST_CASE(const_261_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_261);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3707,10 +3179,7 @@ BOOST_DATA_TEST_CASE(const_262_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_262);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3728,10 +3197,7 @@ BOOST_DATA_TEST_CASE(const_263_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_263);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3749,10 +3215,7 @@ BOOST_DATA_TEST_CASE(const_264_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_264);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3770,10 +3233,7 @@ BOOST_DATA_TEST_CASE(const_265_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_265);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3791,10 +3251,7 @@ BOOST_DATA_TEST_CASE(const_266_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_266);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3812,10 +3269,7 @@ BOOST_DATA_TEST_CASE(const_267_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_267);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3833,10 +3287,7 @@ BOOST_DATA_TEST_CASE(const_268_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_268);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3854,10 +3305,7 @@ BOOST_DATA_TEST_CASE(const_269_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_269);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3875,10 +3323,7 @@ BOOST_DATA_TEST_CASE(const_270_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_270);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3896,10 +3341,7 @@ BOOST_DATA_TEST_CASE(const_271_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_271);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3917,10 +3359,7 @@ BOOST_DATA_TEST_CASE(const_272_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_272);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3938,10 +3377,7 @@ BOOST_DATA_TEST_CASE(const_273_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_273);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3959,10 +3395,7 @@ BOOST_DATA_TEST_CASE(const_274_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_274);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -3980,10 +3413,7 @@ BOOST_DATA_TEST_CASE(const_275_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_275);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4001,10 +3431,7 @@ BOOST_DATA_TEST_CASE(const_276_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_276);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4022,10 +3449,7 @@ BOOST_DATA_TEST_CASE(const_277_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_277);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4043,10 +3467,7 @@ BOOST_DATA_TEST_CASE(const_278_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_278);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4064,10 +3485,7 @@ BOOST_DATA_TEST_CASE(const_279_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_279);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4085,10 +3503,7 @@ BOOST_DATA_TEST_CASE(const_280_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_280);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4106,10 +3521,7 @@ BOOST_DATA_TEST_CASE(const_281_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_281);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4127,10 +3539,7 @@ BOOST_DATA_TEST_CASE(const_282_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_282);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4148,10 +3557,7 @@ BOOST_DATA_TEST_CASE(const_283_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_283);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4169,10 +3575,7 @@ BOOST_DATA_TEST_CASE(const_284_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_284);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4190,10 +3593,7 @@ BOOST_DATA_TEST_CASE(const_285_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_285);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4211,10 +3611,7 @@ BOOST_DATA_TEST_CASE(const_286_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_286);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4232,10 +3629,7 @@ BOOST_DATA_TEST_CASE(const_287_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_287);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4253,10 +3647,7 @@ BOOST_DATA_TEST_CASE(const_288_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_288);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4274,10 +3665,7 @@ BOOST_DATA_TEST_CASE(const_289_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_289);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4295,10 +3683,7 @@ BOOST_DATA_TEST_CASE(const_290_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_290);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4316,10 +3701,7 @@ BOOST_DATA_TEST_CASE(const_291_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_291);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4337,10 +3719,7 @@ BOOST_DATA_TEST_CASE(const_292_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_292);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4358,10 +3737,7 @@ BOOST_DATA_TEST_CASE(const_293_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_293);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4379,10 +3755,7 @@ BOOST_DATA_TEST_CASE(const_294_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_294);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4400,10 +3773,7 @@ BOOST_DATA_TEST_CASE(const_295_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_295);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4421,10 +3791,7 @@ BOOST_DATA_TEST_CASE(const_296_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_296);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4442,10 +3809,7 @@ BOOST_DATA_TEST_CASE(const_297_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_297);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4463,10 +3827,7 @@ BOOST_DATA_TEST_CASE(const_298_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_298);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4484,10 +3845,7 @@ BOOST_DATA_TEST_CASE(const_299_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_299);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4505,10 +3863,7 @@ BOOST_DATA_TEST_CASE(const_30_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_30);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4526,10 +3881,7 @@ BOOST_DATA_TEST_CASE(const_300_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_300);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4547,10 +3899,7 @@ BOOST_DATA_TEST_CASE(const_301_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_301);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4568,10 +3917,7 @@ BOOST_DATA_TEST_CASE(const_302_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_302);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4589,10 +3935,7 @@ BOOST_DATA_TEST_CASE(const_303_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_303);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4610,10 +3953,7 @@ BOOST_DATA_TEST_CASE(const_304_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_304);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4631,10 +3971,7 @@ BOOST_DATA_TEST_CASE(const_305_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_305);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4652,10 +3989,7 @@ BOOST_DATA_TEST_CASE(const_306_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_306);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4673,10 +4007,7 @@ BOOST_DATA_TEST_CASE(const_307_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_307);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4694,10 +4025,7 @@ BOOST_DATA_TEST_CASE(const_308_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_308);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4715,10 +4043,7 @@ BOOST_DATA_TEST_CASE(const_309_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_309);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4736,10 +4061,7 @@ BOOST_DATA_TEST_CASE(const_31_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_31);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4757,10 +4079,7 @@ BOOST_DATA_TEST_CASE(const_310_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_310);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4778,10 +4097,7 @@ BOOST_DATA_TEST_CASE(const_311_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_311);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4799,10 +4115,7 @@ BOOST_DATA_TEST_CASE(const_312_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_312);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4820,10 +4133,7 @@ BOOST_DATA_TEST_CASE(const_313_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_313);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4841,10 +4151,7 @@ BOOST_DATA_TEST_CASE(const_314_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_314);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4862,10 +4169,7 @@ BOOST_DATA_TEST_CASE(const_315_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_315);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4883,10 +4187,7 @@ BOOST_DATA_TEST_CASE(const_316_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_316);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4904,10 +4205,7 @@ BOOST_DATA_TEST_CASE(const_317_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_317);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4925,10 +4223,7 @@ BOOST_DATA_TEST_CASE(const_318_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_318);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4946,10 +4241,7 @@ BOOST_DATA_TEST_CASE(const_319_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_319);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4967,10 +4259,7 @@ BOOST_DATA_TEST_CASE(const_320_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_320);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -4988,10 +4277,7 @@ BOOST_DATA_TEST_CASE(const_321_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_321);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5009,10 +4295,7 @@ BOOST_DATA_TEST_CASE(const_322_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_322);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5030,10 +4313,7 @@ BOOST_DATA_TEST_CASE(const_323_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_323);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5051,10 +4331,7 @@ BOOST_DATA_TEST_CASE(const_324_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_324);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5072,10 +4349,7 @@ BOOST_DATA_TEST_CASE(const_325_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_325);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5093,10 +4367,7 @@ BOOST_DATA_TEST_CASE(const_326_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_326);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5114,10 +4385,7 @@ BOOST_DATA_TEST_CASE(const_327_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_327);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5135,10 +4403,7 @@ BOOST_DATA_TEST_CASE(const_328_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_328);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5156,10 +4421,7 @@ BOOST_DATA_TEST_CASE(const_329_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_329);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5177,10 +4439,7 @@ BOOST_DATA_TEST_CASE(const_330_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_330);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5198,10 +4457,7 @@ BOOST_DATA_TEST_CASE(const_331_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_331);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5219,10 +4475,7 @@ BOOST_DATA_TEST_CASE(const_332_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_332);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5240,10 +4493,7 @@ BOOST_DATA_TEST_CASE(const_333_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_333);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5261,10 +4511,7 @@ BOOST_DATA_TEST_CASE(const_334_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_334);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5282,10 +4529,7 @@ BOOST_DATA_TEST_CASE(const_335_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_335);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5303,10 +4547,7 @@ BOOST_DATA_TEST_CASE(const_336_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_336);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5324,10 +4565,7 @@ BOOST_DATA_TEST_CASE(const_337_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_337);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5345,10 +4583,7 @@ BOOST_DATA_TEST_CASE(const_338_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_338);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5366,10 +4601,7 @@ BOOST_DATA_TEST_CASE(const_339_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_339);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5387,10 +4619,7 @@ BOOST_DATA_TEST_CASE(const_34_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_34);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5408,10 +4637,7 @@ BOOST_DATA_TEST_CASE(const_340_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_340);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5429,10 +4655,7 @@ BOOST_DATA_TEST_CASE(const_341_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_341);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5450,10 +4673,7 @@ BOOST_DATA_TEST_CASE(const_342_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_342);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5471,10 +4691,7 @@ BOOST_DATA_TEST_CASE(const_343_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_343);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5492,10 +4709,7 @@ BOOST_DATA_TEST_CASE(const_344_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_344);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5513,10 +4727,7 @@ BOOST_DATA_TEST_CASE(const_345_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_345);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5534,10 +4745,7 @@ BOOST_DATA_TEST_CASE(const_346_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_346);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5555,10 +4763,7 @@ BOOST_DATA_TEST_CASE(const_347_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_347);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5576,10 +4781,7 @@ BOOST_DATA_TEST_CASE(const_348_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_348);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5597,10 +4799,7 @@ BOOST_DATA_TEST_CASE(const_349_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_349);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5618,10 +4817,7 @@ BOOST_DATA_TEST_CASE(const_35_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_35);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5639,10 +4835,7 @@ BOOST_DATA_TEST_CASE(const_350_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_350);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5660,10 +4853,7 @@ BOOST_DATA_TEST_CASE(const_351_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_351);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5681,10 +4871,7 @@ BOOST_DATA_TEST_CASE(const_352_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_352);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5702,10 +4889,7 @@ BOOST_DATA_TEST_CASE(const_353_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_353);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5723,10 +4907,7 @@ BOOST_DATA_TEST_CASE(const_354_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_354);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5744,10 +4925,7 @@ BOOST_DATA_TEST_CASE(const_355_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_355);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5765,10 +4943,7 @@ BOOST_DATA_TEST_CASE(const_356_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_356);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5786,10 +4961,7 @@ BOOST_DATA_TEST_CASE(const_357_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_357);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5807,10 +4979,7 @@ BOOST_DATA_TEST_CASE(const_358_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_358);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5828,10 +4997,7 @@ BOOST_DATA_TEST_CASE(const_359_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_359);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5849,10 +5015,7 @@ BOOST_DATA_TEST_CASE(const_360_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_360);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5870,10 +5033,7 @@ BOOST_DATA_TEST_CASE(const_361_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_361);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5891,10 +5051,7 @@ BOOST_DATA_TEST_CASE(const_362_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_362);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5912,10 +5069,7 @@ BOOST_DATA_TEST_CASE(const_363_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_363);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5933,10 +5087,7 @@ BOOST_DATA_TEST_CASE(const_364_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_364);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5954,10 +5105,7 @@ BOOST_DATA_TEST_CASE(const_365_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_365);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5975,10 +5123,7 @@ BOOST_DATA_TEST_CASE(const_366_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_366);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -5996,10 +5141,7 @@ BOOST_DATA_TEST_CASE(const_367_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_367);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6017,10 +5159,7 @@ BOOST_DATA_TEST_CASE(const_38_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_38);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6038,10 +5177,7 @@ BOOST_DATA_TEST_CASE(const_39_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_39);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6059,10 +5195,7 @@ BOOST_DATA_TEST_CASE(const_4_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6080,10 +5213,7 @@ BOOST_DATA_TEST_CASE(const_40_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_40);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6101,10 +5231,7 @@ BOOST_DATA_TEST_CASE(const_41_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_41);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6122,10 +5249,7 @@ BOOST_DATA_TEST_CASE(const_42_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_42);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6143,10 +5267,7 @@ BOOST_DATA_TEST_CASE(const_43_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_43);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6164,10 +5285,7 @@ BOOST_DATA_TEST_CASE(const_44_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_44);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6185,10 +5303,7 @@ BOOST_DATA_TEST_CASE(const_45_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_45);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6206,10 +5321,7 @@ BOOST_DATA_TEST_CASE(const_5_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_5);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6227,10 +5339,7 @@ BOOST_DATA_TEST_CASE(const_50_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_50);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6248,10 +5357,7 @@ BOOST_DATA_TEST_CASE(const_51_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_51);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6269,10 +5375,7 @@ BOOST_DATA_TEST_CASE(const_54_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_54);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6290,10 +5393,7 @@ BOOST_DATA_TEST_CASE(const_55_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_55);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6311,10 +5411,7 @@ BOOST_DATA_TEST_CASE(const_58_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_58);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6332,10 +5429,7 @@ BOOST_DATA_TEST_CASE(const_59_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_59);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6353,10 +5447,7 @@ BOOST_DATA_TEST_CASE(const_60_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_60);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6374,10 +5465,7 @@ BOOST_DATA_TEST_CASE(const_61_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_const_61);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6395,10 +5483,7 @@ BOOST_DATA_TEST_CASE(const_68_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_68);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6416,10 +5501,7 @@ BOOST_DATA_TEST_CASE(const_69_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_69);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6437,10 +5519,7 @@ BOOST_DATA_TEST_CASE(const_70_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_70);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6458,10 +5537,7 @@ BOOST_DATA_TEST_CASE(const_71_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_71);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6479,10 +5555,7 @@ BOOST_DATA_TEST_CASE(const_72_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_72);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6500,10 +5573,7 @@ BOOST_DATA_TEST_CASE(const_73_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_73);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6521,10 +5591,7 @@ BOOST_DATA_TEST_CASE(const_74_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_74);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6542,10 +5609,7 @@ BOOST_DATA_TEST_CASE(const_75_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_75);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6563,10 +5627,7 @@ BOOST_DATA_TEST_CASE(const_76_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_76);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6584,10 +5645,7 @@ BOOST_DATA_TEST_CASE(const_77_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_77);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6605,10 +5663,7 @@ BOOST_DATA_TEST_CASE(const_78_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_78);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6626,10 +5681,7 @@ BOOST_DATA_TEST_CASE(const_79_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_79);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6647,10 +5699,7 @@ BOOST_DATA_TEST_CASE(const_8_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_8);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6668,10 +5717,7 @@ BOOST_DATA_TEST_CASE(const_80_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_80);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6689,10 +5735,7 @@ BOOST_DATA_TEST_CASE(const_81_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_81);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6710,10 +5753,7 @@ BOOST_DATA_TEST_CASE(const_82_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_82);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6731,10 +5771,7 @@ BOOST_DATA_TEST_CASE(const_83_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_83);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6752,10 +5789,7 @@ BOOST_DATA_TEST_CASE(const_84_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_84);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6773,10 +5807,7 @@ BOOST_DATA_TEST_CASE(const_85_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_85);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6794,10 +5825,7 @@ BOOST_DATA_TEST_CASE(const_86_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_86);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6815,10 +5843,7 @@ BOOST_DATA_TEST_CASE(const_87_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_87);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6836,10 +5861,7 @@ BOOST_DATA_TEST_CASE(const_88_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_88);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6857,10 +5879,7 @@ BOOST_DATA_TEST_CASE(const_89_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_89);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6878,10 +5897,7 @@ BOOST_DATA_TEST_CASE(const_9_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_const_9);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6899,10 +5915,7 @@ BOOST_DATA_TEST_CASE(const_90_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_90);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6920,10 +5933,7 @@ BOOST_DATA_TEST_CASE(const_91_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_91);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6941,10 +5951,7 @@ BOOST_DATA_TEST_CASE(const_92_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_92);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6962,10 +5969,7 @@ BOOST_DATA_TEST_CASE(const_93_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_93);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -6983,10 +5987,7 @@ BOOST_DATA_TEST_CASE(const_94_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_94);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -7004,10 +6005,7 @@ BOOST_DATA_TEST_CASE(const_95_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_95);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -7025,10 +6023,7 @@ BOOST_DATA_TEST_CASE(const_96_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_96);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -7046,10 +6041,7 @@ BOOST_DATA_TEST_CASE(const_97_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_97);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -7067,10 +6059,7 @@ BOOST_DATA_TEST_CASE(const_98_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_98);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -7088,10 +6077,7 @@ BOOST_DATA_TEST_CASE(const_99_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_const_99);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/conversions.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/conversions.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(conversions_0_check_throw, boost::unit_test::data::xrange(0
    tester.set_code("wasmtest"_n, wasm_conversions_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(conversions_0_pass, boost::unit_test::data::xrange(67,71), 
    tester.set_code("wasmtest"_n, wasm_conversions_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/custom.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/custom.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(custom_0_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_custom_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(custom_1_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_custom_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(custom_2_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_custom_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/endianness.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/endianness.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(endianness_0_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_endianness_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/f32.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/f32.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(f32_0_pass, boost::unit_test::data::xrange(0,25), index) { 
    tester.set_code("wasmtest"_n, wasm_f32_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/f32_bitwise.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/f32_bitwise.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(f32_bitwise_0_pass, boost::unit_test::data::xrange(0,4), in
    tester.set_code("wasmtest"_n, wasm_f32_bitwise_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/f32_cmp.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/f32_cmp.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(f32_cmp_0_pass, boost::unit_test::data::xrange(0,24), index
    tester.set_code("wasmtest"_n, wasm_f32_cmp_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/f64.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/f64.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(f64_0_pass, boost::unit_test::data::xrange(0,25), index) { 
    tester.set_code("wasmtest"_n, wasm_f64_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/f64_bitwise.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/f64_bitwise.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(f64_bitwise_0_pass, boost::unit_test::data::xrange(0,4), in
    tester.set_code("wasmtest"_n, wasm_f64_bitwise_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/f64_cmp.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/f64_cmp.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(f64_cmp_0_pass, boost::unit_test::data::xrange(0,24), index
    tester.set_code("wasmtest"_n, wasm_f64_cmp_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/fac.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/fac.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(fac_0_check_throw, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_fac_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(fac_0_pass, boost::unit_test::data::xrange(1,2), index) { t
    tester.set_code("wasmtest"_n, wasm_fac_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/float_exprs.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/float_exprs.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(float_exprs_0_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(float_exprs_1_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(float_exprs_10_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_10);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(float_exprs_11_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_11);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -95,10 +83,7 @@ BOOST_DATA_TEST_CASE(float_exprs_12_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_12);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -116,10 +101,7 @@ BOOST_DATA_TEST_CASE(float_exprs_13_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_13);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -137,10 +119,7 @@ BOOST_DATA_TEST_CASE(float_exprs_14_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_14);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -158,10 +137,7 @@ BOOST_DATA_TEST_CASE(float_exprs_15_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_15);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -179,10 +155,7 @@ BOOST_DATA_TEST_CASE(float_exprs_16_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_16);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -200,10 +173,7 @@ BOOST_DATA_TEST_CASE(float_exprs_17_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_17);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -221,10 +191,7 @@ BOOST_DATA_TEST_CASE(float_exprs_18_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_18);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -242,10 +209,7 @@ BOOST_DATA_TEST_CASE(float_exprs_19_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_19);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -263,10 +227,7 @@ BOOST_DATA_TEST_CASE(float_exprs_2_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -284,10 +245,7 @@ BOOST_DATA_TEST_CASE(float_exprs_20_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_20);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -305,10 +263,7 @@ BOOST_DATA_TEST_CASE(float_exprs_21_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_21);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -326,10 +281,7 @@ BOOST_DATA_TEST_CASE(float_exprs_22_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_22);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -347,10 +299,7 @@ BOOST_DATA_TEST_CASE(float_exprs_23_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_23);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -368,10 +317,7 @@ BOOST_DATA_TEST_CASE(float_exprs_24_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_24);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -389,10 +335,7 @@ BOOST_DATA_TEST_CASE(float_exprs_25_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_25);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -410,10 +353,7 @@ BOOST_DATA_TEST_CASE(float_exprs_26_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_26);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -431,10 +371,7 @@ BOOST_DATA_TEST_CASE(float_exprs_27_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_27);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -452,10 +389,7 @@ BOOST_DATA_TEST_CASE(float_exprs_28_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_28);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -473,10 +407,7 @@ BOOST_DATA_TEST_CASE(float_exprs_29_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_29);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -494,10 +425,7 @@ BOOST_DATA_TEST_CASE(float_exprs_3_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -515,10 +443,7 @@ BOOST_DATA_TEST_CASE(float_exprs_30_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_30);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -536,10 +461,7 @@ BOOST_DATA_TEST_CASE(float_exprs_31_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_31);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -557,10 +479,7 @@ BOOST_DATA_TEST_CASE(float_exprs_32_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_32);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -578,10 +497,7 @@ BOOST_DATA_TEST_CASE(float_exprs_33_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_33);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -599,10 +515,7 @@ BOOST_DATA_TEST_CASE(float_exprs_34_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_34);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -620,10 +533,7 @@ BOOST_DATA_TEST_CASE(float_exprs_35_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_35);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -641,10 +551,7 @@ BOOST_DATA_TEST_CASE(float_exprs_36_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_36);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -662,10 +569,7 @@ BOOST_DATA_TEST_CASE(float_exprs_37_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_37);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -683,10 +587,7 @@ BOOST_DATA_TEST_CASE(float_exprs_38_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_38);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -704,10 +605,7 @@ BOOST_DATA_TEST_CASE(float_exprs_39_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_39);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -725,10 +623,7 @@ BOOST_DATA_TEST_CASE(float_exprs_4_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -746,10 +641,7 @@ BOOST_DATA_TEST_CASE(float_exprs_40_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_40);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -767,10 +659,7 @@ BOOST_DATA_TEST_CASE(float_exprs_41_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_41);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -788,10 +677,7 @@ BOOST_DATA_TEST_CASE(float_exprs_42_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_42);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -809,10 +695,7 @@ BOOST_DATA_TEST_CASE(float_exprs_43_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_43);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -830,10 +713,7 @@ BOOST_DATA_TEST_CASE(float_exprs_44_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_44);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -851,10 +731,7 @@ BOOST_DATA_TEST_CASE(float_exprs_45_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_45);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -872,10 +749,7 @@ BOOST_DATA_TEST_CASE(float_exprs_46_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_46);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -893,10 +767,7 @@ BOOST_DATA_TEST_CASE(float_exprs_47_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_47);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -914,10 +785,7 @@ BOOST_DATA_TEST_CASE(float_exprs_48_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_48);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -935,10 +803,7 @@ BOOST_DATA_TEST_CASE(float_exprs_49_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_49);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -956,10 +821,7 @@ BOOST_DATA_TEST_CASE(float_exprs_5_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_5);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -977,10 +839,7 @@ BOOST_DATA_TEST_CASE(float_exprs_50_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_50);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -998,10 +857,7 @@ BOOST_DATA_TEST_CASE(float_exprs_51_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_51);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1019,10 +875,7 @@ BOOST_DATA_TEST_CASE(float_exprs_52_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_52);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1040,10 +893,7 @@ BOOST_DATA_TEST_CASE(float_exprs_53_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_53);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1061,10 +911,7 @@ BOOST_DATA_TEST_CASE(float_exprs_54_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_54);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1082,10 +929,7 @@ BOOST_DATA_TEST_CASE(float_exprs_55_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_55);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1103,10 +947,7 @@ BOOST_DATA_TEST_CASE(float_exprs_56_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_56);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1124,10 +965,7 @@ BOOST_DATA_TEST_CASE(float_exprs_57_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_57);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1145,10 +983,7 @@ BOOST_DATA_TEST_CASE(float_exprs_58_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_58);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1166,10 +1001,7 @@ BOOST_DATA_TEST_CASE(float_exprs_59_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_59);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1187,10 +1019,7 @@ BOOST_DATA_TEST_CASE(float_exprs_6_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_6);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1208,10 +1037,7 @@ BOOST_DATA_TEST_CASE(float_exprs_60_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_60);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1229,10 +1055,7 @@ BOOST_DATA_TEST_CASE(float_exprs_61_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_61);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1250,10 +1073,7 @@ BOOST_DATA_TEST_CASE(float_exprs_62_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_62);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1271,10 +1091,7 @@ BOOST_DATA_TEST_CASE(float_exprs_63_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_63);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1292,10 +1109,7 @@ BOOST_DATA_TEST_CASE(float_exprs_64_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_64);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1313,10 +1127,7 @@ BOOST_DATA_TEST_CASE(float_exprs_65_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_65);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1334,10 +1145,7 @@ BOOST_DATA_TEST_CASE(float_exprs_66_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_66);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1355,10 +1163,7 @@ BOOST_DATA_TEST_CASE(float_exprs_67_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_67);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1376,10 +1181,7 @@ BOOST_DATA_TEST_CASE(float_exprs_68_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_68);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1397,10 +1199,7 @@ BOOST_DATA_TEST_CASE(float_exprs_69_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_69);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1418,10 +1217,7 @@ BOOST_DATA_TEST_CASE(float_exprs_7_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_7);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1439,10 +1235,7 @@ BOOST_DATA_TEST_CASE(float_exprs_70_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_70);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1460,10 +1253,7 @@ BOOST_DATA_TEST_CASE(float_exprs_71_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_71);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1481,10 +1271,7 @@ BOOST_DATA_TEST_CASE(float_exprs_72_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_72);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1502,10 +1289,7 @@ BOOST_DATA_TEST_CASE(float_exprs_73_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_73);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1523,10 +1307,7 @@ BOOST_DATA_TEST_CASE(float_exprs_74_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_74);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1544,10 +1325,7 @@ BOOST_DATA_TEST_CASE(float_exprs_75_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_75);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1565,10 +1343,7 @@ BOOST_DATA_TEST_CASE(float_exprs_76_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_76);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1586,10 +1361,7 @@ BOOST_DATA_TEST_CASE(float_exprs_77_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_77);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1607,10 +1379,7 @@ BOOST_DATA_TEST_CASE(float_exprs_78_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_78);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1628,10 +1397,7 @@ BOOST_DATA_TEST_CASE(float_exprs_79_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_79);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1649,10 +1415,7 @@ BOOST_DATA_TEST_CASE(float_exprs_8_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_8);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1670,10 +1433,7 @@ BOOST_DATA_TEST_CASE(float_exprs_80_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_80);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1691,10 +1451,7 @@ BOOST_DATA_TEST_CASE(float_exprs_81_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_81);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1712,10 +1469,7 @@ BOOST_DATA_TEST_CASE(float_exprs_82_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_82);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1733,10 +1487,7 @@ BOOST_DATA_TEST_CASE(float_exprs_83_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_83);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1754,10 +1505,7 @@ BOOST_DATA_TEST_CASE(float_exprs_84_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_84);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1775,10 +1523,7 @@ BOOST_DATA_TEST_CASE(float_exprs_85_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_85);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1796,10 +1541,7 @@ BOOST_DATA_TEST_CASE(float_exprs_86_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_86);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1817,10 +1559,7 @@ BOOST_DATA_TEST_CASE(float_exprs_87_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_87);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1838,10 +1577,7 @@ BOOST_DATA_TEST_CASE(float_exprs_88_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_88);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1859,10 +1595,7 @@ BOOST_DATA_TEST_CASE(float_exprs_89_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_89);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1880,10 +1613,7 @@ BOOST_DATA_TEST_CASE(float_exprs_9_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_float_exprs_9);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1901,10 +1631,7 @@ BOOST_DATA_TEST_CASE(float_exprs_90_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_90);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1922,10 +1649,7 @@ BOOST_DATA_TEST_CASE(float_exprs_91_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_91);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1943,10 +1667,7 @@ BOOST_DATA_TEST_CASE(float_exprs_92_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_92);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1964,10 +1685,7 @@ BOOST_DATA_TEST_CASE(float_exprs_93_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_93);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -1985,10 +1703,7 @@ BOOST_DATA_TEST_CASE(float_exprs_94_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_94);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -2006,10 +1721,7 @@ BOOST_DATA_TEST_CASE(float_exprs_95_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_exprs_95);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/float_literals.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/float_literals.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(float_literals_0_pass, boost::unit_test::data::xrange(0,1),
    tester.set_code("wasmtest"_n, wasm_float_literals_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(float_literals_1_pass, boost::unit_test::data::xrange(0,1),
    tester.set_code("wasmtest"_n, wasm_float_literals_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/float_memory.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/float_memory.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(float_memory_0_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_memory_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(float_memory_1_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_memory_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(float_memory_2_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_memory_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(float_memory_3_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_memory_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -95,10 +83,7 @@ BOOST_DATA_TEST_CASE(float_memory_4_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_memory_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -116,10 +101,7 @@ BOOST_DATA_TEST_CASE(float_memory_5_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_float_memory_5);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/float_misc.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/float_misc.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(float_misc_0_pass, boost::unit_test::data::xrange(0,5), ind
    tester.set_code("wasmtest"_n, wasm_float_misc_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/forward.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/forward.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(forward_0_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_forward_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/func.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/func.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(func_0_pass, boost::unit_test::data::xrange(0,1), index) { 
    tester.set_code("wasmtest"_n, wasm_func_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(func_1_module, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_func_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(func_3_pass, boost::unit_test::data::xrange(0,1), index) { 
    tester.set_code("wasmtest"_n, wasm_func_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/func_ptrs.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/func_ptrs.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(func_ptrs_0_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_func_ptrs_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(func_ptrs_8_check_throw, boost::unit_test::data::xrange(0,6
    tester.set_code("wasmtest"_n, wasm_func_ptrs_8);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -49,10 +43,7 @@ BOOST_DATA_TEST_CASE(func_ptrs_8_pass, boost::unit_test::data::xrange(6,7), inde
    tester.set_code("wasmtest"_n, wasm_func_ptrs_8);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -70,10 +61,7 @@ BOOST_DATA_TEST_CASE(func_ptrs_9_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_func_ptrs_9);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/globals.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/globals.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(globals_0_check_throw, boost::unit_test::data::xrange(0,1),
    tester.set_code("wasmtest"_n, wasm_globals_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(globals_0_pass, boost::unit_test::data::xrange(1,2), index)
    tester.set_code("wasmtest"_n, wasm_globals_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -49,10 +43,7 @@ BOOST_DATA_TEST_CASE(globals_17_module, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_globals_17);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/i32.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/i32.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(i32_0_check_throw, boost::unit_test::data::xrange(0,9), ind
    tester.set_code("wasmtest"_n, wasm_i32_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(i32_0_pass, boost::unit_test::data::xrange(9,13), index) { 
    tester.set_code("wasmtest"_n, wasm_i32_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/i64.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/i64.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(i64_0_check_throw, boost::unit_test::data::xrange(0,9), ind
    tester.set_code("wasmtest"_n, wasm_i64_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(i64_0_pass, boost::unit_test::data::xrange(9,13), index) { 
    tester.set_code("wasmtest"_n, wasm_i64_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/if.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/if.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(if_0_check_throw, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_if_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(if_0_pass, boost::unit_test::data::xrange(1,2), index) { tr
    tester.set_code("wasmtest"_n, wasm_if_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/int_exprs.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/int_exprs.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(int_exprs_0_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_int_exprs_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(int_exprs_1_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_int_exprs_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(int_exprs_10_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_int_exprs_10);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(int_exprs_11_check_throw, boost::unit_test::data::xrange(0,
    tester.set_code("wasmtest"_n, wasm_int_exprs_11);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -94,10 +82,7 @@ BOOST_DATA_TEST_CASE(int_exprs_12_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_int_exprs_12);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -115,10 +100,7 @@ BOOST_DATA_TEST_CASE(int_exprs_13_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_int_exprs_13);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -136,10 +118,7 @@ BOOST_DATA_TEST_CASE(int_exprs_14_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_int_exprs_14);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -157,10 +136,7 @@ BOOST_DATA_TEST_CASE(int_exprs_15_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_int_exprs_15);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -178,10 +154,7 @@ BOOST_DATA_TEST_CASE(int_exprs_16_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_int_exprs_16);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -199,10 +172,7 @@ BOOST_DATA_TEST_CASE(int_exprs_17_pass, boost::unit_test::data::xrange(0,1), ind
    tester.set_code("wasmtest"_n, wasm_int_exprs_17);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -220,10 +190,7 @@ BOOST_DATA_TEST_CASE(int_exprs_18_check_throw, boost::unit_test::data::xrange(0,
    tester.set_code("wasmtest"_n, wasm_int_exprs_18);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -240,10 +207,7 @@ BOOST_DATA_TEST_CASE(int_exprs_2_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_int_exprs_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -261,10 +225,7 @@ BOOST_DATA_TEST_CASE(int_exprs_3_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_int_exprs_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -282,10 +243,7 @@ BOOST_DATA_TEST_CASE(int_exprs_4_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_int_exprs_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -303,10 +261,7 @@ BOOST_DATA_TEST_CASE(int_exprs_5_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_int_exprs_5);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -324,10 +279,7 @@ BOOST_DATA_TEST_CASE(int_exprs_6_check_throw, boost::unit_test::data::xrange(0,4
    tester.set_code("wasmtest"_n, wasm_int_exprs_6);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -344,10 +296,7 @@ BOOST_DATA_TEST_CASE(int_exprs_7_check_throw, boost::unit_test::data::xrange(0,4
    tester.set_code("wasmtest"_n, wasm_int_exprs_7);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -364,10 +313,7 @@ BOOST_DATA_TEST_CASE(int_exprs_8_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_int_exprs_8);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -385,10 +331,7 @@ BOOST_DATA_TEST_CASE(int_exprs_9_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_int_exprs_9);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/int_literals.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/int_literals.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(int_literals_0_pass, boost::unit_test::data::xrange(0,1), i
    tester.set_code("wasmtest"_n, wasm_int_literals_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/labels.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/labels.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(labels_0_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_labels_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/left-to-right.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/left-to-right.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(left_to_right_0_pass, boost::unit_test::data::xrange(0,1), 
    tester.set_code("wasmtest"_n, wasm_left_to_right_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/load.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/load.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(load_0_pass, boost::unit_test::data::xrange(0,1), index) { 
    tester.set_code("wasmtest"_n, wasm_load_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/local_get.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/local_get.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(local_get_0_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_local_get_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/local_set.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/local_set.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(local_set_0_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_local_set_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/local_tee.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/local_tee.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(local_tee_0_pass, boost::unit_test::data::xrange(0,1), inde
    tester.set_code("wasmtest"_n, wasm_local_tee_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/loop.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/loop.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(loop_0_pass, boost::unit_test::data::xrange(0,1), index) { 
    tester.set_code("wasmtest"_n, wasm_loop_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/memory.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/memory.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(memory_0_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_memory_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(memory_1_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_memory_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(memory_2_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_memory_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(memory_25_pass, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_memory_25);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -95,10 +83,7 @@ BOOST_DATA_TEST_CASE(memory_3_module, boost::unit_test::data::xrange(0,1), index
    tester.set_code("wasmtest"_n, wasm_memory_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -116,10 +101,7 @@ BOOST_DATA_TEST_CASE(memory_6_check_throw, boost::unit_test::data::xrange(0,1), 
    tester.set_code("wasmtest"_n, wasm_memory_6);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -136,10 +118,7 @@ BOOST_DATA_TEST_CASE(memory_7_check_throw, boost::unit_test::data::xrange(0,1), 
    tester.set_code("wasmtest"_n, wasm_memory_7);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -156,10 +135,7 @@ BOOST_DATA_TEST_CASE(memory_8_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_memory_8);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/memory_grow.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/memory_grow.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(memory_grow_0_check_throw, boost::unit_test::data::xrange(0
    tester.set_code("wasmtest"_n, wasm_memory_grow_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(memory_grow_0_pass, boost::unit_test::data::xrange(6,7), in
    tester.set_code("wasmtest"_n, wasm_memory_grow_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -49,10 +43,7 @@ BOOST_DATA_TEST_CASE(memory_grow_1_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_memory_grow_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -70,10 +61,7 @@ BOOST_DATA_TEST_CASE(memory_grow_2_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_memory_grow_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -91,10 +79,7 @@ BOOST_DATA_TEST_CASE(memory_grow_4_check_throw, boost::unit_test::data::xrange(0
    tester.set_code("wasmtest"_n, wasm_memory_grow_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -108,10 +93,7 @@ BOOST_DATA_TEST_CASE(memory_grow_4_pass, boost::unit_test::data::xrange(1,2), in
    tester.set_code("wasmtest"_n, wasm_memory_grow_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/memory_redundancy.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/memory_redundancy.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(memory_redundancy_0_pass, boost::unit_test::data::xrange(0,
    tester.set_code("wasmtest"_n, wasm_memory_redundancy_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/memory_size.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/memory_size.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(memory_size_0_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_memory_size_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(memory_size_1_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_memory_size_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(memory_size_2_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_memory_size_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(memory_size_3_pass, boost::unit_test::data::xrange(0,1), in
    tester.set_code("wasmtest"_n, wasm_memory_size_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/memory_trap.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/memory_trap.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(memory_trap_0_check_throw, boost::unit_test::data::xrange(0
    tester.set_code("wasmtest"_n, wasm_memory_trap_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(memory_trap_0_pass, boost::unit_test::data::xrange(10,11), 
    tester.set_code("wasmtest"_n, wasm_memory_trap_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -48,10 +42,7 @@ void memory_trap_1_check_throw_common(TESTER& tester, uint32_t index) {
    tester.set_code("wasmtest"_n, wasm_memory_trap_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -75,10 +66,7 @@ BOOST_DATA_TEST_CASE(memory_trap_1_pass, boost::unit_test::data::xrange(156,157)
    tester.set_code("wasmtest"_n, wasm_memory_trap_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/nop.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/nop.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(nop_0_pass, boost::unit_test::data::xrange(0,1), index) { t
    tester.set_code("wasmtest"_n, wasm_nop_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/return.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/return.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(return_0_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_return_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/select.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/select.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(select_0_check_throw, boost::unit_test::data::xrange(0,6), 
    tester.set_code("wasmtest"_n, wasm_select_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(select_0_pass, boost::unit_test::data::xrange(6,7), index) 
    tester.set_code("wasmtest"_n, wasm_select_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/stack.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/stack.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(stack_0_pass, boost::unit_test::data::xrange(0,1), index) {
    tester.set_code("wasmtest"_n, wasm_stack_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(stack_1_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_stack_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/start.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/start.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(start_3_pass, boost::unit_test::data::xrange(0,1), index) {
    tester.set_code("wasmtest"_n, wasm_start_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -32,10 +29,7 @@ BOOST_DATA_TEST_CASE(start_4_pass, boost::unit_test::data::xrange(0,1), index) {
    tester.set_code("wasmtest"_n, wasm_start_4);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -53,10 +47,7 @@ BOOST_DATA_TEST_CASE(start_5_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_start_5);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();
@@ -74,10 +65,7 @@ BOOST_DATA_TEST_CASE(start_6_module, boost::unit_test::data::xrange(0,1), index)
    tester.set_code("wasmtest"_n, wasm_start_6);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/store.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/store.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(store_0_pass, boost::unit_test::data::xrange(0,1), index) {
    tester.set_code("wasmtest"_n, wasm_store_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/switch.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/switch.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(switch_0_pass, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_switch_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/traps.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/traps.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(traps_0_check_throw, boost::unit_test::data::xrange(0,6), i
    tester.set_code("wasmtest"_n, wasm_traps_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -31,10 +28,7 @@ BOOST_DATA_TEST_CASE(traps_1_check_throw, boost::unit_test::data::xrange(0,4), i
    tester.set_code("wasmtest"_n, wasm_traps_1);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -51,10 +45,7 @@ BOOST_DATA_TEST_CASE(traps_2_check_throw, boost::unit_test::data::xrange(0,8), i
    tester.set_code("wasmtest"_n, wasm_traps_2);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -71,10 +62,7 @@ BOOST_DATA_TEST_CASE(traps_3_check_throw, boost::unit_test::data::xrange(0,14), 
    tester.set_code("wasmtest"_n, wasm_traps_3);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/type.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/type.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(type_0_module, boost::unit_test::data::xrange(0,1), index) 
    tester.set_code("wasmtest"_n, wasm_type_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/unreachable.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/unreachable.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(unreachable_0_check_throw, boost::unit_test::data::xrange(0
    tester.set_code("wasmtest"_n, wasm_unreachable_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(unreachable_0_pass, boost::unit_test::data::xrange(57,58), 
    tester.set_code("wasmtest"_n, wasm_unreachable_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm-spec-tests/generated-tests/unwind.cpp
+++ b/unittests/wasm-spec-tests/generated-tests/unwind.cpp
@@ -11,10 +11,7 @@ BOOST_DATA_TEST_CASE(unwind_0_check_throw, boost::unit_test::data::xrange(0,8), 
    tester.set_code("wasmtest"_n, wasm_unwind_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    BOOST_CHECK_THROW(push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t()), wasm_execution_error);
    tester.produce_block();
@@ -28,10 +25,7 @@ BOOST_DATA_TEST_CASE(unwind_0_pass, boost::unit_test::data::xrange(8,9), index) 
    tester.set_code("wasmtest"_n, wasm_unwind_0);
    tester.produce_block();
 
-   action test;
-   test.account = "wasmtest"_n;
-   test.name = account_name((uint64_t)index);
-   test.authorization = {{"wasmtest"_n, config::active_name}};
+   action test({{"wasmtest"_n, config::active_name}}, "wasmtest"_n, account_name((uint64_t)index), {});
 
    push_action(tester, std::move(test), "wasmtest"_n.to_uint64_t());
    tester.produce_block();

--- a/unittests/wasm_config_tests.cpp
+++ b/unittests/wasm_config_tests.cpp
@@ -270,10 +270,8 @@ void test_max_func_local_bytes(T& chain, int32_t n_params, int32_t n_locals, int
    }
 
    auto pushit = [&]() {
-      action act;
-      act.account = "stackz"_n;
-      act.name = name();
-      act.authorization = vector<permission_level>{{"stackz"_n,config::active_name}};
+      action act(vector<permission_level>{{"stackz"_n,config::active_name}}, "stackz"_n,
+                 name(), {});
       signed_transaction trx;
       trx.actions.push_back(act);
 
@@ -463,10 +461,8 @@ BOOST_DATA_TEST_CASE_F(old_wasm_tester, max_func_local_bytes_old, data::make({0,
    produce_block();
 
    auto pushit = [&]() {
-      action act;
-      act.account = "stackz"_n;
-      act.name = name();
-      act.authorization = vector<permission_level>{{"stackz"_n,config::active_name}};
+      action act(vector<permission_level>{{"stackz"_n,config::active_name}}, "stackz"_n,
+                 name(), {});
       signed_transaction trx;
       trx.actions.push_back(act);
 
@@ -913,10 +909,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( max_pages, T, wasm_config_testers ) try {
       chain.produce_block();
 
       auto pushit = [&](uint64_t extra_pages) {
-         action act;
-         act.account = "bigmem"_n;
-         act.name = name(extra_pages);
-         act.authorization = vector<permission_level>{{"bigmem"_n,config::active_name}};
+         action act(vector<permission_level>{{"bigmem"_n,config::active_name}}, "bigmem"_n,
+                    name(extra_pages), {});
          signed_transaction trx;
          trx.actions.push_back(act);
 
@@ -928,10 +922,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( max_pages, T, wasm_config_testers ) try {
 
       // verify that page accessibility cannot leak across wasm executions
       auto checkaccess = [&](uint64_t pagenum) {
-         action act;
-         act.account = "accessmem"_n;
-         act.name = name(pagenum);
-         act.authorization = vector<permission_level>{{"accessmem"_n,config::active_name}};
+         action act(vector<permission_level>{{"accessmem"_n,config::active_name}}, "accessmem"_n,
+                    name(pagenum), {});
          signed_transaction trx;
          trx.actions.push_back(act);
 
@@ -943,10 +935,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( max_pages, T, wasm_config_testers ) try {
 
       // verify checking of intrinsic arguments
       auto pushintrinsic = [&](uint64_t pages) {
-         action act;
-         act.account = "intrinsicmem"_n;
-         act.name = name(pages);
-         act.authorization = vector<permission_level>{{"intrinsicmem"_n,config::active_name}};
+         action act(vector<permission_level>{{"intrinsicmem"_n,config::active_name}}, "intrinsicmem"_n,
+                    name(pages), {});
          signed_transaction trx;
          trx.actions.push_back(act);
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -223,10 +223,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_tests, T, validating_testers ) try {
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = "f32.tests"_n;
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{"f32.tests"_n,config::active_name}};
+      action act(vector<permission_level>{{"f32.tests"_n,config::active_name}}, "f32.tests"_n, ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -248,10 +245,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_test_bitwise, T, validating_testers ) try {
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = "f32.tests"_n;
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{"f32.tests"_n,config::active_name}};
+      action act(vector<permission_level>{{"f32.tests"_n,config::active_name}}, "f32.tests"_n, ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -273,10 +267,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_test_cmp, T, validating_testers ) try {
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = "f32.tests"_n;
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{"f32.tests"_n,config::active_name}};
+      action act(vector<permission_level>{{"f32.tests"_n,config::active_name}}, "f32.tests"_n, ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -300,10 +291,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_tests, T, validating_testers ) try {
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = "f.tests"_n;
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{"f.tests"_n,config::active_name}};
+      action act(vector<permission_level>{{"f.tests"_n,config::active_name}}, "f.tests"_n, ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -325,10 +313,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_test_bitwise, T, validating_testers ) try {
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = "f.tests"_n;
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{"f.tests"_n,config::active_name}};
+      action act(vector<permission_level>{{"f.tests"_n,config::active_name}}, "f.tests"_n, ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -350,10 +335,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f64_test_cmp, T, validating_testers ) try {
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = "f.tests"_n;
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{"f.tests"_n,config::active_name}};
+      action act(vector<permission_level>{{"f.tests"_n,config::active_name}}, "f.tests"_n, ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -378,10 +360,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_f64_conversion_tests, T, validating_testers )
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = "ftests"_n;
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{"ftests"_n,config::active_name}};
+      action act(vector<permission_level>{{"ftests"_n,config::active_name}}, "ftests"_n, ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -409,10 +388,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( f32_f64_overflow_tests, T, validating_testers ) t
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = name("ftests"_n.to_uint64_t()+count);
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{name("ftests"_n.to_uint64_t()+count),config::active_name}};
+      action act(vector<permission_level>{{name("ftests"_n.to_uint64_t()+count),config::active_name}},
+                 name("ftests"_n.to_uint64_t()+count), ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -509,10 +486,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( misaligned_tests, T, validating_testers ) try {
       chain.produce_block();
 
       signed_transaction trx;
-      action act;
-      act.account = "aligncheck"_n;
-      act.name = ""_n;
-      act.authorization = vector<permission_level>{{"aligncheck"_n,config::active_name}};
+      action act(vector<permission_level>{{"aligncheck"_n,config::active_name}}, "aligncheck"_n,
+                 ""_n, {});
       trx.actions.push_back(act);
 
       chain.set_transaction_headers(trx);
@@ -543,10 +518,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_entry_behavior, T, validating_testers ) try
    chain.produce_block();
 
    signed_transaction trx;
-   action act;
-   act.account = "entrycheck"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"entrycheck"_n,config::active_name}};
+   action act(vector<permission_level>{{"entrycheck"_n,config::active_name}}, "entrycheck"_n,
+              ""_n, {});
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx);
@@ -569,10 +542,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_entry_behavior_2, T, validating_testers ) t
    chain.produce_block();
 
    signed_transaction trx;
-   action act;
-   act.account = "entrycheck"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"entrycheck"_n,config::active_name}};
+   action act(vector<permission_level>{{"entrycheck"_n,config::active_name}}, "entrycheck"_n, ""_n, {});
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx);
@@ -593,10 +563,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( entry_import, T, validating_testers ) try {
    chain.set_code("enterimport"_n, entry_import_wast);
 
    signed_transaction trx;
-   action act;
-   act.account = "enterimport"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"enterimport"_n,config::active_name}};
+   action act(vector<permission_level>{{"enterimport"_n,config::active_name}}, "enterimport"_n, ""_n, {});
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx);
@@ -613,10 +580,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( entry_db, T, validating_testers ) try {
    chain.set_code("entrydb"_n, entry_db_wast);
 
    signed_transaction trx;
-   action act;
-   act.account = "entrydb"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"entrydb"_n,config::active_name}};
+   action act(vector<permission_level>{{"entrydb"_n,config::active_name}}, "entrydb"_n, ""_n, {});
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx);
@@ -640,10 +604,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( simple_no_memory_check, T, validating_testers ) t
 
    //the apply func of simple_no_memory_wast tries to call a native func with linear memory pointer
    signed_transaction trx;
-   action act;
-   act.account = "nomem"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"nomem"_n,config::active_name}};
+   action act(vector<permission_level>{{"nomem"_n,config::active_name}}, "nomem"_n, ""_n, {});
    trx.actions.push_back(act);
    trx.expiration = fc::time_point_sec{chain.head().block_time()};
    chain.set_transaction_headers(trx);
@@ -665,18 +626,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_global_reset, T, validating_testers ) try {
 
    signed_transaction trx;
    {
-   action act;
-   act.account = "globalreset"_n;
-   act.name = name(0ULL);
-   act.authorization = vector<permission_level>{{"globalreset"_n,config::active_name}};
-   trx.actions.push_back(act);
+      action act(vector<permission_level>{{"globalreset"_n,config::active_name}}, "globalreset"_n, name(0ULL), {});
+      trx.actions.push_back(act);
    }
    {
-   action act;
-   act.account = "globalreset"_n;
-   act.name = name(1ULL);
-   act.authorization = vector<permission_level>{{"globalreset"_n,config::active_name}};
-   trx.actions.push_back(act);
+      action act(vector<permission_level>{{"globalreset"_n,config::active_name}}, "globalreset"_n, name(1ULL), {});
+      trx.actions.push_back(act);
    }
 
    chain.set_transaction_headers(trx);
@@ -708,10 +663,7 @@ void test_big_memory(setup_policy policy) {
    t.produce_block();
 
    signed_transaction trx;
-   action act;
-   act.account = "bigmem"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"bigmem"_n,config::active_name}};
+   action act(vector<permission_level>{{"bigmem"_n,config::active_name}}, "bigmem"_n, ""_n, {});
    trx.actions.push_back(act);
 
    t.set_transaction_headers(trx);
@@ -1108,17 +1060,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( noop, T, validating_testers ) try {
    {
       chain.produce_block();
       signed_transaction trx;
-      action act;
-      act.account = "noop"_n;
-      act.name = "anyaction"_n;
-      act.authorization = vector<permission_level>{{"noop"_n, config::active_name}};
-
-      act.data = abi_ser.variant_to_binary("anyaction", mutable_variant_object()
+      action act(vector<permission_level>{{"noop"_n, config::active_name}}, "noop"_n, "anyaction"_n,
+                 abi_ser.variant_to_binary("anyaction", mutable_variant_object()
                                            ("from", "noop")
                                            ("type", "some type")
                                            ("data", "some data goes here"),
-                                           abi_serializer::create_yield_function( chain.abi_serializer_max_time )
-                                           );
+                                           abi_serializer::create_yield_function( chain.abi_serializer_max_time )));
 
       trx.actions.emplace_back(std::move(act));
 
@@ -1133,17 +1080,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( noop, T, validating_testers ) try {
    {
       chain.produce_block();
       signed_transaction trx;
-      action act;
-      act.account = "noop"_n;
-      act.name = "anyaction"_n;
-      act.authorization = vector<permission_level>{{"alice"_n, config::active_name}};
-
-      act.data = abi_ser.variant_to_binary("anyaction", mutable_variant_object()
+      action act(vector<permission_level>{{"alice"_n, config::active_name}}, "noop"_n, "anyaction"_n,
+                 abi_ser.variant_to_binary("anyaction", mutable_variant_object()
                                            ("from", "alice")
                                            ("type", "some type")
                                            ("data", "some data goes here"),
-                                           abi_serializer::create_yield_function( chain.abi_serializer_max_time )
-                                           );
+                                           abi_serializer::create_yield_function( chain.abi_serializer_max_time )));
 
       trx.actions.emplace_back(std::move(act));
 
@@ -1284,10 +1226,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    chain.produce_block();
    {
    signed_transaction trx;
-   action act;
-   act.name = name(555ULL<<32 | 0ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   //top 32 is what we assert against, bottom 32 is indirect call index
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(555ULL<<32 | 0ULL), {});
    trx.actions.push_back(act);
       chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1298,10 +1238,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
 
    {
    signed_transaction trx;
-   action act;
-   act.name = name(555ULL<<32 | 1022ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   //top 32 is what we assert against, bottom 32 is indirect call index
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(555ULL<<32 | 1022ULL), {});
    trx.actions.push_back(act);
       chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1312,10 +1250,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
 
    {
    signed_transaction trx;
-   action act;
-   act.name = name(7777ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   //top 32 is what we assert against, bottom 32 is indirect call index
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(7777ULL<<32 | 1023ULL), {});
    trx.actions.push_back(act);
       chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1326,10 +1262,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
 
    {
    signed_transaction trx;
-   action act;
-   act.name = name(7778ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   //top 32 is what we assert against, bottom 32 is indirect call index
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(7778ULL<<32 | 1023ULL), {});
    trx.actions.push_back(act);
       chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1342,10 +1276,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
 
    {
    signed_transaction trx;
-   action act;
-   act.name = name(133ULL<<32 | 5ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(133ULL<<32 | 5ULL), {});
    trx.actions.push_back(act);
       chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1358,10 +1289,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
 
    {
    signed_transaction trx;
-   action act;
-   act.name = name(eosio::chain::wasm_constraints::maximum_table_elements+54334);
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(eosio::chain::wasm_constraints::maximum_table_elements+54334), {});
    trx.actions.push_back(act);
       chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1378,10 +1306,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
 
    {
    signed_transaction trx;
-   action act;
-   act.name = name(555ULL<<32 | 1022ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(555ULL<<32 | 1022ULL), {});
    trx.actions.push_back(act);
       chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1391,10 +1316,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
    chain.produce_block();
    {
    signed_transaction trx;
-   action act;
-   act.name = name(7777ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(7777ULL<<32 | 1023ULL), {});
    trx.actions.push_back(act);
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1405,10 +1327,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_table_maximum, T, validating_testers ) try 
 
    {
    signed_transaction trx;
-   action act;
-   act.name = name(888ULL);
-   act.account = "tbl"_n;
-   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
+   action act(vector<permission_level>{{"tbl"_n,config::active_name}}, "tbl"_n, name(888ULL), {});
    trx.actions.push_back(act);
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "tbl"_n, "active" ), chain.get_chain_id());
@@ -1533,10 +1452,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( mem_growth_memset, T, validating_testers ) try {
    chain.create_accounts( {"grower"_n} );
    chain.produce_block();
 
-   action act;
-   act.account = "grower"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"grower"_n,config::active_name}};
+   action act(vector<permission_level>{{"grower"_n,config::active_name}},  "grower"_n, ""_n, {});
 
    chain.set_code("grower"_n, memory_growth_memset_store);
    {
@@ -1773,10 +1689,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( big_maligned_host_ptr, T, validating_testers ) tr
    chain.produce_block();
 
    signed_transaction trx;
-   action act;
-   act.account = "bigmaligned"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"bigmaligned"_n,config::active_name}};
+   action act(vector<permission_level>{{"bigmaligned"_n,config::active_name}}, "bigmaligned"_n, ""_n, {});
    trx.actions.push_back(act);
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "bigmaligned"_n, "active" ), chain.get_chain_id());
@@ -1858,10 +1771,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( varuint_memory_flags_tests, T, validating_testers
 
    {
    signed_transaction trx;
-   action act;
-   act.account = "memflags"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"memflags"_n,config::active_name}};
+   action act(vector<permission_level>{{"memflags"_n,config::active_name}}, "memflags"_n, ""_n, {});
    trx.actions.push_back(act);
    t.set_transaction_headers(trx);
    trx.sign(validating_tester::get_private_key( "memflags"_n, "active" ), t.get_chain_id());
@@ -1876,10 +1786,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( varuint_memory_flags_tests, T, validating_testers
    // We should still be able to execute the old code
    {
    signed_transaction trx;
-   action act;
-   act.account = "memflags"_n;
-   act.name = ""_n;
-   act.authorization = vector<permission_level>{{"memflags"_n,config::active_name}};
+   action act(vector<permission_level>{{"memflags"_n,config::active_name}}, "memflags"_n, ""_n, {});
    trx.actions.push_back(act);
    t.set_transaction_headers(trx);
    trx.sign(validating_tester::get_private_key( "memflags"_n, "active" ), t.get_chain_id());
@@ -2236,10 +2143,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( eosio_exit_in_start, T, validating_testers ) try 
    chain.produce_block();
 
    signed_transaction trx;
-   action act;
-   act.account = "startexit"_n;
-   act.name = name();
-   act.authorization = vector<permission_level>{{"startexit"_n,config::active_name}};
+   action act(vector<permission_level>{{"startexit"_n,config::active_name}}, "startexit"_n, name(), {});
    trx.actions.push_back(act);
    chain.set_transaction_headers(trx);
    trx.sign(chain.get_private_key( "startexit"_n, "active" ), chain.get_chain_id());
@@ -2261,10 +2165,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( negative_memory_grow, T, validating_testers ) try
 
    {
    signed_transaction trx;
-   action act;
-   act.account = "negmemgrow"_n;
-   act.name = name();
-   act.authorization = vector<permission_level>{{"negmemgrow"_n,config::active_name}};
+   action act(vector<permission_level>{{"negmemgrow"_n,config::active_name}}, "negmemgrow"_n, name(), {});
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx);
@@ -2277,10 +2178,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( negative_memory_grow, T, validating_testers ) try
    chain.produce_block();
    {
    signed_transaction trx;
-   action act;
-   act.account = "negmemgrow"_n;
-   act.name = name();
-   act.authorization = vector<permission_level>{{"negmemgrow"_n,config::active_name}};
+   action act(vector<permission_level>{{"negmemgrow"_n,config::active_name}}, "negmemgrow"_n, name(), {});
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx);


### PR DESCRIPTION
This is an experiment attempting to make two members of `action_base` const. 

We may not want to merge it as it may cause other repo tests to fail.

However, we could merge the first commit, which does not change `action_base`, but updates or code to construct `action` using the constructor, instead of declaring a default constructed object and assigning the members after the fact.
