### PR TITLE
Remove fc dynamic_rethrow_exception

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -141,10 +141,6 @@
        \
        virtual std::shared_ptr<fc::exception> dynamic_copy_exception()const\
        { return std::make_shared<TYPE>( *this ); } \
-       virtual NO_RETURN void     dynamic_rethrow_exception()const \
-       { if( code() == CODE ) throw *this;\
-         else fc::exception::dynamic_rethrow_exception(); \
-       } \
        std::optional<uint64_t> error_code; \
    };
 

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -133,7 +133,7 @@ void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chai
    auto next = [srid, this](const chain::next_function_variant<snapshot_information>& result) {
       if(std::holds_alternative<fc::exception_ptr>(result)) {
          try {
-            std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();
+            throw *std::get<fc::exception_ptr>(result);
          } catch(const fc::exception& e) {
             EOS_THROW(snapshot_execution_exception,
                      "Snapshot creation error: ${details}",

--- a/libraries/libfc/src/exception.cpp
+++ b/libraries/libfc/src/exception.cpp
@@ -7,26 +7,6 @@
 
 namespace fc
 {
-   FC_REGISTER_EXCEPTIONS( (timeout_exception)
-                           (file_not_found_exception)
-                           (parse_error_exception)
-                           (invalid_arg_exception)
-                           (invalid_operation_exception)
-                           (key_not_found_exception)
-                           (bad_cast_exception)
-                           (out_of_range_exception)
-                           (canceled_exception)
-                           (assert_exception)
-                           (eof_exception)
-                           (unknown_host_exception)
-                           (null_optional)
-                           (udt_exception)
-                           (aes_exception)
-                           (overflow_exception)
-                           (underflow_exception)
-                           (divide_by_zero_exception)
-                         )
-
    namespace detail
    {
       class exception_impl
@@ -76,12 +56,6 @@ namespace fc
    { my->_elog = fc::move(m); }
 
    std::exception_ptr unhandled_exception::get_inner_exception()const { return _inner; }
-
-   NO_RETURN void     unhandled_exception::dynamic_rethrow_exception()const
-   {
-      if( !(_inner == std::exception_ptr()) ) std::rethrow_exception( _inner );
-      else { fc::exception::dynamic_rethrow_exception(); }
-   }
 
    std::shared_ptr<exception> unhandled_exception::dynamic_copy_exception()const
    {
@@ -244,23 +218,6 @@ namespace fc
       return std::string();
    }
 
-   void NO_RETURN exception_factory::rethrow( const exception& e )const
-   {
-      auto itr = _registered_exceptions.find( e.code() );
-      if( itr != _registered_exceptions.end() )
-         itr->second->rethrow( e );
-      throw e;
-   }
-   /**
-    * Rethrows the exception restoring the proper type based upon
-    * the error code.  This is used to propagate exception types
-    * across conversions to/from JSON
-    */
-   NO_RETURN void  exception::dynamic_rethrow_exception()const
-   {
-      exception_factory::instance().rethrow( *this );
-   }
-
    exception_ptr exception::dynamic_copy_exception()const
    {
        return std::make_shared<exception>(*this);
@@ -341,12 +298,6 @@ namespace fc
    }
 
    std::exception_ptr std_exception_wrapper::get_inner_exception()const { return _inner; }
-
-   NO_RETURN void std_exception_wrapper::dynamic_rethrow_exception()const
-   {
-      if( !(_inner == std::exception_ptr()) ) std::rethrow_exception( _inner );
-      else { fc::exception::dynamic_rethrow_exception(); }
-   }
 
    std::shared_ptr<exception> std_exception_wrapper::dynamic_copy_exception()const
    {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -483,7 +483,7 @@ namespace eosio::testing {
             auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true, 0 );
             if(!no_throw && trace->except) {
                // this always throws an fc::exception, since the original exception is copied into an fc::exception
-               trace->except->dynamic_rethrow_exception();
+               throw *trace->except;
             }
             itr = unapplied_transactions.erase( itr );
             res.unapplied_transaction_traces.emplace_back( std::move(trace) );
@@ -495,7 +495,7 @@ namespace eosio::testing {
                auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
                if( !no_throw && trace->except ) {
                   // this always throws an fc::exception, since the original exception is copied into an fc::exception
-                  trace->except->dynamic_rethrow_exception();
+                  throw *trace->except;
                }
             }
          }

--- a/plugins/http_plugin/include/eosio/http_plugin/macros.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/macros.hpp
@@ -13,7 +13,7 @@
            (const chain::next_function_variant<call_result>& result) mutable {                                  \
               if (std::holds_alternative<fc::exception_ptr>(result)) {                                          \
                  try {                                                                                          \
-                    std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();                           \
+                    throw *std::get<fc::exception_ptr>(result);                                                 \
                  } catch (...) {                                                                                \
                     http_plugin::handle_exception(#api_name, #call_name, body, cb);                             \
                  }                                                                                              \
@@ -28,7 +28,7 @@
                     chain::t_or_exception<call_result> result = http_fwd();                                     \
                     if (std::holds_alternative<fc::exception_ptr>(result)) {                                    \
                        try {                                                                                    \
-                          std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();                     \
+                          throw *std::get<fc::exception_ptr>(result);                                           \
                        } catch (...) {                                                                          \
                           http_plugin::handle_exception(#api_name, #call_name, body, cb);                       \
                        }                                                                                        \
@@ -65,7 +65,7 @@
                    chain::t_or_exception<call_result> result = http_fwd();                                      \
                    if (std::holds_alternative<fc::exception_ptr>(result)) {                                     \
                       try {                                                                                     \
-                         std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();                      \
+                         throw *std::get<fc::exception_ptr>(result);                                            \
                       } catch (...) {                                                                           \
                          http_plugin::handle_exception(#api_name, #call_name, body, cb);                        \
                       }                                                                                         \

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -40,7 +40,7 @@ using namespace eosio;
       auto next = [cb=std::move(cb), body=std::move(body)](const chain::next_function_variant<call_result>& result){ \
          if (std::holds_alternative<fc::exception_ptr>(result)) {\
             try {\
-               std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();\
+               throw *std::get<fc::exception_ptr>(result);\
             } catch (...) {\
                http_plugin::handle_exception(#api_name, #call_name, body, cb);\
             }\

--- a/tests/chain_test_utils.hpp
+++ b/tests/chain_test_utils.hpp
@@ -91,13 +91,13 @@ inline auto push_input_trx(appbase::scoped_app& app, eosio::chain::controller& c
            [trx_promise](const next_function_variant<transaction_trace_ptr>& result) {
               if( std::holds_alternative<fc::exception_ptr>( result ) ) {
                  try {
-                    std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();
+                    throw *std::get<fc::exception_ptr>(result);
                  } catch(...) {
                     trx_promise->set_exception(std::current_exception());
                  }
               } else if ( std::get<chain::transaction_trace_ptr>( result )->except ) {
                  try {
-                    std::get<chain::transaction_trace_ptr>(result)->except->dynamic_rethrow_exception();
+                    throw *std::get<chain::transaction_trace_ptr>(result)->except;
                  } catch(...) {
                     trx_promise->set_exception(std::current_exception());
                  }


### PR DESCRIPTION
Remove `fc::exception::dynamic_rethrow_exception`. To work correctly `dynamic_rethrow_exception` requires registration via `FC_REGISTER_EXCEPTIONS` which was never done for any of the `eosio::chain` defined exceptions.

Since this feature never has worked as expected for `eosio::chain` defined exceptions, remove it to avoid confusion.

Resolves #980 