### PR TITLE
workaround cdt's small const memcpy host function calls in EOS VM OC

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic.hpp
@@ -25,4 +25,7 @@ using intrinsic_map_t = std::map<std::string, intrinsic_entry>;
 
 const intrinsic_map_t& get_intrinsic_map();
 
+static constexpr unsigned minimum_const_memcpy_intrinsic_to_optimize = 1;
+static constexpr unsigned maximum_const_memcpy_intrinsic_to_optimize = 128;
+
 }}}

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic_mapping.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic_mapping.hpp
@@ -278,7 +278,8 @@ inline constexpr auto get_intrinsic_table() {
       "env.bls_fp_mod",
       "env.bls_fp_mul",
       "env.bls_fp_exp",
-      "env.set_finalizers"
+      "env.set_finalizers",
+      "eosvmoc_internal.check_memcpy_params"
    );
 }
 inline constexpr std::size_t find_intrinsic_index(std::string_view hf) {

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
@@ -88,8 +88,9 @@ static intrinsic eosio_exit_intrinsic("env.eosio_exit", IR::FunctionType::get(IR
   std::integral_constant<std::size_t, find_intrinsic_index("env.eosio_exit")>::value
 );
 
-static void throw_internal_exception(const char* const s) {
-   *reinterpret_cast<std::exception_ptr*>(eos_vm_oc_get_exception_ptr()) = std::make_exception_ptr(wasm_execution_error(FC_LOG_MESSAGE(error, s)));
+template <typename E>
+static void throw_internal_exception(const E& e) {
+   *reinterpret_cast<std::exception_ptr*>(eos_vm_oc_get_exception_ptr()) = std::make_exception_ptr(e);
    siglongjmp(*eos_vm_oc_get_jmp_buf(), EOSVMOC_EXIT_EXCEPTION);
    __builtin_unreachable();
 }
@@ -102,23 +103,23 @@ static void throw_internal_exception(const char* const s) {
 	void name()
 
 DEFINE_EOSVMOC_TRAP_INTRINSIC(eosvmoc_internal,depth_assert) {
-   throw_internal_exception("Exceeded call depth maximum");
+   throw_internal_exception(wasm_execution_error(FC_LOG_MESSAGE(error, "Exceeded call depth maximum")));
 }
 
 DEFINE_EOSVMOC_TRAP_INTRINSIC(eosvmoc_internal,div0_or_overflow) {
-   throw_internal_exception("Division by 0 or integer overflow trapped");
+   throw_internal_exception(wasm_execution_error(FC_LOG_MESSAGE(error, "Division by 0 or integer overflow trapped")));
 }
 
 DEFINE_EOSVMOC_TRAP_INTRINSIC(eosvmoc_internal,indirect_call_mismatch) {
-   throw_internal_exception("Indirect call function type mismatch");
+   throw_internal_exception(wasm_execution_error(FC_LOG_MESSAGE(error, "Indirect call function type mismatch")));
 }
 
 DEFINE_EOSVMOC_TRAP_INTRINSIC(eosvmoc_internal,indirect_call_oob) {
-   throw_internal_exception("Indirect call index out of bounds");
+   throw_internal_exception(wasm_execution_error(FC_LOG_MESSAGE(error, "Indirect call index out of bounds")));
 }
 
 DEFINE_EOSVMOC_TRAP_INTRINSIC(eosvmoc_internal,unreachable) {
-   throw_internal_exception("Unreachable reached");
+   throw_internal_exception(wasm_execution_error(FC_LOG_MESSAGE(error, "Unreachable reached")));
 }
 
 struct executor_signal_init {

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -16,6 +16,7 @@
 #include <eosio/chain/wasm_interface.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/finalizer_authority.hpp>
+#include <eosio/chain/webassembly/eos-vm-oc.hpp>
 
 #include <fc/crypto/digest.hpp>
 #include <fc/crypto/sha256.hpp>
@@ -3350,6 +3351,86 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( get_code_hash_tests, T, validating_testers ) { tr
    check("test"_n, 2);
    t.set_code("test"_n, std::vector<uint8_t>{});
    check("test"_n, 3);
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE( small_const_memcpy_tests, T, validating_testers ) { try {
+   T t;
+   t.create_account("smallmemcpy"_n);
+   t.produce_block();
+
+   for(unsigned i = eosvmoc::minimum_const_memcpy_intrinsic_to_optimize; i <= eosvmoc::maximum_const_memcpy_intrinsic_to_optimize; ++i) {
+      t.set_code("smallmemcpy"_n, fc::format_string(small_memcpy_const_dstsrc_wastfmt, fc::mutable_variant_object("COPY_SIZE", i)).c_str());
+
+      signed_transaction trx;
+      action act;
+      act.account = "smallmemcpy"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"smallmemcpy"_n,config::active_name}};
+      act.data.push_back(i);
+      trx.actions.push_back(act);
+      t.set_transaction_headers(trx);
+      trx.sign(t.get_private_key( "smallmemcpy"_n, "active" ), t.get_chain_id());
+      t.push_transaction(trx);
+
+      if(i%10 == 0)
+         t.produce_block();
+   }
+
+} FC_LOG_AND_RETHROW() }
+
+//similar to above, but the source and destination values passed to memcpy are not consts
+BOOST_AUTO_TEST_CASE_TEMPLATE( small_var_memcpy_tests, T, validating_testers ) { try {
+   T t;
+   t.create_account("smallmemcpy"_n);
+   t.produce_block();
+
+   for(unsigned i = eosvmoc::minimum_const_memcpy_intrinsic_to_optimize; i <= eosvmoc::maximum_const_memcpy_intrinsic_to_optimize; ++i) {
+      t.set_code("smallmemcpy"_n, fc::format_string(small_memcpy_var_dstsrc_wastfmt, fc::mutable_variant_object("COPY_SIZE", i)).c_str());
+
+      signed_transaction trx;
+      action act;
+      act.account = "smallmemcpy"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"smallmemcpy"_n,config::active_name}};
+      act.data.push_back(i);
+      trx.actions.push_back(act);
+      t.set_transaction_headers(trx);
+      trx.sign(t.get_private_key( "smallmemcpy"_n, "active" ), t.get_chain_id());
+      t.push_transaction(trx);
+
+      if(i%10 == 0)
+         t.produce_block();
+   }
+
+} FC_LOG_AND_RETHROW() }
+
+//check that small constant sized memcpys (that OC will optimize "away") correctly fail on edge or high side of invalid memory
+BOOST_AUTO_TEST_CASE_TEMPLATE( small_const_memcpy_oob_tests, T, validating_testers ) { try {
+   T t;
+   t.create_account("smallmemcpy"_n);
+   t.produce_block();
+
+   auto sendit = [&]() {
+      signed_transaction trx;
+      action act;
+      act.account = "smallmemcpy"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"smallmemcpy"_n,config::active_name}};
+      trx.actions.push_back(act);
+      t.set_transaction_headers(trx);
+      trx.sign(t.get_private_key( "smallmemcpy"_n, "active" ), t.get_chain_id());
+      t.push_transaction(trx);
+   };
+
+   t.set_code("smallmemcpy"_n, small_memcpy_overlapenddst_wast);
+   BOOST_REQUIRE_EXCEPTION(sendit(), eosio::chain::wasm_execution_error, [](const eosio::chain::wasm_execution_error& e) {return expect_assert_message(e, "access violation");});
+
+   t.set_code("smallmemcpy"_n, small_memcpy_overlapendsrc_wast);
+   BOOST_REQUIRE_EXCEPTION(sendit(), eosio::chain::wasm_execution_error, [](const eosio::chain::wasm_execution_error& e) {return expect_assert_message(e, "access violation");});
+
+   t.set_code("smallmemcpy"_n, small_memcpy_high_wast);
+   BOOST_REQUIRE_EXCEPTION(sendit(), eosio::chain::wasm_execution_error, [](const eosio::chain::wasm_execution_error& e) {return expect_assert_message(e, "access violation");});
+
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
AntelopeIO/cdt#102 is a long time thorn and while obviously it would be ideal to fix cdt to not generate these host function calls in the first place, it's not clear when that will happen and regardless there will be many contracts that may never be recompiled and years of historical blocks that will have these calls forever.

This implements a workaround in EOS VM OC that identifies small constant size memcpy host function calls during code generation and replaces them with simple memory loads and stores plus a small call to a native function that verifies the memcpy ranges do not overlap as required by protocol rules.

As a simple example, a contract such as,
```wat
(module
 (import "env" "memcpy" (func $memcpy (param i32 i32 i32) (result i32)))
 (export "apply" (func $apply))
 (memory 1)
 (func $apply (param $0 i64) (param $1 i64) (param $2 i64)
    (drop (call $memcpy (i32.const 4) (i32.const 200) (i32.const 8)))
 )
)
```
Will generate machine code (annotated by me)
```asm
    pushq	%rax
    decl	%gs:-18888     ;;decrement depth count and jump if zero
    je  	51
    movq	%gs:200, %rax  ;;load 8 bytes from address 200 in to register
    movq	%rax, %gs:4    ;;store 8 bytes to address 4 from register
    movl	$4, %edi       ;;prepare the 3 parameters to check_memcpy_params
    movl	$200, %esi
    movl	$8, %edx
    callq	*%gs:-21056    ;;call check_memcpy_params
    incl	%gs:-18888     ;;increment depth count
    popq	%rax
    retq
    callq	*%gs:-18992    ;;call depth_assert
```
(in practice the source and destination addresses are typically not constants)

For some tested block ranges starting at 346025446, 348083350, 371435719, and 396859576 replay performance increases within a range of 3.5% to 6%. This is a bit lower than I expected -- I was expecting consistently north of 5% -- the reason for missing my expectation is that there are still many memcpy host function calls that are not optimized out, and the overlap check can still consume significant amount of CPU.

A run of the LLVM exhaustive workflow is at,
https://github.com/AntelopeIO/spring/actions/runs/11711214896