### PR TITLE
[1.0.4] skip EOS VM interpreter parallel unit_tests and spec_tests on sanitizer builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -151,12 +151,14 @@ jobs:
         with:
           name: ${{matrix.cfg.builddir}}-build
       - name: Run Parallel Tests
+        env:
+          IS_SAN: ${{endsWith(matrix.cfg.name, 'san') && 'yes' || ''}}
         run: |
           # https://github.com/actions/runner/issues/2033  -- need this because of full version label test looking at git revs
           chown -R $(id -u):$(id -g) $PWD
           zstdcat build.tar.zst | tar x
           cd build
-          ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" --timeout 480
+          ctest --output-on-failure -j $(nproc) -LE "(nonparallelizable_tests|long_running_tests)" ${IS_SAN:+-E 'eos-vm$'} --timeout 480
       - name: Upload core files from failed tests
         uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
EOS VM interpreter is slow. Sanitizer builds are slow. The two combined is _really_ slow and we've fought CI test timeouts on and off with that combo.

EOS VM interpreter isn't useful for production usage so maybe just go ahead and disable the `unit_test` and `wasm_spec_test` runs with EOS VM interpreter for ASAN & UBSAN builds in CI.

Will resolve #958.