### PR TITLE
[1.0.3] Trace_API: Fix get_transaction_trace endpoint fails to return transaction trace if the initial block including the transaction forks out

### DIFF
--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -136,7 +136,7 @@ namespace eosio::trace_api {
             } else if (std::holds_alternative<lib_entry_v0>(entry)) {
                auto lib = std::get<lib_entry_v0>(entry).lib;
                if (!trx_block_nums.empty() && lib >= *(--trx_block_nums.end())) {
-                  return *(--trx_block_nums.end());
+                  return *(--trx_block_nums.end()); // *(--trx_block_nums.end()) is the block with highest block number which is final
                }
             } else {
                FC_ASSERT( false, "unpacked data should be a block_trxs_entry or a lib_entry_v0" );;

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -98,43 +98,6 @@ namespace eosio::trace_api {
       return std::make_tuple( entry.value(), irreversible );
    }
 
-   // Returns true if `block` includes the transaction identified by `trx_id`
-   static bool block_has_trx(const get_block_t& block, const chain::transaction_id_type& trx_id) {
-      bool           has_trx     = false;
-      data_log_entry block_trace = std::get<0>(*block);
-
-      if (std::holds_alternative<block_trace_v0> (block_trace)) {
-         auto& trace_v0 = std::get<block_trace_v0>(block_trace);
-         auto  itr      = std::find_if(trace_v0.transactions.begin(), trace_v0.transactions.end(),
-                                       [&](const auto& trx) { return trx.id == trx_id; });
-         has_trx = (itr != trace_v0.transactions.end());
-      } else if (std::holds_alternative<block_trace_v1>(block_trace)) {
-         auto& trace_v1 = std::get<block_trace_v1>(block_trace);
-         auto  itr      = std::find_if(trace_v1.transactions_v1.begin(), trace_v1.transactions_v1.end(),
-                                       [&](const auto& trx) { return trx.id == trx_id; });
-         has_trx        = (itr != trace_v1.transactions_v1.end());
-      } else if (std::holds_alternative<block_trace_v2>(block_trace)) {
-         auto& trace_v2 = std::get<block_trace_v2>(block_trace);
-         if (std::holds_alternative<std::vector<transaction_trace_v2>>(trace_v2.transactions)) {
-            auto& trxs = std::get<std::vector<transaction_trace_v2>>(trace_v2.transactions);
-            auto  itr  = std::find_if(trxs.begin(), trxs.end(),
-                                      [&](const auto& trx) { return trx.id == trx_id; });
-            has_trx    = (itr != trxs.end());
-         } else if (std::holds_alternative<std::vector<transaction_trace_v3>>(trace_v2.transactions)) {
-            auto& trxs = std::get<std::vector<transaction_trace_v3>>(trace_v2.transactions);
-            auto  itr  = std::find_if(trxs.begin(), trxs.end(),
-                                      [&](const auto& trx) { return trx.id == trx_id; });
-            has_trx    = (itr != trxs.end());
-         } else {
-            FC_ASSERT( false, "block_trace_v2 should contain transaction_trace_v2 or transaction_trace_v3 transactions" );;
-         }
-      } else {
-         FC_ASSERT( false, "block_trace should be a block_trace_v0, block_trace_v1, or a block_trace_v3" );
-      }
-
-      return has_trx;
-   }
-
    get_block_n store_provider::get_trx_block_number(const chain::transaction_id_type& trx_id, std::optional<uint32_t> minimum_irreversible_history_blocks, const yield_function& yield) {
       fc::cfile trx_id_file;
       int32_t slice_number;

--- a/plugins/trace_api_plugin/test/test_trace_file.cpp
+++ b/plugins/trace_api_plugin/test/test_trace_file.cpp
@@ -1154,12 +1154,23 @@ BOOST_AUTO_TEST_SUITE(slice_tests)
       sp.append(initial_block_trace);                  // block 1
       sp.append_trx_ids(initial_block_trxs_entry);     // block 1
 
+      // target trx is in the first block (is still reversible)
+      get_block_n block_num = sp.get_trx_block_number(target_trx_id, {});
+      BOOST_REQUIRE(block_num);
+      BOOST_REQUIRE_EQUAL(*block_num, initial_block_num);
+
       // initial block forks out
       sp.append(forked_block_trace);                   // block 1
       sp.append_trx_ids(forked_block_trxs_entry);      // block 1
 
       // forked block becomes final
       sp.append_lib(initial_block_num);                // block 1
+
+      // target trx is forked out. block 1 does not include
+      // target_trx (trx_trace1) but trx_trace2;
+      // therefore no block is found for target_trx_id.
+      block_num = sp.get_trx_block_number(target_trx_id, {});
+      BOOST_REQUIRE(!block_num);
 
       // on_accepted_block of the final block
       sp.append(final_block_trace);                    // block 3
@@ -1168,8 +1179,7 @@ BOOST_AUTO_TEST_SUITE(slice_tests)
       // final block becomes final
       sp.append_lib(final_block_num);                  // block 3
 
-      get_block_n block_num = sp.get_trx_block_number(target_trx_id, {});
-
+      block_num = sp.get_trx_block_number(target_trx_id, {});
       BOOST_REQUIRE(block_num);
       BOOST_REQUIRE_EQUAL(*block_num, final_block_num); // target trx is in final block
    }


### PR DESCRIPTION
Trace_API's `get_transaction_trace` is supposed to return the transaction trace of a transaction. But the current implementation only finds any block whose block number matches the first block proposing the transaction; this block might not contains the transaction due to forking.

This PR
* adds a test reproducing the problem and a test for normal case.
* fixes the problem by not updating `trx_block_num` in `get_trx_block_number` if the block does not include the transaction.

Resolves https://github.com/AntelopeIO/spring/issues/942