### PR TITLE
[1.0.4] P2P: Fix sync stuck corner case

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3992,6 +3992,7 @@ namespace eosio {
    }
 
    void net_plugin_impl::on_accepted_block( const signed_block_ptr& block, const block_id_type&) {
+      update_chain_info();
       sync_master->send_handshakes_if_synced(fc::time_point::now() - block->timestamp);
       if (const auto* pending_producers = chain_plug->chain().pending_producers()) {
          on_pending_schedule(*pending_producers);


### PR DESCRIPTION
Update `chain_info` on `accepted_block` signal since `chain_head` has changed. The sync logic needs up to date info of the state of the node. This normally doesn't cause an issue because under normal conditions the node would soon receive a `accepted_block_header` or `irreversible_block` signal which would update the `net_plugin` state.

Resolves #998 