### PR TITLE
[1.0.4 -> main] Advance fork db root when pending lib greater than head

### DIFF
--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -145,6 +145,13 @@ BOOST_FIXTURE_TEST_CASE(add_remove_test, generate_fork_db_state) try {
    auto bsp14c = test_block_state_accessor::make_unique_block_state(14, bsp13c); // should be best branch
    BOOST_TEST(fork_db.add(bsp14c, ignore_duplicate_t::yes));
 
+   // test fetch branch when lib is greater than head
+   branch = fork_db.fetch_branch(bsp13b->id(), bsp12a->id());
+   BOOST_TEST(branch.empty());
+   branch = fork_db.fetch_branch(bsp13b->id(), bsp12b->id());
+   BOOST_REQUIRE(branch.size() == 2);
+   BOOST_TEST(branch[0] == bsp12b);
+   BOOST_TEST(branch[1] == bsp11b);
 } FC_LOG_AND_RETHROW();
 
 


### PR DESCRIPTION
When syncing under Savanna it is common for pending LIB to be greater than head. `log_irreversible` updates the block log and fork db root by the range of blocks from root->LIB when head is in root->LIB. Since LIB can be greater than head this would result in `forkdb.fetch_branch` returning an empty branch since searching back from head would not find the LIB causing large delays in the advancement of root.

Update `log_irreversible` to fetch branch from root->head when LIB is greater than head and head is in root->head.

Merges `release/1.0` into `main` including #1009 

Resolves #1003