### PR TITLE
Do not reject future blocks on speculative nodes

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -476,7 +476,7 @@ namespace eosio::chain {
       void replace_account_keys( name account, name permission, const public_key_type& key );
 
       void set_producer_node(bool is_producer_node);
-      bool is_producer_node()const;
+      bool is_producer_node()const; // thread safe, set at program initialization
 
       void set_db_read_only_mode();
       void unset_db_read_only_mode();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3716,8 +3716,10 @@ namespace eosio {
          bool unlinkable = false;
          sync_manager::closing_mode close_mode = sync_manager::closing_mode::immediately;
          try {
-            EOS_ASSERT(ptr->timestamp < (fc::time_point::now() + fc::seconds(7)), block_from_the_future,
-                       "received a block from the future, rejecting it: ${id}", ("id", id));
+            if (cc.is_producer_node()) {
+               EOS_ASSERT(ptr->timestamp < (fc::time_point::now() + fc::seconds(7)), block_from_the_future,
+                          "received a block from the future, rejecting it: ${id}", ("id", id));
+            }
             // this will return empty optional<block_handle> if block is not linkable
             controller::accepted_block_result abh = cc.accept_block( id, ptr );
             best_head = abh.is_new_best_head;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1963,8 +1963,10 @@ producer_plugin::get_unapplied_transactions_result producer_plugin::get_unapplie
 
 block_timestamp_type producer_plugin_impl::calculate_pending_block_time() const {
    const chain::controller& chain = chain_plug->chain();
-   const fc::time_point     now   = fc::time_point::now();
-   const fc::time_point     base  = std::max<fc::time_point>(now, chain.head().block_time());
+   // on speculative nodes, always use next block time. On producers, honor current clock time
+   const fc::time_point base  = _producers.empty()
+                                   ? chain.head().block_time()
+                                   : std::max<fc::time_point>(fc::time_point::now(), chain.head().block_time());
    return block_timestamp_type(base).next();
 }
 


### PR DESCRIPTION
On speculative, non-block-producer, nodes do not reject blocks from the future. This allows a speculative node to have a clock skew without it interfering with maintaining synchronization. Before, this change a clock skew of 7 seconds would cause a speculative node to reject a block. 

Note block producers still need to keep their clocks synchronized so they produce on time. Block producers will continue to reject blocks with timestamps >= 7 seconds in the future.

Resolves #239 