### PR TITLE
[1.0.3 -> main] Prometheus: Update speculative block metrics for produced blocks

### DIFF
--- a/plugins/prometheus_plugin/metrics.hpp
+++ b/plugins/prometheus_plugin/metrics.hpp
@@ -259,6 +259,7 @@ struct catalog_type {
       net_usage_us_produced_block.Increment(metrics.net_usage_us);
 
       update(produced_metrics, metrics);
+      update(speculative_metrics, metrics);
 
       last_irreversible.Set(metrics.last_irreversible);
       head_block_num.Set(metrics.head_block_num);


### PR DESCRIPTION
Update the speculative block metrics for produced blocks.

Merges `release/1.0` into `main` including #957

Resolves #956 