### PR TITLE
Remove redundant log output and prometheus metrics update during replay

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3546,7 +3546,7 @@ struct controller_impl {
               ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)("et", br.total_elapsed_time)
               ("tt", now - br.start_time));
 
-         if (_update_produced_block_metrics) {
+         if (_update_produced_block_metrics && !replaying) { // no need to update prometheus while replaying
             produced_block_metrics metrics;
             metrics.subjective_bill_account_size_total = subjective_bill.get_account_cache_size();
             metrics.scheduled_trxs_total = db.get_index<generated_transaction_multi_index, by_delay>().size();

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3562,12 +3562,15 @@ struct controller_impl {
          return;
       }
 
-      ilog("Received block ${id}... #${n} @ ${t} signed by ${p} " // "Received" instead of "Applied" so it matches existing log output
-           "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu} us, elapsed: ${elapsed} us, applying time: ${time} us, latency: ${latency} ms]",
-           ("p", chain_head.producer())("id", chain_head.id().str().substr(8, 16))("n", chain_head.block_num())("t", chain_head.timestamp())
-           ("count", chain_head.block()->transactions.size())("lib", chain_head.irreversible_blocknum())
-           ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)
-           ("elapsed", br.total_elapsed_time)("time", now - br.start_time)("latency", (now - chain_head.timestamp()).count() / 1000));
+      if (!replaying) { // logging for replaying is done in replay_block_log()
+         ilog("Received block ${id}... #${n} @ ${t} signed by ${p} " // "Received" instead of "Applied" so it matches existing log output
+              "[trxs: ${count}, lib: ${lib}, net: ${net}, cpu: ${cpu} us, elapsed: ${elapsed} us, applying time: ${time} us, latency: ${latency} ms]",
+              ("p", chain_head.producer())("id", chain_head.id().str().substr(8, 16))("n", chain_head.block_num())("t", chain_head.timestamp())
+              ("count", chain_head.block()->transactions.size())("lib", chain_head.irreversible_blocknum())
+              ("net", br.total_net_usage)("cpu", br.total_cpu_usage_us)
+              ("elapsed", br.total_elapsed_time)("time", now - br.start_time)("latency", (now - chain_head.timestamp()).count() / 1000));
+      }
+
       if (_update_incoming_block_metrics) {
          _update_incoming_block_metrics({.trxs_incoming_total   = chain_head.block()->transactions.size(),
                                          .cpu_usage_us          = br.total_cpu_usage_us,


### PR DESCRIPTION
Before the change:
```
info  2024-11-07T23:18:21.438 nodeos    controller.cpp:1725           replay_block_log     ] 500 of 4983
info  2024-11-07T23:18:21.552 nodeos    controller.cpp:3566           log_applied          ] Received block 733efdcdfaeda3e0... #1000 @ 2024-  11-07T22:42:35.500 signed by eosio [trxs: 0, lib: 999, net: 0, cpu: 100 us, elapsed: 74 us, applying time: 188 us, latency: 2146052 ms]
info  2024-11-07T23:18:21.552 nodeos    controller.cpp:1725           replay_block_log     ] 1000 of 4983
info  2024-11-07T23:18:21.667 nodeos    controller.cpp:1725           replay_block_log     ] 1500 of 4983
info  2024-11-07T23:18:21.781 nodeos    controller.cpp:3566           log_applied          ] Received block d9216020d5998767... #2000 @ 2024-  11-07T22:50:55.500 signed by eosio [trxs: 0, lib: 1999, net: 0, cpu: 100 us, elapsed: 73 us, applying time: 188 us, latency: 1646281 ms]
info  2024-11-07T23:18:21.781 nodeos    controller.cpp:1725           replay_block_log     ] 2000 of 4983
info  2024-11-07T23:18:21.896 nodeos    controller.cpp:1725           replay_block_log     ] 2500 of 4983
info  2024-11-07T23:18:22.011 nodeos    controller.cpp:3566           log_applied          ] Received block 4cea00b8b37f995d... #3000 @ 2024-  11-07T22:59:15.500 signed by eosio [trxs: 0, lib: 2999, net: 0, cpu: 100 us, elapsed: 74 us, applying time: 188 us, latency: 1146511 ms]
info  2024-11-07T23:18:22.011 nodeos    controller.cpp:1725           replay_block_log     ] 3000 of 4983
```

After the change

```
info  2024-11-07T23:31:03.069 nodeos    controller.cpp:1725           replay_block_log     ] 500 of 5227
info  2024-11-07T23:31:03.182 nodeos    controller.cpp:1725           replay_block_log     ] 1000 of 5227
info  2024-11-07T23:31:03.295 nodeos    controller.cpp:1725           replay_block_log     ] 1500 of 5227
info  2024-11-07T23:31:03.408 nodeos    controller.cpp:1725           replay_block_log     ] 2000 of 5227
info  2024-11-07T23:31:03.521 nodeos    controller.cpp:1725           replay_block_log     ] 2500 of 5227
info  2024-11-07T23:31:03.634 nodeos    controller.cpp:1725           replay_block_log     ] 3000 of 5227
```

Resolves https://github.com/AntelopeIO/spring/issues/1017