### PR TITLE
Fix start_block to return correct return code for incomplete apply_block

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4402,6 +4402,7 @@ struct controller_impl {
             return;// nothing to do, fork_db at root
          auto [new_head_branch, old_head_branch] = fork_db.fetch_branch_from( new_head->id(), chain_head.id() );
 
+         auto new_head_branch_size = new_head_branch.size();
          bool switch_fork = !old_head_branch.empty();
          if( switch_fork ) {
             auto head_fork_comp_str =
@@ -4446,6 +4447,7 @@ struct controller_impl {
             try {
                bool applied = apply_block( bsp, bsp->is_valid() ? controller::block_status::validated
                                                                 : controller::block_status::complete, trx_lookup );
+               --new_head_branch_size;
                if (!switch_fork) { // always complete a switch fork
                   if (!applied || check_shutdown()) {
                      shutdown();
@@ -4453,7 +4455,7 @@ struct controller_impl {
                   }
                   // Break every ~500ms to allow other tasks (e.g. get_info, SHiP) opportunity to run. User expected
                   // to call apply_blocks again if this returns incomplete.
-                  if (!replaying && fc::time_point::now() - start_apply_blocks_loop > fc::milliseconds(500)) {
+                  if (!replaying && new_head_branch_size > 0 && fc::time_point::now() - start_apply_blocks_loop > fc::milliseconds(500)) {
                      result = controller::apply_blocks_result::incomplete;
                      break;
                   }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1987,7 +1987,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    auto r = chain.apply_blocks([this](const transaction_metadata_ptr& trx) { _unapplied_transactions.add_forked(trx); },
                                [this](const transaction_id_type& id) { return _unapplied_transactions.get_trx(id); });
    if (r != controller::apply_blocks_result::complete)
-      return start_block_result::failed;
+      return start_block_result::waiting_for_block;
 
    if (chain.should_terminate()) {
       app().quit();


### PR DESCRIPTION
`start_block` was returned `failed` instead of `waiting_for_block` when `apply_block` returned `incomplete` processing of blocks. This resulted in a `warn` log message and a reschedule of block production instead of just waiting for processing to complete.

Also fixed `apply_block` to not return `incomplete` for a block that takes more than 500ms to validate.

Resolves #1002 