### PR TITLE
Add `.clang_format` file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+BasedOnStyle: LLVM
+BraceWrapping:
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+IndentWidth: 3
+ColumnLimit: 120
+PointerAlignment: Left
+AccessModifierOffset: -3
+AlwaysBreakTemplateDeclarations: Yes
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveDeclarations: Consecutive
+AlignEscapedNewlines: Left
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Inline
+BreakBeforeBraces: Custom
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+ConstructorInitializerIndentWidth: 3
+ContinuationIndentWidth: 3
+MaxEmptyLinesToKeep: 3
+SortIncludes:    Never
+IndentPPDirectives: BeforeHash


### PR DESCRIPTION
This PR adds to the repo the `.clang_format` that Kevin and I have been using to format small pieces of new or updated code. Use as you see fit.