### PR TITLE
Replace `static_cast` of forwarding references with `std::forward`

### DIFF
--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
@@ -30,7 +30,7 @@
 
 extern "C" int arch_prctl(int code, unsigned long* addr);
 
-namespace eosio { namespace chain { namespace eosvmoc {
+namespace eosio::chain::eosvmoc {
 
 static constexpr auto signal_sentinel = 0x4D56534F45534559ul;
 
@@ -265,4 +265,4 @@ executor::~executor() {
    munmap(code_mapping, code_mapping_size);
 }
 
-}}}
+}

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -27,7 +27,7 @@ namespace {
      template<typename F>
      struct guard {
         guard(transaction_checktime_timer& timer, F&& func)
-           : _timer(timer), _func(static_cast<F&&>(func)) {
+           : _timer(timer), _func(std::forward<F>(func)) {
            _timer.set_expiration_callback(&callback, this);
            if(_timer.expired) {
               _func(); // it's harmless if _func is invoked twice
@@ -45,7 +45,7 @@ namespace {
      };
      template<typename F>
      guard<F> scoped_run(F&& func) {
-        return guard{_timer, static_cast<F&&>(func)};
+        return guard{_timer, std::forward<F>(func)};
      }
      transaction_checktime_timer& _timer;
   };
@@ -158,7 +158,7 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          };
          try {
             checktime_watchdog wd(context.trx_context.transaction_timer);
-            _runtime->_bkend.timed_run(wd, fn);
+            _runtime->_bkend.timed_run(std::move(wd), std::move(fn));
          } catch(eosio::vm::timeout_exception&) {
             context.trx_context.checktime();
          } catch(eosio::vm::wasm_memory_exception& e) {
@@ -202,7 +202,7 @@ class eos_vm_profiling_module : public wasm_instantiated_module_interface {
          try {
             scoped_profile profile_runner(prof);
             checktime_watchdog wd(context.trx_context.transaction_timer);
-            _instantiated_module->timed_run(wd, fn);
+            _instantiated_module->timed_run(std::move(wd), std::move(fn));
          } catch(eosio::vm::timeout_exception&) {
             context.trx_context.checktime();
          } catch(eosio::vm::wasm_memory_exception& e) {


### PR DESCRIPTION
When stepping through eos-vm code, I noticed some incorrect `static_cast` and `std::move` usages, which don't seem to hide bugs because these functions are called with references which are afterwards unused. Still this seems worthwhile fixing imo.

I linked this PR to issue #958, since these changes came to mind when investigating that issue, but this PR doesn't resolve the issue (that would be PR #965 )