### PR TITLE
Do not unwind validated blocks on interrupt

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4462,6 +4462,7 @@ struct controller_impl {
             } catch (const fc::exception& e) {
                if (e.code() == interrupt_exception::code_value) {
                   ilog("interrupt while applying block ${bn} : ${id}", ("bn", bsp->block_num())("id", bsp->id()));
+                  throw; // do not want to remove block from fork_db
                } else {
                   elog("exception thrown while applying block ${bn} : ${id}, previous ${p}, error: ${e}",
                        ("bn", bsp->block_num())("id", bsp->id())("p", bsp->previous())("e", e.to_detail_string()));
@@ -4478,18 +4479,20 @@ struct controller_impl {
                // Remove the block that threw and all forks built off it.
                fork_db.remove( (*ritr)->id() );
 
-               // pop all blocks from the bad fork, discarding their transactions
-               // ritr base is a forward itr to the last block successfully applied
-               auto applied_itr = ritr.base();
-               for( auto itr = applied_itr; itr != new_head_branch.end(); ++itr ) {
-                  pop_block();
-               }
-               EOS_ASSERT( !switch_fork || chain_head.id() == old_head_branch.back()->header.previous, fork_database_exception,
-                           "loss of sync between fork_db and chainbase during fork switch reversal" ); // _should_ never fail
+               if (switch_fork) {
+                  // pop all blocks from the bad fork, discarding their transactions
+                  // ritr base is a forward itr to the last block successfully applied
+                  auto applied_itr = ritr.base();
+                  for( auto itr = applied_itr; itr != new_head_branch.end(); ++itr ) {
+                     pop_block();
+                  }
+                  EOS_ASSERT( chain_head.id() == old_head_branch.back()->header.previous, fork_database_exception,
+                              "loss of sync between fork_db and chainbase during fork switch reversal" ); // _should_ never fail
 
-               // re-apply good blocks
-               for( auto ritr = old_head_branch.rbegin(); ritr != old_head_branch.rend(); ++ritr ) {
-                  apply_block( *ritr, controller::block_status::validated /* we previously validated these blocks*/, trx_lookup );
+                  // re-apply good blocks
+                  for( auto ritr = old_head_branch.rbegin(); ritr != old_head_branch.rend(); ++ritr ) {
+                     apply_block( *ritr, controller::block_status::validated /* we previously validated these blocks*/, trx_lookup );
+                  }
                }
                std::rethrow_exception(except);
             } // end if exception

--- a/tests/interrupt_trx_test.py
+++ b/tests/interrupt_trx_test.py
@@ -71,18 +71,16 @@ try:
     trans=prodNode.pushMessage(contract, action, data, opts, silentErrors=True)
     assert trans and not trans[0], "push doitforever action did not fail as expected"
 
-    prodNode.processUrllibRequest("test_control", "swap_action", {"from": "doitslow", "to": "doitforever"})
-
-    action="doitslow"
-    trans=prodNode.pushMessage(contract, action, data, opts)
-    assert trans and trans[0], "Failed to push doitslow action"
-
     prodNode.waitForProducer("defproducera")
 
     prodNode.processUrllibRequest("test_control", "swap_action",
                                   {"from":"doitslow", "to":"doitforever",
                                    "trx_priv_key":EOSIO_ACCT_PRIVATE_DEFAULT_KEY,
                                    "blk_priv_key":cluster.defproduceraAccount.activePrivateKey})
+
+    action="doitslow"
+    trans=prodNode.pushMessage(contract, action, data, opts)
+    assert trans and trans[0], "Failed to push doitslow action"
 
     assert not prodNode.waitForHeadToAdvance(3), f"prodNode did advance head after doitforever action"
 


### PR DESCRIPTION
Noticed the following warning.
```
^Cinfo  2024-11-08T13:04:40.741 nodeos    main.cpp:193                  operator()           ] appbase quit called
info  2024-11-08T13:04:40.741 nodeos    controller.cpp:4536           interrupt_transactio ] Interrupting apply block
info  2024-11-08T13:04:40.742 nodeos    controller.cpp:3820           apply_block          ] Interrupt of trx id: e6175b672d97e3f0110d70466c6c65d27f8cd2a5fc344d7efbe5a3e7c59090f5
info  2024-11-08T13:04:40.742 nodeos    controller.cpp:4464           operator()           ] interrupt while applying block 398678346 : 17c3594aee3d06f3d51e01c5afbe6c18d3216298d870cdfb9c79264cdcb6049d
warn  2024-11-08T13:04:40.754 nodeos    controller.cpp:4385           apply_blocks         ] 3030000 block_validate_exception: Block exception
attempt to pop beyond last irreversible block
    {}
    nodeos  controller.cpp:1165 pop_block
```

When interrupting a transaction via `ctrl-c`, do not attempt to unwind the branch. Also no need to attempt to discard a bad fork if not actually switching forks.

Related to #993
Resolves #1022 