### PR TITLE
[1.0.4] Fix nodeos_startup_catchup test

### DIFF
--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -248,12 +248,8 @@ try:
         # See https://github.com/AntelopeIO/spring/issues/81 for fix to reduce the number of expected unlinkable blocks
         # Test verifies LIB is advancing, check to see that not too many unlinkable block exceptions are generated
         # while syncing up to head.
-        numUnlinkable = catchupNode.countInLog("unlinkable_block")
-        numUnlinkableAllowed = 500
-        Print(f"Node{catchupNodeNum} has {numUnlinkable} unlinkable_block in {catchupNode.data_dir}")
-        if numUnlinkable > numUnlinkableAllowed:
-            errorExit(f"Node{catchupNodeNum} has {numUnlinkable} which is more than the configured "
-                      f"allowed {numUnlinkableAllowed} unlinkable blocks: {catchupNode.data_dir}.")
+        if not catchupNode.verifyUnlinkableBlocksExpected(sync_fetch_span):
+            errorExit(f"unlinkable blocks are not expected") # details already logged in verifyUnlinkableBlocksExpected
 
     testSuccessful=True
 


### PR DESCRIPTION
The test is broken in `Rel 1.0.3` and flaky in `main`. The counts the number of `unlinkable_block` occurrences in logging files and make sure it is not greater than `500`.

But in `Rel 1.0.3`, `unlinkable_block` (part of `unlinkable_block_exception`) shows up 3 times per unlinkable block, for example:
```
warn  2024-11-14T13:48:06.038 nodeos    controller.cpp:4334           push_block           ] 3030001 unlinkable_block_exception: Unlinkable block
info  2024-11-14T13:48:06.038 nodeos    producer_plugin.cpp:938       operator()           ] Exception on block 130: 3030001 unlinkable_block_exception: Unlinkable block
info  2024-11-14T13:48:06.038 nodeos    net_plugin.cpp:3870           process_signed_block ] unlinkable_block_exception connection - 1: #130 1d74c43582d10251...: Unlinkable block (3030001)
```

This PR searches for `unlinkable_block_exception connection - \d+: #(\d+)`, extracts the unlinkable block number, and verifies that
1. unlinkable blocks are consecutive
2. the number of unlinkable blocks is less than sync fetch span

Resolves https://github.com/AntelopeIO/spring/issues/1015