### PR TITLE
[1.0.3 -> main] Test: Fix flakey production_pause_max_rev_blks_test

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -236,6 +236,13 @@ class Node(Transactions):
             return self.getIrreversibleBlockNum() > currentLib
         return Utils.waitForBool(isLibAdvancing, timeout)
 
+    def waitForLibNotToAdvance(self, timeout=30):
+        endTime=time.time()+timeout
+        while self.waitForLibToAdvance(timeout=timeout):
+            if time.time() > endTime:
+                return False
+        return True
+
     def waitForProducer(self, producer, timeout=None, exitOnError=False):
         if timeout is None:
             # default to the typical configuration of 21 producers, each producing 12 blocks in a row (every 1/2 second)

--- a/tests/production_pause_max_rev_blks_test.py
+++ b/tests/production_pause_max_rev_blks_test.py
@@ -118,10 +118,9 @@ try:
 
     # Verify LIB stalled on node0 and producerbNode due to finalizerNode was shutdown
     Print("Verify LIB stalled after shutdown of finalizerbNode")
-    if producerbNode.waitForLibToAdvance(timeout=5): # LIB can advance for a few blocks first
-        assert not producerbNode.waitForLibToAdvance(timeout=5), "LIB should not advance on producerbNode after finalizerbNode was shutdown"
-    if node0.waitForLibToAdvance(timeout=5): # LIB can advance for a few blocks first
-        assert not node0.waitForLibToAdvance(timeout=5), "LIB should not advance on node0 after finalizerbNode was shutdown"
+    # LIB can advance for a few blocks first
+    assert producerbNode.waitForLibNotToAdvance(timeout=10), "LIB should not advance on producerbNode after finalizerbNode was shutdown"
+    assert node0.waitForLibNotToAdvance(timeout=10), "LIB should not advance on node0 after finalizerbNode was shutdown"
 
     # Wait until enough reversible blocks are produced
     node0.getInfo()


### PR DESCRIPTION
Add a better method for waiting for LIB to stop advancing.

Merges `release/1.0` into `main` including #960 

Resolves #955 