### PR TITLE
[1.0.4] Fix stuck plugin_http_api_test

### DIFF
--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -887,42 +887,6 @@ class PluginHttpTest(unittest.TestCase):
     def test_ProducerApi(self) :
         resource = "producer"
         endpoint=self.endpoint("producer_rw")
-        # pause with empty parameter
-        command = "pause"
-        ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
-        self.assertEqual(ret_json["payload"]["result"], "ok")
-        # pause with empty content parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
-        self.assertEqual(ret_json["payload"]["result"], "ok")
-        # pause with invalid parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-
-        # resume with empty parameter
-        command = "resume"
-        ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
-        self.assertEqual(ret_json["payload"]["result"], "ok")
-        # resume with empty content parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
-        self.assertEqual(ret_json["payload"]["result"], "ok")
-        # resume with invalid parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-
-        endpoint=self.endpoint("producer_ro")
-        # paused with empty parameter
-        command = "paused"
-        ret_str = self.nodeos.processUrllibRequest(resource, command, returnType=ReturnType.raw, endpoint=endpoint).decode('ascii')
-        self.assertEqual(ret_str, "false")
-        # paused with empty content parameter
-        ret_str = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, returnType=ReturnType.raw, endpoint=endpoint).decode('ascii')
-        self.assertEqual(ret_str, "false")
-        # paused with invalid parameter
-        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
 
         # get_runtime_options with empty parameter
         command = "get_runtime_options"
@@ -958,6 +922,18 @@ class PluginHttpTest(unittest.TestCase):
                    "subjective_cpu_leeway_us":0,
                    "incoming_defer_ratio":1.0,
                    "greylist_limit":100}
+        ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
+        self.assertIn(ret_json["payload"]["result"], "ok")
+        # restore runtime options to default values such that future tests are not impacted
+        # by the modified values of last test (max_irreversible_block_age: 1 can make producer
+        # plugin stuck in speculative mode)
+        payload = {"max_transaction_time":499,
+                   "max_irreversible_block_age":-1,
+                   "cpu_effort_us":400000,
+                   "max_scheduled_transaction_time_per_block_ms":10000,
+                   "subjective_cpu_leeway_us":31000,
+                   "incoming_defer_ratio":1.0,
+                   "greylist_limit":1000}
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
         self.assertIn(ret_json["payload"]["result"], "ok")
 
@@ -1175,6 +1151,46 @@ class PluginHttpTest(unittest.TestCase):
         payload = {"lower_bound":"", "limit":1, "time_limit_ms":500}
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
         self.assertIn("trxs", ret_json["payload"])
+
+        # place pause and resume tests at the end such that they are not impacted
+        # by update_runtime_options
+
+        # pause with empty parameter
+        command = "pause"
+        ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
+        self.assertEqual(ret_json["payload"]["result"], "ok")
+        # pause with empty content parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
+        self.assertEqual(ret_json["payload"]["result"], "ok")
+        # pause with invalid parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # resume with empty parameter
+        command = "resume"
+        ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
+        self.assertEqual(ret_json["payload"]["result"], "ok")
+        # resume with empty content parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
+        self.assertEqual(ret_json["payload"]["result"], "ok")
+        # resume with invalid parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        endpoint=self.endpoint("producer_ro")
+        # paused with empty parameter
+        command = "paused"
+        ret_str = self.nodeos.processUrllibRequest(resource, command, returnType=ReturnType.raw, endpoint=endpoint).decode('ascii')
+        self.assertEqual(ret_str, "false")
+        # paused with empty content parameter
+        ret_str = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, returnType=ReturnType.raw, endpoint=endpoint).decode('ascii')
+        self.assertEqual(ret_str, "false")
+        # paused with invalid parameter
+        ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
 
     # test all wallet api
     def test_WalletApi(self) :

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -918,9 +918,7 @@ class PluginHttpTest(unittest.TestCase):
         payload = {"max_transaction_time":30,
                    "max_irreversible_block_age":1,
                    "cpu_effort_us":400000,
-                   "max_scheduled_transaction_time_per_block_ms":10000,
                    "subjective_cpu_leeway_us":0,
-                   "incoming_defer_ratio":1.0,
                    "greylist_limit":100}
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
         self.assertIn(ret_json["payload"]["result"], "ok")
@@ -930,9 +928,7 @@ class PluginHttpTest(unittest.TestCase):
         payload = {"max_transaction_time":499,
                    "max_irreversible_block_age":-1,
                    "cpu_effort_us":400000,
-                   "max_scheduled_transaction_time_per_block_ms":10000,
                    "subjective_cpu_leeway_us":31000,
-                   "incoming_defer_ratio":1.0,
                    "greylist_limit":1000}
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
         self.assertIn(ret_json["payload"]["result"], "ok")

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -886,7 +886,7 @@ class PluginHttpTest(unittest.TestCase):
     # test all producer api
     def test_ProducerApi(self) :
         resource = "producer"
-        endpoint=self.endpoint("producer_rw")
+        endpoint=self.endpoint("producer_ro")
 
         # get_runtime_options with empty parameter
         command = "get_runtime_options"
@@ -1151,6 +1151,7 @@ class PluginHttpTest(unittest.TestCase):
         # place pause and resume tests at the end such that they are not impacted
         # by update_runtime_options
 
+        endpoint=self.endpoint("producer_rw") # pause and resume are in producer_rw category
         # pause with empty parameter
         command = "pause"
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)


### PR DESCRIPTION
I target this PR to `release/1.0` as it corrects 2 issues in `plugin_http_api_test` but does not touch non-tests code.

`plugin_http_api_test` gets stuck sometimes. This is caused by producer API related tests, where after `pause` and `resume` tests, `update_runtime_options` test modifies `max_irreversible_block_age` to 1 second which causes producer plugin to be stuck in speculative mode.

The PR
* restores options modified by `update_runtime_options` test to default values afterwards
* in addition to fixing the stuck problem, removes `max_scheduled_transaction_time_per_block_ms` and `incoming_defer_ratio` from `update_runtime_options` test  as those options were already removed in Leap 5.0.

Resolves https://github.com/AntelopeIO/spring/issues/992

Detailed log showing the problem:

```
info  2024-10-30T14:16:59.920 nodeos    producer_plugin.cpp:1650      pause                ] Producer paused.
info  2024-10-30T14:16:59.921 nodeos    producer_plugin.cpp:1650      pause                ] Producer paused.
info  2024-10-30T14:16:59.923 nodeos    producer_plugin.cpp:1168      resume               ] Producer resumed.
info  2024-10-30T14:16:59.923 nodeos    producer_plugin.cpp:1168      resume               ] Producer resumed.
error 2024-10-30T14:17:00.004 nodeos    producer_plugin.cpp:2038      start_block          ] Not producing block because the         irreversible block is too old [age:1s, max:1s], block 2024-10-30T14:17:00.500
```

