### PR TITLE
[1.0.4] P2P: Fix peer connections log output

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4828,11 +4828,9 @@ namespace eosio {
    // called from any thread
    void connections_manager::connection_monitor(const std::weak_ptr<connection>& from_connection) {
       size_t num_rm = 0, num_clients = 0, num_peers = 0, num_bp_peers = 0;
-      auto cleanup = [&num_peers, &num_rm, this](vector<connection_ptr>&& reconnecting, 
-                                                 vector<connection_ptr>&& removing) {
+      auto cleanup = [&num_rm, this](vector<connection_ptr>&& reconnecting, vector<connection_ptr>&& removing) {
          for( auto& c : reconnecting ) {
             if (!c->resolve_and_connect()) {
-               --num_peers;
                ++num_rm;
                removing.push_back(c);
             }
@@ -4872,6 +4870,7 @@ namespace eosio {
 
          if (!c->socket_is_open() && c->state() != connection::connection_state::connecting) {
             if (!c->incoming()) {
+               --num_peers;
                reconnecting.push_back(c);
             } else {
                --num_clients;


### PR DESCRIPTION
Only include peer connections that are currently connected in `peer connections` count in connection monitor log.

Before
`p2p client connections: 0/25, peer connections: 17/17, block producer peers: 0`
After
`p2p client connections: 0/25, peer connections: 11/17, block producer peers: 0`

Resolves #1006 