### PR TITLE
[1.0.3] Test: Update flakey http plugin unit test

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -624,6 +624,10 @@ namespace eosio {
       my->plugin_state->update_metrics = std::move(fun);
    }
 
+   size_t http_plugin::requests_in_flight() const {
+      return my->plugin_state->requests_in_flight;
+   }
+
    size_t http_plugin::bytes_in_flight() const {
       return my->plugin_state->bytes_in_flight;
    }

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -624,6 +624,10 @@ namespace eosio {
       my->plugin_state->update_metrics = std::move(fun);
    }
 
+   size_t http_plugin::bytes_in_flight() const {
+      return my->plugin_state->bytes_in_flight;
+   }
+
    std::atomic<bool>& http_plugin::listening() {
       return my->listening;
    }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -130,6 +130,8 @@ namespace eosio {
 
         void register_update_metrics(std::function<void(metrics)>&& fun);
 
+        size_t requests_in_flight() const;
+
         size_t bytes_in_flight() const;
 
         std::atomic<bool>& listening();

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -130,6 +130,8 @@ namespace eosio {
 
         void register_update_metrics(std::function<void(metrics)>&& fun);
 
+        size_t bytes_in_flight() const;
+
         std::atomic<bool>& listening();
    private:
         std::shared_ptr<class http_plugin_impl> my;

--- a/plugins/http_plugin/tests/unit_tests.cpp
+++ b/plugins/http_plugin/tests/unit_tests.cpp
@@ -650,7 +650,7 @@ BOOST_FIXTURE_TEST_CASE(bytes_in_flight, http_plugin_test_fixture) {
    send_4mb_requests(8u);
    r = drain_http_replies();
    for (const auto& e : r) {
-      ilog( "response: ${r}, count: ${c}", ("r", std::string(obsolete_reason(e.first)))("c", e.second));
+      ilog( "response: ${f}, count: ${c}", ("f", std::string(obsolete_reason(e.first)))("c", e.second));
    }
    BOOST_REQUIRE_EQUAL(r[boost::beast::http::status::ok], 8u);
 }
@@ -718,7 +718,7 @@ BOOST_FIXTURE_TEST_CASE(requests_in_flight, http_plugin_test_fixture) {
    send_requests(8u);
    r = scan_http_replies();
    for (const auto& e : r) {
-      ilog( "response: ${r}, count: ${c}", ("r", std::string(obsolete_reason(e.first)))("c", e.second));
+      ilog( "response: ${f}, count: ${c}", ("f", std::string(obsolete_reason(e.first)))("c", e.second));
    }
    BOOST_REQUIRE_EQUAL(r[boost::beast::http::status::ok], 8u);
    connections.clear();

--- a/plugins/http_plugin/tests/unit_tests.cpp
+++ b/plugins/http_plugin/tests/unit_tests.cpp
@@ -604,7 +604,6 @@ BOOST_FIXTURE_TEST_CASE(bytes_in_flight, http_plugin_test_fixture) {
          boost::beast::http::request<boost::beast::http::empty_body> req(boost::beast::http::verb::get, "/4megabyte", 11);
          req.keep_alive(true);
          req.set(http::field::host, "127.0.0.1:8891");
-         s.wait(boost::asio::ip::tcp::socket::wait_write);
          boost::beast::http::write(s, req);
       }
    };
@@ -693,7 +692,6 @@ BOOST_FIXTURE_TEST_CASE(requests_in_flight, http_plugin_test_fixture) {
       for(boost::asio::ip::tcp::socket& c : connections) {
          boost::beast::http::response<boost::beast::http::string_body> resp;
          boost::beast::flat_buffer buffer;
-         c.wait(boost::asio::ip::tcp::socket::wait_read);
          boost::beast::http::read(c, buffer, resp);
 
          count_of_status_replies[resp.result()]++;

--- a/plugins/http_plugin/tests/unit_tests.cpp
+++ b/plugins/http_plugin/tests/unit_tests.cpp
@@ -623,7 +623,7 @@ BOOST_FIXTURE_TEST_CASE(bytes_in_flight, http_plugin_test_fixture) {
    };
 
    auto wait_for_no_bytes_in_flight = [&](uint16_t max = std::numeric_limits<uint16_t>::max()) {
-      while (http_plugin->bytes_in_flight() > 0 && http_plugin->requests_in_flight() > 0 && --max)
+      while ((http_plugin->bytes_in_flight() > 0 || http_plugin->requests_in_flight() > 0) && --max)
          std::this_thread::sleep_for(std::chrono::milliseconds(5));
       BOOST_CHECK(max > 0);
    };

--- a/plugins/http_plugin/tests/unit_tests.cpp
+++ b/plugins/http_plugin/tests/unit_tests.cpp
@@ -628,6 +628,12 @@ BOOST_FIXTURE_TEST_CASE(bytes_in_flight, http_plugin_test_fixture) {
       BOOST_CHECK(max > 0);
    };
 
+   auto wait_for_requests = [&](uint16_t num_requests, uint16_t max = std::numeric_limits<uint16_t>::max()) {
+      while (http_plugin->requests_in_flight() < num_requests && --max)
+         std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      BOOST_CHECK(max > 0);
+   };
+
 
    //send a single request to start with
    send_4mb_requests(1u);
@@ -649,7 +655,7 @@ BOOST_FIXTURE_TEST_CASE(bytes_in_flight, http_plugin_test_fixture) {
    //load up some more requests that exceed max
    send_4mb_requests(32u);
    //make sure got to the point http threads had responses queued
-   std::this_thread::sleep_for(std::chrono::seconds(1));
+   wait_for_requests(32u);
    //now rip these connections out before the responses are completely sent
    connections.clear();
    wait_for_no_bytes_in_flight();

--- a/plugins/http_plugin/tests/unit_tests.cpp
+++ b/plugins/http_plugin/tests/unit_tests.cpp
@@ -648,6 +648,8 @@ BOOST_FIXTURE_TEST_CASE(bytes_in_flight, http_plugin_test_fixture) {
 
    //load up some more requests that exceed max
    send_4mb_requests(32u);
+   //make sure got to the point http threads had responses queued
+   std::this_thread::sleep_for(std::chrono::seconds(1));
    //now rip these connections out before the responses are completely sent
    connections.clear();
    wait_for_no_bytes_in_flight();


### PR DESCRIPTION
Update flakey http plugin unit test. Backport of #943.
Didn't realize the test had failed in CI/CD, thought it was only failing on my machine.

Resolves #683 
