### PR TITLE
Handle exceptions in controller signals

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3445,7 +3445,8 @@ struct controller_impl {
             fork_db_.apply<void>(add_completed_block);
          }
 
-         chain_head = block_handle{cb.bsp};
+         // if an exception is thrown, reset chain_head to prior value
+         fc::scoped_set_value ch(chain_head, cb.bsp);
 
          if (s == controller::block_status::irreversible && replaying) {
             block_handle_accessor::apply_l<void>(chain_head, [&](const auto& head) {
@@ -3503,6 +3504,8 @@ struct controller_impl {
          }
 
          log_applied(s);
+
+         ch.dismiss(); // don't reset chain_head if no exception
       } catch (...) {
          // dont bother resetting pending, instead abort the block
          reset_pending_on_exit.cancel();

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3137,14 +3137,17 @@ struct controller_impl {
          } catch( const protocol_feature_bad_block_exception& ) {
             throw;
          } catch ( const std::bad_alloc& ) {
-           throw;
+            throw;
          } catch ( const boost::interprocess::bad_alloc& ) {
-           throw;
+            throw;
+         } catch ( const controller_emit_signal_exception& e ) {
+            wlog( "on block transaction failed due to controller_emit_signal_exception: ${e}", ("e", e.to_detail_string()) );
+            throw;
          } catch (const fc::exception& e) {
-           handle_exception(e);
+            handle_exception(e);
          } catch (const std::exception& e) {
-           auto wrapper = fc::std_exception_wrapper::from_current_exception(e);
-           handle_exception(wrapper);
+            auto wrapper = fc::std_exception_wrapper::from_current_exception(e);
+            handle_exception(wrapper);
          }
 
          // this code is hit if an exception was thrown, and handled by `handle_exception`
@@ -3324,6 +3327,9 @@ struct controller_impl {
             throw;
          } catch( const boost::interprocess::bad_alloc& e ) {
             elog( "on block transaction failed due to a bad allocation" );
+            throw;
+         } catch ( const controller_emit_signal_exception& e ) {
+            wlog( "on block transaction failed due to controller_emit_signal_exception: ${e}", ("e", e.to_detail_string()) );
             throw;
          } catch( const fc::exception& e ) {
             wlog( "on block transaction failed, but shouldn't impact block generation, system contract needs update" );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -933,9 +933,8 @@ struct controller_impl {
     *  errors and throw exceptions. Unless those exceptions are caught it could impact consensus and/or
     *  cause a node to fork.
     *
-    *  If it is ever desirable to let a signal handler bubble an exception out of this method
-    *  a full audit of its uses needs to be undertaken.
-    *
+    *  Initiate shutdown and rethrow controller_emit_signal_exception transactions as these exeception are
+    *  critical errors where a node should abort the current block and shutdown.
     */
    template<typename Signal, typename Arg>
    void emit( const Signal& s, Arg&& a, const char* file, uint32_t line ) {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -500,35 +500,4 @@ namespace eosio::chain {
          std::unique_ptr<controller_impl> my;
    }; // controller
 
-   /**
-    *  Plugins / observers listening to signals emitted might trigger
-    *  errors and throw exceptions. Unless those exceptions are caught it could impact consensus and/or
-    *  cause a node to fork.
-    *
-    *  If it is ever desirable to let a signal handler bubble an exception out of this method
-    *  a full audit of its uses needs to be undertaken.
-    *
-    */
-   template<typename Signal, typename Arg>
-   void emit( const Signal& s, Arg&& a, const char* file, uint32_t line ) {
-      try {
-         s( std::forward<Arg>( a ));
-      } catch (std::bad_alloc& e) {
-         wlog( "${f}:${l} std::bad_alloc: ${w}", ("f", file)("l", line)("w", e.what()) );
-         throw e;
-      } catch (boost::interprocess::bad_alloc& e) {
-         wlog( "${f}:${l} boost::interprocess::bad alloc: ${w}", ("f", file)("l", line)("w", e.what()) );
-         throw e;
-      } catch ( controller_emit_signal_exception& e ) {
-         wlog( "${f}:${l} controller_emit_signal_exception: ${details}", ("f", file)("l", line)("details", e.to_detail_string()) );
-         throw e;
-      } catch ( fc::exception& e ) {
-         wlog( "${f}:${l} fc::exception: ${details}", ("f", file)("l", line)("details", e.to_detail_string()) );
-      } catch ( std::exception& e ) {
-         wlog( "std::exception: ${details}", ("f", file)("l", line)("details", e.what()) );
-      } catch ( ... ) {
-         wlog( "${f}:${l} signal handler threw exception", ("f", file)("l", line) );
-      }
-   }
-
 }  /// eosio::chain

--- a/libraries/chain/include/eosio/chain/vote_processor.hpp
+++ b/libraries/chain/include/eosio/chain/vote_processor.hpp
@@ -159,8 +159,8 @@ private:
 
 public:
    explicit vote_processor_t(emit_vote_signal_func_t&& emit_vote_signal, fetch_block_func_t&& get_block)
-      : emit_vote_signal_func(emit_vote_signal)
-      , fetch_block_func(get_block)
+      : emit_vote_signal_func(std::move(emit_vote_signal))
+      , fetch_block_func(std::move(get_block))
    {
       assert(emit_vote_signal_func);
       assert(get_block);

--- a/libraries/chain/include/eosio/chain/vote_processor.hpp
+++ b/libraries/chain/include/eosio/chain/vote_processor.hpp
@@ -163,7 +163,7 @@ public:
       , fetch_block_func(std::move(get_block))
    {
       assert(emit_vote_signal_func);
-      assert(get_block);
+      assert(fetch_block_func);
    }
 
    ~vote_processor_t() {

--- a/plugins/test_control_api_plugin/test_control_api_plugin.cpp
+++ b/plugins/test_control_api_plugin/test_control_api_plugin.cpp
@@ -46,6 +46,11 @@ void test_control_api_plugin::plugin_startup() {
    app().get_plugin<http_plugin>().add_api({
       TEST_CONTROL_RW_CALL(kill_node_on_producer, 202, http_params_types::params_required)
    }, appbase::exec_queue::read_write);
+
+   app().get_plugin<http_plugin>().add_api({
+      TEST_CONTROL_RW_CALL(throw_on, 202, http_params_types::params_required)
+   }, appbase::exec_queue::read_write);
+
 }
 
 void test_control_api_plugin::plugin_shutdown() {}

--- a/plugins/test_control_plugin/include/eosio/test_control_plugin/test_control_plugin.hpp
+++ b/plugins/test_control_plugin/include/eosio/test_control_plugin/test_control_plugin.hpp
@@ -27,6 +27,12 @@ class read_write {
       using kill_node_on_producer_results = empty;
       kill_node_on_producer_results kill_node_on_producer(const kill_node_on_producer_params& params) const;
 
+      struct throw_on_params {
+         std::string  signal;    // which signal handler to throw exception from
+         std::string  exception; // exception to throw
+      };
+      empty throw_on(const throw_on_params& params) const;
+
    private:
       test_control_ptr my;
 };
@@ -61,3 +67,4 @@ private:
 
 FC_REFLECT(eosio::test_control_apis::empty, )
 FC_REFLECT(eosio::test_control_apis::read_write::kill_node_on_producer_params, (producer)(where_in_sequence)(based_on_lib) )
+FC_REFLECT(eosio::test_control_apis::read_write::throw_on_params, (signal)(exception) )

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -22,6 +22,7 @@ private:
    void aggregated_vote();
 
    void throw_exception();
+   void reset_throw();
    void process_next_block_state(const chain::block_id_type& id);
 
    chain::controller&  _chain;
@@ -80,10 +81,19 @@ void test_control_plugin_impl::connect() {
 }
 
 void test_control_plugin_impl::throw_exception() {
-   if (_throw_options.exception == "controller_emit_signal_exception")
+   if (_throw_options.exception == "controller_emit_signal_exception") {
+      ilog("throwing controller_emit_signal_exception for signal ${s}", ("s", _throw_options.signal));
+      reset_throw(); // throw only once
       EOS_ASSERT(false, chain::controller_emit_signal_exception, "");
+   }
 
+   ilog("throwing misc_exception for signal ${s}", ("s", _throw_options.signal));
+   reset_throw(); // throw only once
    EOS_ASSERT(false, chain::misc_exception, "");
+}
+
+void test_control_plugin_impl::reset_throw() {
+   _throw_options = test_control_apis::read_write::throw_on_params{};
 }
 
 void test_control_plugin_impl::block_start(chain::block_num_type block_num) {

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -225,7 +225,7 @@ read_write::kill_node_on_producer_results read_write::kill_node_on_producer(cons
 }
 
 empty read_write::throw_on(const read_write::throw_on_params& params) const {
-   ilog("throw on: ${p}", ("p", params));
+   ilog("received throw on: ${p}", ("p", params));
    my->set_throw_on_options(params);
    return {};
 }

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -1,7 +1,5 @@
 #include <eosio/test_control_plugin/test_control_plugin.hpp>
 
-namespace fc { class variant; }
-
 namespace eosio {
 
    static auto _test_control_plugin = application::register_plugin<test_control_plugin>();
@@ -10,52 +8,121 @@ class test_control_plugin_impl {
 public:
    explicit test_control_plugin_impl(chain::controller& c) : _chain(c) {}
    void connect();
-   void disconnect();
    void kill_on_lib(account_name prod, uint32_t where_in_seq);
    void kill_on_head(account_name prod, uint32_t where_in_seq);
 
+   void set_throw_on_options(const test_control_apis::read_write::throw_on_params& throw_options);
 private:
+   void block_start(chain::block_num_type block_num);
+   void accepted_block_header(const chain::block_id_type& id);
    void accepted_block(const chain::block_id_type& id);
-   void applied_irreversible_block(const chain::block_id_type& id);
+   void irreversible_block(const chain::block_id_type& id);
+   void applied_transaction();
+   void voted_block();
+   void aggregated_vote();
+
+   void throw_exception();
    void process_next_block_state(const chain::block_id_type& id);
 
+   chain::controller&  _chain;
+   struct kill_options {
+      account_name        _producer;
+      uint32_t            _where_in_sequence{};
+      bool                _clean_producer_sequence{false};
+      bool                _started_production_round{false};
+      bool                _track_lib{false};
+      bool                _track_head{false};
+   } _kill_options;
+
+   test_control_apis::read_write::throw_on_params _throw_options;
+
+   std::optional<boost::signals2::scoped_connection> _block_start_connection;
+   std::optional<boost::signals2::scoped_connection> _accepted_block_header_connection;
    std::optional<boost::signals2::scoped_connection> _accepted_block_connection;
    std::optional<boost::signals2::scoped_connection> _irreversible_block_connection;
-   chain::controller&  _chain;
-   account_name        _producer;
-   uint32_t            _where_in_sequence{};
-   bool                _clean_producer_sequence{false};
-   bool                _started_production_round{false};
-   bool                _track_lib{false};
-   bool                _track_head{false};
+   std::optional<boost::signals2::scoped_connection> _applied_transaction_connection;
+   std::optional<boost::signals2::scoped_connection> _voted_block_connection;
+   std::optional<boost::signals2::scoped_connection> _aggregated_vote_connection;
 };
 
 void test_control_plugin_impl::connect() {
-   _irreversible_block_connection.emplace(
-         _chain.irreversible_block().connect( [&]( const chain::block_signal_params& t ) {
-            const auto& [ block, id ] = t;
-            applied_irreversible_block( id );
+   _block_start_connection.emplace(
+         _chain.block_start().connect( [&]( chain::block_num_type block_num ) {
+            block_start( block_num );
          } ));
+   _accepted_block_header_connection =
+         _chain.accepted_block_header().connect( [&]( const chain::block_signal_params& t ) {
+            const auto& [ block, id ] = t;
+            accepted_block_header( id );
+         } );
    _accepted_block_connection =
          _chain.accepted_block().connect( [&]( const chain::block_signal_params& t ) {
             const auto& [ block, id ] = t;
             accepted_block( id );
          } );
+   _irreversible_block_connection.emplace(
+         _chain.irreversible_block().connect( [&]( const chain::block_signal_params& t ) {
+            const auto& [ block, id ] = t;
+            irreversible_block( id );
+         } ));
+   _applied_transaction_connection.emplace(
+         _chain.applied_transaction().connect( [&]( std::tuple<const chain::transaction_trace_ptr&, const chain::packed_transaction_ptr&> t) {
+            applied_transaction();
+         } ));
+   _voted_block_connection.emplace(
+         _chain.voted_block().connect( [&]( const chain::vote_signal_params& p) {
+            voted_block();
+         } ));
+   _aggregated_vote_connection.emplace(
+         _chain.aggregated_vote().connect( [&]( const chain::vote_signal_params& p) {
+            aggregated_vote();
+         } ));
 }
 
-void test_control_plugin_impl::disconnect() {
-   _accepted_block_connection.reset();
-   _irreversible_block_connection.reset();
+void test_control_plugin_impl::throw_exception() {
+   if (_throw_options.exception == "controller_emit_signal_exception")
+      EOS_ASSERT(false, chain::controller_emit_signal_exception, "");
+
+   EOS_ASSERT(false, chain::misc_exception, "");
 }
 
-void test_control_plugin_impl::applied_irreversible_block(const chain::block_id_type& id) {
-   if (_track_lib)
-      process_next_block_state(id);
+void test_control_plugin_impl::block_start(chain::block_num_type block_num) {
+   if (_throw_options.signal == "block_start")
+      throw_exception();
+}
+
+void test_control_plugin_impl::accepted_block_header(const chain::block_id_type& id) {
+   if (_throw_options.signal == "accepted_block_header")
+      throw_exception();
 }
 
 void test_control_plugin_impl::accepted_block(const chain::block_id_type& id) {
-   if (_track_head)
+   if (_kill_options._track_head)
       process_next_block_state(id);
+   if (_throw_options.signal == "accepted_block")
+      throw_exception();
+}
+
+void test_control_plugin_impl::irreversible_block(const chain::block_id_type& id) {
+   if (_kill_options._track_lib)
+      process_next_block_state(id);
+   if (_throw_options.signal == "irreversible_block")
+      throw_exception();
+}
+
+void test_control_plugin_impl::applied_transaction() {
+   if (_throw_options.signal == "applied_transaction")
+      throw_exception();
+}
+
+void test_control_plugin_impl::voted_block() {
+   if (_throw_options.signal == "voted_block")
+      throw_exception();
+}
+
+void test_control_plugin_impl::aggregated_vote() {
+   if (_throw_options.signal == "aggregated_vote")
+      throw_exception();
 }
 
 void test_control_plugin_impl::process_next_block_state(const chain::block_id_type& id) {
@@ -66,24 +133,24 @@ void test_control_plugin_impl::process_next_block_state(const chain::block_id_ty
    const auto& producer_authority = _chain.active_producers().get_scheduled_producer(block_time);
    const auto producer_name = producer_authority.producer_name;
    const auto slot = _chain.head().timestamp().slot % chain::config::producer_repetitions;
-   if (_producer != account_name()) {
-      if( _producer != producer_name ) _clean_producer_sequence = true;
-      if( _clean_producer_sequence ) {
+   if (_kill_options._producer != account_name()) {
+      if( _kill_options._producer != producer_name ) _kill_options._clean_producer_sequence = true;
+      if( _kill_options._clean_producer_sequence ) {
          ilog( "producer ${cprod} slot ${pslot}, looking for ${lprod} slot ${slot}",
-               ("cprod", producer_name)("pslot", slot)("lprod", _producer)("slot", _where_in_sequence) );
+               ("cprod", producer_name)("pslot", slot)("lprod", _kill_options._producer)("slot", _kill_options._where_in_sequence) );
       } else {
          ilog( "producer ${cprod} slot ${pslot}, looking for start of ${lprod} production round",
-               ("cprod", producer_name)("pslot", slot)("lprod", _producer) );
+               ("cprod", producer_name)("pslot", slot)("lprod", _kill_options._producer) );
       }
    }
 
    // check started_production_round in case where producer does not produce a full round, still want to shut down
-   if( _clean_producer_sequence && (producer_name == _producer || _started_production_round) ) {
-      _started_production_round = true;
+   if( _kill_options._clean_producer_sequence && (producer_name == _kill_options._producer || _kill_options._started_production_round) ) {
+      _kill_options._started_production_round = true;
       const auto current_slot = chain::block_timestamp_type( block_time ).slot % chain::config::producer_repetitions;
       ilog( "producer ${prod} slot: ${slot}", ("prod", producer_name)("slot", slot) );
 
-      if( current_slot >= _where_in_sequence || producer_name != _producer ) {
+      if( current_slot >= _kill_options._where_in_sequence || producer_name != _kill_options._producer ) {
          ilog("shutting down");
          app().quit();
       }
@@ -91,22 +158,29 @@ void test_control_plugin_impl::process_next_block_state(const chain::block_id_ty
 }
 
 void test_control_plugin_impl::kill_on_lib(account_name prod, uint32_t where_in_seq) {
-   _track_head = false;
-   _producer = prod;
-   _where_in_sequence = where_in_seq;
-   _clean_producer_sequence = false;
-   _started_production_round = false;
-   _track_lib = true;
+   _kill_options._track_head = false;
+   _kill_options._producer = prod;
+   _kill_options._where_in_sequence = where_in_seq;
+   _kill_options._clean_producer_sequence = false;
+   _kill_options._started_production_round = false;
+   _kill_options._track_lib = true;
 }
 
 void test_control_plugin_impl::kill_on_head(account_name prod, uint32_t where_in_seq) {
-   _track_lib = false;
-   _producer = prod;
-   _where_in_sequence = where_in_seq;
-   _clean_producer_sequence = false;
-   _started_production_round = false;
-   _track_head = true;
+   _kill_options._track_lib = false;
+   _kill_options._producer = prod;
+   _kill_options._where_in_sequence = where_in_seq;
+   _kill_options._clean_producer_sequence = false;
+   _kill_options._started_production_round = false;
+   _kill_options._track_head = true;
 }
+
+// ----------------- throw_on --------------------------------
+
+void test_control_plugin_impl::set_throw_on_options(const test_control_apis::read_write::throw_on_params& throw_options) {
+   _throw_options = throw_options;
+}
+
 
 test_control_plugin::test_control_plugin() = default;
 
@@ -127,6 +201,7 @@ void test_control_plugin::plugin_shutdown() {
 }
 
 namespace test_control_apis {
+
 read_write::kill_node_on_producer_results read_write::kill_node_on_producer(const read_write::kill_node_on_producer_params& params) const {
 
    if (params.based_on_lib) {
@@ -139,6 +214,11 @@ read_write::kill_node_on_producer_results read_write::kill_node_on_producer(cons
    return read_write::kill_node_on_producer_results{};
 }
 
-} // namespace test_control_apis
+empty read_write::throw_on(const read_write::throw_on_params& params) const {
+   ilog("throw on: ${p}", ("p", params));
+   my->set_throw_on_options(params);
+   return {};
+}
 
+} // namespace test_control_apis
 } // namespace eosio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/restart-scenarios-test.py ${CMAKE_CUR
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/terminate-scenarios-test.py ${CMAKE_CURRENT_BINARY_DIR}/terminate-scenarios-test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/terminate_scenarios_test_shape.json ${CMAKE_CURRENT_BINARY_DIR}/terminate_scenarios_test_shape.json COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/liveness_test.py ${CMAKE_CURRENT_BINARY_DIR}/liveness_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_signal_throw_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_signal_throw_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_startup_catchup.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_startup_catchup.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_snapshot_diff_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_snapshot_diff_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_snapshot_forked_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_snapshot_forked_test.py COPYONLY)
@@ -343,6 +344,9 @@ add_test(NAME nodeos_chainbase_allocation_test COMMAND tests/nodeos_chainbase_al
 set_property(TEST nodeos_chainbase_allocation_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME nodeos_chainbase_allocation_if_test COMMAND tests/nodeos_chainbase_allocation_test.py --activate-if -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_chainbase_allocation_if_test PROPERTY LABELS nonparallelizable_tests)
+
+add_test(NAME nodeos_signal_throw_test COMMAND tests/nodeos_signal_throw_test.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST nodeos_signal_throw_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME nodeos_startup_catchup_lr_test COMMAND tests/nodeos_startup_catchup.py -v ${UNSHARE} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_startup_catchup_lr_test PROPERTY LABELS long_running_tests)

--- a/tests/nodeos_signal_throw_test.py
+++ b/tests/nodeos_signal_throw_test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import signal
+
+from TestHarness import Cluster, TestHelper, Utils, WalletMgr
+from TestHarness.Node import BlockType
+
+###############################################################
+# nodeos_signal_throw_test
+#
+# Verify throwing in signal handlers is handled correctly by nodeos.
+#
+# A controller_emit_signal_exception should cause nodeos to gracefully shutdown.
+# Any other exception type should be ignored and nodeos continue running.
+#
+###############################################################
+
+Print=Utils.Print
+errorExit=Utils.errorExit
+
+args=TestHelper.parse_args({"-d","--keep-logs","--dump-error-details","-v","--leave-running","--unshared"})
+pnodes=1
+delay=args.d
+debug=args.v
+prod_count = 1 # per node prod count
+total_nodes=pnodes+2
+dumpErrorDetails=args.dump_error_details
+
+Utils.Debug=debug
+testSuccessful=False
+
+cluster=Cluster(unshared=args.unshared, keepRunning=args.leave_running, keepLogs=args.keep_logs)
+walletMgr=WalletMgr(True, keepRunning=args.leave_running, keepLogs=args.keep_logs)
+
+def verifyExceptionDoesNotShutdown(node, sig, exception):
+    if node.isProducer:
+        node.waitForProducer("defproducera")
+    node.processUrllibRequest("test_control", "throw_on", {"signal":sig, "exception":exception})
+    assert node.verifyAlive(), f"Node {node.nodeId} shutdown on {sig} exception {exception}"
+    assert node.waitForHeadToAdvance(), f"Node {node.nodeId} did not advance head after {sig} exception {exception}"
+
+def verifyExceptionShutsdown(node, sig, exception):
+    if node.isProducer:
+        node.waitForProducer("defproducera")
+    node.processUrllibRequest("test_control", "throw_on", {"signal":sig, "exception":exception})
+    assert node.waitForNodeToExit(timeout=5), f"Node {node.nodeId} did not shutdown on {sig} exception {exception}"
+    assert not node.verifyAlive(), f"Node {node.nodeId} did not shutdown on {sig} exception {exception}"
+    assert node.relaunch(), f"Node {node.nodeId} relaunch failed after {sig} exception {exception}"
+    assert node.waitForHeadToAdvance(), f"Node {node.nodeId} did not advance head after relaunch after {sig} exception {exception}"
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+
+    cluster.setWalletMgr(walletMgr)
+
+    Print(f'producing nodes: {pnodes}, delay between nodes launch: {delay} second{"s" if delay != 1 else ""}')
+
+    Print("Stand up cluster")
+    extraNodeosArgs="--plugin eosio::test_control_api_plugin"
+    specificExtraNodeosArgs= {"0": "--enable-stale-production"}
+    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, totalProducers=pnodes, delay=delay,
+                      activateIF=True, extraNodeosArgs=extraNodeosArgs, specificExtraNodeosArgs=specificExtraNodeosArgs) is False:
+        errorExit("Failed to stand up eos cluster.")
+
+    assert cluster.biosNode.getInfo(exitOnError=True)["head_block_producer"] != "eosio", "launch should have waited for production to change"
+    cluster.waitOnClusterSync(blockAdvancing=2)
+
+    node0 = cluster.getNode(0) # producer A
+    node1 = cluster.getNode(1) # speculative node for exceptions
+    node2 = cluster.getNode(2) # speculative node for trx generator
+
+    Print("Configure and launch txn generators")
+    targetTpsPerGenerator = 5
+    testTrxGenDurationSec=60*60
+    cluster.launchTrxGenerators(contractOwnerAcctName=cluster.eosioAccount.name, acctNamesList=[cluster.defproduceraAccount.name, cluster.eosioAccount.name],
+                                acctPrivKeysList=[cluster.defproduceraAccount.activePrivateKey,cluster.eosioAccount.activePrivateKey], nodeId=node2.nodeId,
+                                tpsPerGenerator=targetTpsPerGenerator, numGenerators=1, durationSec=testTrxGenDurationSec,
+                                waitToComplete=False)
+
+    status = cluster.waitForTrxGeneratorsSpinup(nodeId=node2.nodeId, numGenerators=1)
+    assert status is not None and status is not False, "ERROR: Failed to spinup Transaction Generators"
+
+
+    verifyExceptionDoesNotShutdown(node1, "block_start", "misc")
+    verifyExceptionDoesNotShutdown(node1, "accepted_block_header", "misc")
+    verifyExceptionDoesNotShutdown(node1, "accepted_block", "misc")
+    verifyExceptionDoesNotShutdown(node1, "irreversible_block", "misc")
+    verifyExceptionDoesNotShutdown(node1, "applied_transaction", "misc")
+    # only applicable to producers:  verifyExceptionDoesNotShutdown(node1, "voted_block", "misc")
+    # only applicable to finalizers: verifyExceptionDoesNotShutdown(node1, "aggregated_vote", "misc")
+
+    verifyExceptionDoesNotShutdown(node0, "block_start", "misc")
+    verifyExceptionDoesNotShutdown(node0, "accepted_block_header", "misc")
+    verifyExceptionDoesNotShutdown(node0, "accepted_block", "misc")
+    verifyExceptionDoesNotShutdown(node0, "irreversible_block", "misc")
+    verifyExceptionDoesNotShutdown(node0, "applied_transaction", "misc")
+    verifyExceptionDoesNotShutdown(node0, "voted_block", "misc")
+    verifyExceptionDoesNotShutdown(node0, "aggregated_vote", "misc")
+
+    verifyExceptionShutsdown(node1, "block_start", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node1, "accepted_block_header", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node1, "accepted_block", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node1, "irreversible_block", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node1, "applied_transaction", "controller_emit_signal_exception")
+    # only applicable to producers:  verifyExceptionShutsdown(node1, "voted_block", "controller_emit_signal_exception")
+    # only applicable to finalizers: verifyExceptionShutsdown(node1, "aggregated_vote", "controller_emit_signal_exception")
+
+    verifyExceptionShutsdown(node0, "block_start", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node0, "accepted_block_header", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node0, "accepted_block", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node0, "irreversible_block", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node0, "applied_transaction", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node0, "voted_block", "controller_emit_signal_exception")
+    verifyExceptionShutsdown(node0, "aggregated_vote", "controller_emit_signal_exception")
+
+    testSuccessful=True
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, dumpErrorDetails=dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/unittests/vote_processor_tests.cpp
+++ b/unittests/vote_processor_tests.cpp
@@ -146,10 +146,11 @@ BOOST_AUTO_TEST_CASE( vote_processor_test ) {
       ++signaled;
    } );
 
-   vote_processor_t vp{voted_block, [&](const block_id_type& id) -> block_state_ptr {
-      std::lock_guard g(fork_db_mtx);
-      return fork_db[id];
-   }};
+   vote_processor_t vp{[&](const vote_signal_params& p) { voted_block(p); },
+                       [&](const block_id_type& id) -> block_state_ptr {
+                          std::lock_guard g(fork_db_mtx);
+                          return fork_db[id];
+                       }};
    vp.start(2, [](const fc::exception& e) {
       edump((e));
       BOOST_REQUIRE(false);


### PR DESCRIPTION
Adds new integration test that thows in all controller signals. It verifies that non-`controller_emit_signal_exception` exceptions are caught and dropped and that `controller_emit_signal_exception` shuts down the node in a state where it can be restarted. `test_control_plugin` updated with `/v1/test_control/throw_on` endpoint for allowing external triggers of exceptions on signals.

Includes a fix for reverting `chain_head` if `accepted_block` throws. This caused nodeos not to be able to restart as the `chain_head` did not match the chainbase state.
Includes a fix for `applied_transaction` throwing and shutting down nodeos.
Includes a fix for `vote_signal` throwing and shutting down nodeos.

Looking for opinions on if this PR should be backported to `release/1.0`

Resolves #946