### PR TITLE
regenerate jumborow.wasm when `EOSIO_COMPILE_TEST_CONTRACTS` enabled

### DIFF
--- a/unittests/contracts/jumborow/CMakeLists.txt
+++ b/unittests/contracts/jumborow/CMakeLists.txt
@@ -1,2 +1,9 @@
-configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/jumborow.wasm ${CMAKE_CURRENT_BINARY_DIR}/jumborow.wasm COPYONLY )
+if(EOSIO_COMPILE_TEST_CONTRACTS)
+   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/jumborow.wasm"
+                      COMMAND "${CDT_ROOT}/bin/eosio-wast2wasm" "${CMAKE_CURRENT_SOURCE_DIR}/jumborow.wast" -o "${CMAKE_CURRENT_BINARY_DIR}/jumborow.wasm"
+                      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/jumborow.wast")
+   add_custom_target(gen_jumborow_wasm ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/jumborow.wasm")
+else()
+   configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/jumborow.wasm ${CMAKE_CURRENT_BINARY_DIR}/jumborow.wasm COPYONLY )
+endif()
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/jumborow.abi  ${CMAKE_CURRENT_BINARY_DIR}/jumborow.abi  COPYONLY )

--- a/unittests/contracts/jumborow/jumborow.wast
+++ b/unittests/contracts/jumborow/jumborow.wast
@@ -3,6 +3,6 @@
    (memory $0 528)
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
-      (drop (call $db_store_i64 (local.get $receiver) (local.get $receiver) (local.get $receiver) (i64.const 0) (i32.const 1) (i32.const 34603007)))
+      (drop (call $db_store_i64 (get_local $receiver) (get_local $receiver) (get_local $receiver) (i64.const 0) (i32.const 1) (i32.const 34603007)))
    )
 )


### PR DESCRIPTION
When `EOSIO_COMPILE_TEST_CONTRACTS` is set, regenerate the wasm from the wast using cdt tooling.