### PR TITLE
Interrupt block validation on new best head

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2038,21 +2038,6 @@ struct controller_impl {
       // Furthermore, fork_db.root()->block_num() <= lib_num.
       // Also, even though blog.head() may still be nullptr, blog.first_block_num() is guaranteed to be lib_num + 1.
 
-      auto finish_init = [&](auto& fork_db) {
-         if( read_mode != db_read_mode::IRREVERSIBLE ) {
-            auto pending_head = fork_db.head();
-            if ( pending_head && pending_head->id() != chain_head.id() ) {
-               // chain_head equal to root means that read_mode was changed from irreversible mode to head/speculative
-               bool chain_head_is_root = chain_head.id() == fork_db.root()->id();
-               if (chain_head_is_root) {
-                  ilog( "read_mode has changed from irreversible" );
-               }
-            }
-         }
-      };
-
-      fork_db_.apply<void>(finish_init);
-
       // At Leap startup, we want to provide to our local finalizers the correct safety information
       // to use if they don't already have one.
       // If we start at a block prior to the IF transition, that information will be provided when

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4232,11 +4232,11 @@ struct controller_impl {
          assert(!verify_qc_future.valid());
       }
 
-      bool best_head = fork_db.add(bsp, ignore_duplicate_t::yes);
+      fork_db_add_t add_result = fork_db.add(bsp, ignore_duplicate_t::yes);
       if constexpr (is_proper_savanna_block)
          vote_processor.notify_new_block(async_aggregation);
 
-      return controller::accepted_block_result{best_head, block_handle{std::move(bsp)}};
+      return controller::accepted_block_result{add_result, block_handle{std::move(bsp)}};
    }
 
    // thread safe, expected to be called from thread other than the main thread

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4538,7 +4538,7 @@ struct controller_impl {
       return applied_trxs;
    }
 
-   void interrupt_transaction() {
+   void interrupt_apply_block_transaction() {
       // Only interrupt transaction if applying a block. Speculative trxs already have a deadline set so they
       // have limited run time already. This is to allow killing a long-running transaction in a block being
       // validated.
@@ -5308,8 +5308,8 @@ deque<transaction_metadata_ptr> controller::abort_block() {
    return my->abort_block();
 }
 
-void controller::interrupt_transaction() {
-   my->interrupt_transaction();
+void controller::interrupt_apply_block_transaction() {
+   my->interrupt_apply_block_transaction();
 }
 
 boost::asio::io_context& controller::get_thread_pool() {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -208,8 +208,8 @@ namespace eosio::chain {
           */
          deque<transaction_metadata_ptr> abort_block();
 
-         /// Expected to be called from signal handler
-         void interrupt_transaction();
+         /// Expected to be called from signal handler, or producer_plugin
+         void interrupt_apply_block_transaction();
 
        /**
         *

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -96,6 +96,7 @@ namespace eosio::chain {
    using resource_limits::resource_limits_manager;
    using apply_handler = std::function<void(apply_context&)>;
 
+   enum class fork_db_add_t;
    using forked_callback_t = std::function<void(const transaction_metadata_ptr&)>;
 
    // lookup transaction_metadata via supplied function to avoid re-creation
@@ -235,7 +236,7 @@ namespace eosio::chain {
          void set_async_aggregation(async_t val);
 
          struct accepted_block_result {
-            const bool is_new_best_head = false; // true if new best head
+            const fork_db_add_t add_result;
             std::optional<block_handle> block;   // empty optional if block is unlinkable
          };
          // thread-safe

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -12,7 +12,13 @@ namespace eosio::chain {
    using block_branch_t = std::vector<signed_block_ptr>;
    enum class ignore_duplicate_t { no, yes };
    enum class include_root_t { no, yes };
-   enum class fork_db_add_t { failure, duplicate, added, appended_to_head, fork_switch };
+   enum class fork_db_add_t {
+      failure,            // add failed
+      duplicate,          // already added and ignore_duplicate=true
+      added,              // inserted into an existing branch or started a new branch, but not best branch
+      appended_to_head,   // new best head of current best branch; no fork switch
+      fork_switch         // new best head of new branch, fork switch to new branch
+   };
 
    // Used for logging of comparison values used for best fork determination
    std::string log_fork_comparison(const block_state& bs);
@@ -68,10 +74,7 @@ namespace eosio::chain {
       /**
        *  Add block state to fork database.
        *  Must link to existing block in fork database or the root.
-       *  @returns duplicate - already added and ignore_duplicate=true
-       *           added - inserted into an existing branch or started a new branch, not best branch
-       *           appended_to_head - new best head of current best branch
-       *           fork_switch - new best head of new branch, fork switch to new branch
+       *  @returns fork_db_add_t - result of the add
        *  @throws unlinkable_block_exception - unlinkable to any branch
        *  @throws fork_database_exception - no root, n is nullptr, protocol feature error, duplicate when ignore_duplicate=false
        */

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -12,7 +12,7 @@ namespace eosio::chain {
    using block_branch_t = std::vector<signed_block_ptr>;
    enum class ignore_duplicate_t { no, yes };
    enum class include_root_t { no, yes };
-   enum class fork_db_add_t { duplicate, added, appended_to_head, fork_switch };
+   enum class fork_db_add_t { failure, duplicate, added, appended_to_head, fork_switch };
 
    // Used for logging of comparison values used for best fork determination
    std::string log_fork_comparison(const block_state& bs);
@@ -314,4 +314,4 @@ namespace eosio::chain {
 } /// eosio::chain
 
 FC_REFLECT_ENUM( eosio::chain::fork_db_add_t,
-                 (duplicate)(added)(appended_to_head)(fork_switch) )
+                 (failure)(duplicate)(added)(appended_to_head)(fork_switch) )

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -218,6 +218,7 @@ namespace eosio::testing {
          // producer become inactive
          void                 produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(const fc::microseconds target_elapsed_time = fc::microseconds());
          void                 push_block(const signed_block_ptr& b);
+         void                 apply_blocks();
 
          /**
           * These transaction IDs represent transactions available in the head chain state as scheduled

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -424,6 +424,7 @@ namespace eosio::testing {
       open(std::move(pfs), snapshot_chain_id, [&snapshot,&control=this->control]() {
          control->startup( [](){}, []() { return false; }, snapshot );
       });
+      apply_blocks();
    }
 
    void base_tester::open( protocol_feature_set&& pfs, const genesis_state& genesis, call_startup_t call_startup ) {
@@ -431,6 +432,7 @@ namespace eosio::testing {
          open(std::move(pfs), genesis.compute_chain_id(), [&genesis,&control=this->control]() {
             control->startup( [](){}, []() { return false; }, genesis );
          });
+         apply_blocks();
       } else {
          open(std::move(pfs), genesis.compute_chain_id(), nullptr);
       }
@@ -440,6 +442,7 @@ namespace eosio::testing {
       open(std::move(pfs), expected_chain_id, [&control=this->control]() {
          control->startup( [](){}, []() { return false; } );
       });
+      apply_blocks();
    }
 
    void base_tester::push_block(const signed_block_ptr& b) {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -340,8 +340,9 @@ namespace eosio::testing {
       case block_signal::accepted_block:
          // should get accepted_block signal after accepted_block_header signal
          // or after accepted_block (on fork switch, accepted block signaled when block re-applied)
-         return present && (itr->second == block_signal::accepted_block_header ||
-                            itr->second == block_signal::accepted_block);
+         // or first thing on restart if applying out of the forkdb
+         return !present || (present && (itr->second == block_signal::accepted_block_header ||
+                                         itr->second == block_signal::accepted_block));
 
       case block_signal::irreversible_block:
          // can be signaled on restart as the first thing since other signals happened before shutdown
@@ -458,6 +459,11 @@ namespace eosio::testing {
          last_produced_block[b->producer] = block_id;
       }
       _check_for_vote_if_needed(*control, bh);
+   }
+
+   void base_tester::apply_blocks() {
+      while (control->apply_blocks( {}, {} ) == controller::apply_blocks_result::incomplete)
+         ;
    }
 
    signed_block_ptr base_tester::_produce_block( fc::microseconds skip_time, bool skip_pending_trxs ) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1133,7 +1133,10 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 void chain_plugin_impl::plugin_startup()
 { try {
    try {
-      auto shutdown = [](){ return app().quit(); };
+      auto shutdown = []() {
+         dlog("controller shutdown, quitting...");
+         return app().quit();
+      };
       auto check_shutdown = [](){ return app().is_quiting(); };
       if (snapshot_path)
          chain->startup(shutdown, check_shutdown, std::make_shared<threaded_snapshot_reader>(*snapshot_path));

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -94,6 +94,9 @@ namespace eosio {
         void register_increment_failed_p2p_connections(std::function<void()>&&);
         void register_increment_dropped_trxs(std::function<void()>&&);
 
+        // for testing
+        void broadcast_block(const signed_block_ptr& b, const block_id_type& id);
+
       private:
         std::shared_ptr<class net_plugin_impl> my;
    };

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4459,6 +4459,11 @@ namespace eosio {
       my->increment_dropped_trxs = std::move(fun);
    }
 
+   void net_plugin::broadcast_block(const signed_block_ptr& b, const block_id_type& id) {
+      fc_dlog(logger, "broadcasting block ${n} ${id}", ("n", b->block_num())("id", id));
+      my->dispatcher.bcast_block(b, id);
+   }
+
    //----------------------------------------------------------------------------
 
    size_t connections_manager::number_connections() const {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -9,6 +9,7 @@
 #include <eosio/chain/plugin_interface.hpp>
 #include <eosio/chain/thread_utils.hpp>
 #include <eosio/producer_plugin/producer_plugin.hpp>
+#include <eosio/chain/fork_database.hpp>
 
 #include <fc/bitutil.hpp>
 #include <fc/network/message_buffer.hpp>
@@ -3722,7 +3723,7 @@ namespace eosio {
             }
             // this will return empty optional<block_handle> if block is not linkable
             controller::accepted_block_result abh = cc.accept_block( id, ptr );
-            best_head = abh.is_new_best_head;
+            best_head = abh.add_result == fork_db_add_t::appended_to_head || abh.add_result == fork_db_add_t::fork_switch;
             obh = std::move(abh.block);
             unlinkable = !obh;
             close_mode = sync_manager::closing_mode::handshake;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4510,7 +4510,13 @@ namespace eosio {
          resolve_and_connect(peer, p2p_address);
       }
       if (!peers.empty()) {
-         // in case there are blocks in the fork database ready to process
+         // It is possible that the node was shutdown with blocks to process in the fork database. For example, if
+         // it was syncing and had processed blocks into the fork database but not yet applied them.
+         // If the node was shutdown via terminate-at-block, the current expectation is that the node can be restarted
+         // to examine the state at which it was shutdown. For now, we will only process these blocks if there are
+         // peers configured. This is a bit of a hack for Spring 1.0.0 until we can add a proper
+         // pause-at-block (issue #570) which could be used to explicitly request a node to not process beyond
+         // a specified block.
          my_impl->process_blocks();
       }
    }

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -141,7 +141,7 @@ public:
    void log_failed_transaction(const transaction_id_type& trx_id, const chain::packed_transaction_ptr& packed_trx_ptr, const char* reason) const;
 
    // thread-safe, called when a new block is received
-   void received_block(uint32_t block_num);
+   void received_block(uint32_t block_num, chain::fork_db_add_t fork_db_add_result);
 
    const std::set<account_name>& producer_accounts() const;
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -9,6 +9,7 @@
 #include <eosio/chain/subjective_billing.hpp>
 #include <eosio/chain/thread_utils.hpp>
 #include <eosio/chain/unapplied_transaction_queue.hpp>
+#include <eosio/chain/fork_database.hpp>
 #include <eosio/resource_monitor_plugin/resource_monitor_plugin.hpp>
 
 #include <fc/io/json.hpp>
@@ -2947,8 +2948,12 @@ void producer_plugin_impl::produce_block() {
    _time_tracker.clear();
 }
 
-void producer_plugin::received_block(uint32_t block_num) {
+void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fork_db_add_result) {
    my->_received_block = block_num;
+   if (fork_db_add_result == fork_db_add_t::fork_switch) {
+      fc_ilog(_log, "new best fork received");
+      my->chain_plug->chain().interrupt_apply_block_transaction();
+   }
 }
 
 void producer_plugin::log_failed_transaction(const transaction_id_type&    trx_id,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1633,7 +1633,10 @@ void producer_plugin_impl::plugin_startup() {
          app().quit();
       } );
 
-      schedule_production_loop();
+      // start production after net_plugin has started in case there are poison blocks in the fork database
+      app().executor().post(priority::high, exec_queue::read_write, [this]() {
+         schedule_production_loop();
+      });
 
       dlog("producer plugin:  plugin_startup() end");
    }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -557,9 +557,8 @@ private:
 class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin_impl> {
 public:
    producer_plugin_impl()
-      : _timer(app().make_timer<boost::asio::deadline_timer>())
-      , _transaction_ack_channel(app().get_channel<compat::channels::transaction_ack>())
-      , _ro_timer(app().make_timer<boost::asio::deadline_timer>()) {}
+      : _transaction_ack_channel(app().get_channel<compat::channels::transaction_ack>())
+   {}
 
    void     schedule_production_loop();
    void     schedule_maybe_produce_block(bool exhausted);
@@ -683,11 +682,13 @@ public:
    bool                                  _production_enabled = false;
    bool                                  _pause_production   = false;
 
+   eosio::chain::named_thread_pool<struct prod>      _timer_thread;
+   boost::asio::deadline_timer                       _timer{_timer_thread.get_executor()};
+
    using signature_provider_type = signature_provider_plugin::signature_provider_type;
    std::map<chain::public_key_type, signature_provider_type> _signature_providers;
    chain::bls_pub_priv_key_map_t                     _finalizer_keys; // public, private
    std::set<chain::account_name>                     _producers;
-   boost::asio::deadline_timer                       _timer;
    block_timing_util::producer_watermarks            _producer_watermarks;
    pending_block_mode                                _pending_block_mode = pending_block_mode::speculating;
    unapplied_transaction_queue                       _unapplied_transactions;
@@ -800,7 +801,7 @@ public:
                                                                    // use atomic for simplicity and performance
    fc::time_point                 _ro_read_window_start_time;
    fc::time_point                 _ro_window_deadline;    // only modified on app thread, read-window deadline or write-window deadline
-   boost::asio::deadline_timer    _ro_timer;              // only accessible from the main thread
+   boost::asio::deadline_timer    _ro_timer{_timer_thread.get_executor()}; // only accessible from the main thread
    fc::microseconds               _ro_max_trx_time_us{0}; // calculated during option initialization
    ro_trx_queue_t                 _ro_exhausted_trx_queue;
    alignas(hardware_destructive_interference_sz)
@@ -1612,6 +1613,11 @@ void producer_plugin_impl::plugin_startup() {
          start_write_window();
       }
 
+      _timer_thread.start( 1, []( const fc::exception& e ) {
+         elog("Exception in producer timer thread, exiting: ${e}", ("e", e.to_detail_string()));
+         app().quit();
+      } );
+
       schedule_production_loop();
 
       dlog("producer plugin:  plugin_startup() end");
@@ -1624,6 +1630,7 @@ void producer_plugin::plugin_startup() {
 }
 
 void producer_plugin_impl::plugin_shutdown() {
+   _timer_thread.stop();
    _ro_thread_pool.stop();
    // unapplied transaction queue holds lambdas that reference plugins
    _unapplied_transactions.clear();
@@ -2742,13 +2749,13 @@ void producer_plugin_impl::schedule_production_loop() {
       _timer.expires_from_now(boost::posix_time::microseconds(config::block_interval_us / 10));
 
       // we failed to start a block, so try again later?
-      _timer.async_wait(
-         app().executor().wrap(priority::high, exec_queue::read_write,
-                               [this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
-                                  if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
-                                     schedule_production_loop();
-                                  }
-                               }));
+      _timer.async_wait([this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
+         if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
+            app().executor().post(priority::high, exec_queue::read_write, [this]() {
+               schedule_production_loop();
+            });
+         }
+      });
    } else if (result == start_block_result::waiting_for_block) {
       if (is_configured_producer() && !production_disabled_by_policy()) {
          chain::controller& chain = chain_plug->chain();
@@ -2808,16 +2815,17 @@ void producer_plugin_impl::schedule_maybe_produce_block(bool exhausted) {
               ("num", chain.head().block_num() + 1)("desc", block_is_exhausted() ? "Exhausted" : "Deadline exceeded"));
    }
 
-   _timer.async_wait(app().executor().wrap(priority::high, exec_queue::read_write,
-      [&chain, this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
-         if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
+   _timer.async_wait([&chain, this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
+      if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
+         app().executor().post(priority::high, exec_queue::read_write, [&chain, this]() {
             // pending_block_state expected, but can't assert inside async_wait
             auto block_num = chain.is_building_block() ? chain.head().block_num() + 1 : 0;
             fc_dlog(_log, "Produce block timer for ${num} running at ${time}", ("num", block_num)("time", fc::time_point::now()));
             auto res = maybe_produce_block();
             fc_dlog(_log, "Producing Block #${num} returned: ${res}", ("num", block_num)("res", res));
-         }
-      }));
+         });
+      }
+   });
 }
 
 void producer_plugin_impl::schedule_delayed_production_loop(const std::weak_ptr<producer_plugin_impl>& weak_this,
@@ -2826,12 +2834,13 @@ void producer_plugin_impl::schedule_delayed_production_loop(const std::weak_ptr<
       fc_dlog(_log, "Scheduling Speculative/Production Change at ${time}", ("time", wake_up_time));
       static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
       _timer.expires_at(epoch + boost::posix_time::microseconds(wake_up_time->time_since_epoch().count()));
-      _timer.async_wait(app().executor().wrap(priority::high, exec_queue::read_write,
-         [this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
-            if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
+      _timer.async_wait([this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
+         if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
+            app().executor().post(priority::high, exec_queue::read_write, [this]() {
                schedule_production_loop();
-            }
-         }));
+            });
+         }
+      });
    } else {
       fc_dlog(_log, "Not Scheduling Speculative/Production, no local producers had valid wake up times");
    }
@@ -2971,13 +2980,14 @@ void producer_plugin_impl::start_write_window() {
    _ro_window_deadline = now + _ro_write_window_time_us; // not allowed on block producers, so no need to limit to block deadline
    auto expire_time = boost::posix_time::microseconds(_ro_write_window_time_us.count());
    _ro_timer.expires_from_now(expire_time);
-   _ro_timer.async_wait(app().executor().wrap( // stay on app thread
-      priority::high, exec_queue::read_write, // placed in read_write so only called from main thread
-      [this](const boost::system::error_code& ec) {
-         if (ec != boost::asio::error::operation_aborted) {
-            switch_to_read_window();
-         }
-      }));
+   _ro_timer.async_wait([this](const boost::system::error_code& ec) {
+      if (ec != boost::asio::error::operation_aborted) {
+         app().executor().post(priority::high, exec_queue::read_write, // placed in read_write so only called from main thread
+                               [this]() {
+                                  switch_to_read_window();
+                               });
+      }
+   });
 }
 
 // Called only from app thread
@@ -3017,8 +3027,8 @@ void producer_plugin_impl::switch_to_read_window() {
    auto expire_time = boost::posix_time::microseconds(_ro_read_window_time_us.count());
    _ro_timer.expires_from_now(expire_time);
    // Needs to be on read_only because that is what is being processed until switch_to_write_window().
-   _ro_timer.async_wait(
-      app().executor().wrap(priority::high, exec_queue::read_only, [this](const boost::system::error_code& ec) {
+   _ro_timer.async_wait([this](const boost::system::error_code& ec) {
+      app().executor().post(priority::high, exec_queue::read_only, [this, ec]() {
          if (ec != boost::asio::error::operation_aborted) {
             // use future to make sure all read-only tasks finished before switching to write window
             for (auto& task : _ro_exec_tasks_fut) {
@@ -3030,7 +3040,8 @@ void producer_plugin_impl::switch_to_read_window() {
          } else {
             _ro_exec_tasks_fut.clear();
          }
-      }));
+      });
+   });
 }
 
 // Called from a read only thread. Run in parallel with app and other read only threads

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -3000,6 +3000,8 @@ void producer_plugin_impl::produce_block() {
 
 void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fork_db_add_result) {
    my->_received_block = block_num;
+   // fork_db_add_t::fork_switch means head block of best fork (different from the current branch) is received.
+   // Since a better fork is available, interrupt current block validation and allow a fork switch to the better branch.
    if (fork_db_add_result == fork_db_add_t::fork_switch) {
       fc_ilog(_log, "new best fork received");
       my->chain_plug->chain().interrupt_apply_block_transaction();

--- a/plugins/test_control_plugin/CMakeLists.txt
+++ b/plugins/test_control_plugin/CMakeLists.txt
@@ -4,6 +4,6 @@ add_library( test_control_plugin
              test_control_plugin.cpp
              ${HEADERS} )
 
-target_link_libraries( test_control_plugin producer_plugin chain_plugin http_client_plugin appbase eosio_chain )
+target_link_libraries( test_control_plugin producer_plugin chain_plugin net_plugin http_client_plugin appbase eosio_chain )
 target_include_directories( test_control_plugin
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )

--- a/plugins/test_control_plugin/include/eosio/test_control_plugin/test_control_plugin.hpp
+++ b/plugins/test_control_plugin/include/eosio/test_control_plugin/test_control_plugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <eosio/chain/application.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/net_plugin/net_plugin.hpp>
 #include <fc/variant.hpp>
 #include <memory>
 
@@ -53,7 +54,7 @@ private:
 
 class test_control_plugin : public plugin<test_control_plugin> {
 public:
-   APPBASE_PLUGIN_REQUIRES((chain_plugin))
+   APPBASE_PLUGIN_REQUIRES((chain_plugin)(net_plugin))
 
    test_control_plugin();
    test_control_plugin(const test_control_plugin&) = delete;

--- a/plugins/test_control_plugin/include/eosio/test_control_plugin/test_control_plugin.hpp
+++ b/plugins/test_control_plugin/include/eosio/test_control_plugin/test_control_plugin.hpp
@@ -41,6 +41,7 @@ class read_write {
          chain::name to;
          fc::crypto::private_key trx_priv_key;
          fc::crypto::private_key blk_priv_key;
+         bool shutdown = false; // shutdown node before next block
       };
       empty swap_action(const swap_action_params& params) const;
 
@@ -79,4 +80,4 @@ private:
 FC_REFLECT(eosio::test_control_apis::empty, )
 FC_REFLECT(eosio::test_control_apis::read_write::kill_node_on_producer_params, (producer)(where_in_sequence)(based_on_lib) )
 FC_REFLECT(eosio::test_control_apis::read_write::throw_on_params, (signal)(exception) )
-FC_REFLECT(eosio::test_control_apis::read_write::swap_action_params, (from)(to)(trx_priv_key)(blk_priv_key) )
+FC_REFLECT(eosio::test_control_apis::read_write::swap_action_params, (from)(to)(trx_priv_key)(blk_priv_key)(shutdown) )

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -1,4 +1,5 @@
 #include <eosio/test_control_plugin/test_control_plugin.hpp>
+#include <eosio/chain/fork_database.hpp>
 
 namespace eosio {
 
@@ -160,9 +161,9 @@ void test_control_plugin_impl::swap_action_in_block(const chain::signed_block_pt
    copy_b->producer_signature = _swap_on_options.blk_priv_key.sign(copy_b->calculate_id());
 
    // will be processed on the next start_block if is_new_best_head
-   const auto&[is_new_best_head, bh] = _chain.accept_block(copy_b->calculate_id(), copy_b);
-   ilog("Swapped action ${f} to ${t}, is_new_best_head ${bh}, block ${bn}",
-        ("f", _swap_on_options.from)("t", _swap_on_options.to)("bh", is_new_best_head)("bn", bh ? bh->block_num() : 0));
+   const auto&[add_result, bh] = _chain.accept_block(copy_b->calculate_id(), copy_b);
+   ilog("Swapped action ${f} to ${t}, add_result ${a}, block ${bn}",
+        ("f", _swap_on_options.from)("t", _swap_on_options.to)("a", add_result)("bn", bh ? bh->block_num() : 0));
    reset_swap_action();
 }
 

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -164,6 +164,7 @@ void test_control_plugin_impl::swap_action_in_block(const chain::signed_block_pt
    const auto&[add_result, bh] = _chain.accept_block(copy_b->calculate_id(), copy_b);
    ilog("Swapped action ${f} to ${t}, add_result ${a}, block ${bn}",
         ("f", _swap_on_options.from)("t", _swap_on_options.to)("a", add_result)("bn", bh ? bh->block_num() : 0));
+   app().find_plugin<net_plugin>()->broadcast_block(copy_b, copy_b->calculate_id());
    reset_swap_action();
 }
 

--- a/plugins/test_control_plugin/test_control_plugin.cpp
+++ b/plugins/test_control_plugin/test_control_plugin.cpp
@@ -165,6 +165,8 @@ void test_control_plugin_impl::swap_action_in_block(const chain::signed_block_pt
    ilog("Swapped action ${f} to ${t}, add_result ${a}, block ${bn}",
         ("f", _swap_on_options.from)("t", _swap_on_options.to)("a", add_result)("bn", bh ? bh->block_num() : 0));
    app().find_plugin<net_plugin>()->broadcast_block(copy_b, copy_b->calculate_id());
+   if (_swap_on_options.shutdown)
+      app().quit();
    reset_swap_action();
 }
 

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char** argv)
       controller& chain = app->get_plugin<chain_plugin>().chain();
       app->set_stop_executor_cb([&app, &chain]() {
          ilog("appbase quit called");
-         chain.interrupt_transaction();
+         chain.interrupt_apply_block_transaction();
          app->get_io_context().stop();
       });
       if (auto resmon_plugin = app->find_plugin<resource_monitor_plugin>()) {

--- a/tests/interrupt_trx_test.py
+++ b/tests/interrupt_trx_test.py
@@ -9,8 +9,8 @@ from TestHarness.TestHelper import AppArgs
 ###############################################################
 # interrupt_trx_test
 #
-# Test applying a block with an infinite trx and verify SIGTERM kill
-# interrupts the transaction and aborts the block.
+# Verify an infinite trx in a block is auto recovered when a new
+# best head is received.
 # 
 ###############################################################
 
@@ -32,18 +32,19 @@ testSuccessful = False
 try:
     TestHelper.printSystemInfo("BEGIN")
     assert cluster.launch(
-        pnodes=1,
-        prodCount=1,
-        totalProducers=1,
-        totalNodes=2,
+        pnodes=2,
+        prodCount=2,
+        totalProducers=2,
+        totalNodes=3,
         loadSystemContract=False,
         activateIF=True,
         extraNodeosArgs="--plugin eosio::test_control_api_plugin")
 
     prodNode = cluster.getNode(0)
-    validationNode = cluster.getNode(1)
+    prodNode2 = cluster.getNode(1)
+    validationNode = cluster.getNode(2)
 
-    # Create a transaction to create an account
+    # load payloadless contract
     Utils.Print("create a new account payloadless from the producer node")
     payloadlessAcc = Account("payloadless")
     payloadlessAcc.ownerPublicKey = EOSIO_ACCT_PUBLIC_DEFAULT_KEY
@@ -56,6 +57,7 @@ try:
     Utils.Print("Publish payloadless contract")
     trans = prodNode.publishContract(payloadlessAcc, contractDir, wasmFile, abiFile, waitForTransBlock=True)
 
+    # test normal trx
     contract="payloadless"
     action="doit"
     data="{}"
@@ -63,16 +65,41 @@ try:
     trans=prodNode.pushMessage(contract, action, data, opts)
     assert trans and trans[0], "Failed to push doit action"
 
+    # test trx that will be replaced later
     action="doitslow"
     trans=prodNode.pushMessage(contract, action, data, opts)
     assert trans and trans[0], "Failed to push doitslow action"
 
+    # infinite trx, will fail since it will hit trx exec limit
     action="doitforever"
     trans=prodNode.pushMessage(contract, action, data, opts, silentErrors=True)
     assert trans and not trans[0], "push doitforever action did not fail as expected"
 
+    # swap out doitslow action in block with doitforever action
+    prodNode.waitForProducer("defproducerb")
     prodNode.waitForProducer("defproducera")
 
+    prodNode.processUrllibRequest("test_control", "swap_action",
+                                  {"from":"doitslow", "to":"doitforever",
+                                   "trx_priv_key":EOSIO_ACCT_PRIVATE_DEFAULT_KEY,
+                                   "blk_priv_key":cluster.defproduceraAccount.activePrivateKey,
+                                   "shutdown":"true"})
+
+    # trx that will be swapped out for doitforever
+    action="doitslow"
+    trans=prodNode.pushMessage(contract, action, data, opts)
+    assert trans and trans[0], "Failed to push doitslow action"
+
+    assert prodNode.waitForNodeToExit(5), f"prodNode did not exit after doitforever action and shutdown"
+    assert not prodNode.verifyAlive(), f"prodNode did not exit after doitforever action"
+
+    # relaunch and verify auto recovery
+    prodNode.relaunch(timeout=365) # large timeout to wait on other producer
+
+    prodNode.waitForProducer("defproducerb")
+    prodNode.waitForProducer("defproducera")
+
+    # verify auto recovery without any restart
     prodNode.processUrllibRequest("test_control", "swap_action",
                                   {"from":"doitslow", "to":"doitforever",
                                    "trx_priv_key":EOSIO_ACCT_PRIVATE_DEFAULT_KEY,
@@ -82,11 +109,8 @@ try:
     trans=prodNode.pushMessage(contract, action, data, opts)
     assert trans and trans[0], "Failed to push doitslow action"
 
-    assert not prodNode.waitForHeadToAdvance(3), f"prodNode did advance head after doitforever action"
-
-    prodNode.interruptAndVerifyExitStatus()
-
-    assert not prodNode.verifyAlive(), "prodNode did not exit from SIGINT"
+    assert prodNode.waitForLibToAdvance(), "prodNode did not advance lib after doitforever action"
+    assert prodNode2.waitForLibToAdvance(), "prodNode2 did not advance lib after doitforever action"
 
     testSuccessful = True
 finally:

--- a/tests/trx_finality_status_forked_test.py
+++ b/tests/trx_finality_status_forked_test.py
@@ -212,6 +212,9 @@ try:
             info = prodD.getInfo()
             retStatus = prodD.getTransactionStatus(transId)
             state = getState(retStatus)
+            if state == forkedOutState:
+                prodD.waitForNextBlock()
+                continue
             blockNum = getBlockNum(retStatus) + 2 # Add 2 to give time to move from locally applied to in-block
             if (state == inBlockState or state == irreversibleState) or ( info['head_block_producer'] == 'defproducerd' and info['last_irreversible_block_num'] > blockNum ):
                 break

--- a/unittests/blocks_log_replay_tests.cpp
+++ b/unittests/blocks_log_replay_tests.cpp
@@ -87,6 +87,7 @@ struct blog_replay_fixture {
       // Resume replay
       eosio::testing::tester replay_chain_1(copied_config_1, *genesis, call_startup_t::no);
       replay_chain_1.control->startup( [](){}, []()->bool{ return false; } );
+      replay_chain_1.apply_blocks();
 
       // Make sure new chain contain the account created by original chain
       BOOST_REQUIRE_NO_THROW(replay_chain_1.get_account("replay1"_n));
@@ -97,7 +98,6 @@ struct blog_replay_fixture {
       // with last_irreversible_block_num and last_head_block_num
       BOOST_CHECK(replay_chain_1.last_irreversible_block_num() == last_irreversible_block_num);
       if (!remove_fork_db) {
-         replay_chain_1.apply_blocks();
          BOOST_CHECK(replay_chain_1.head().block_num() == last_head_block_num);
       } else {
          BOOST_CHECK(replay_chain_1.head().block_num() == last_irreversible_block_num);
@@ -129,7 +129,6 @@ BOOST_FIXTURE_TEST_CASE(replay_through, blog_replay_fixture) try {
    // Make sure replayed irreversible_block_num and head_block_num match
    // with last_irreversible_block_num and last_head_block_num
    BOOST_CHECK(replay_chain.last_irreversible_block_num() == last_irreversible_block_num);
-   replay_chain.apply_blocks();
    BOOST_CHECK(replay_chain.head().block_num() == last_head_block_num);
 } FC_LOG_AND_RETHROW()
 

--- a/unittests/blocks_log_replay_tests.cpp
+++ b/unittests/blocks_log_replay_tests.cpp
@@ -97,6 +97,7 @@ struct blog_replay_fixture {
       // with last_irreversible_block_num and last_head_block_num
       BOOST_CHECK(replay_chain_1.last_irreversible_block_num() == last_irreversible_block_num);
       if (!remove_fork_db) {
+         replay_chain_1.apply_blocks();
          BOOST_CHECK(replay_chain_1.head().block_num() == last_head_block_num);
       } else {
          BOOST_CHECK(replay_chain_1.head().block_num() == last_irreversible_block_num);
@@ -128,6 +129,7 @@ BOOST_FIXTURE_TEST_CASE(replay_through, blog_replay_fixture) try {
    // Make sure replayed irreversible_block_num and head_block_num match
    // with last_irreversible_block_num and last_head_block_num
    BOOST_CHECK(replay_chain.last_irreversible_block_num() == last_irreversible_block_num);
+   replay_chain.apply_blocks();
    BOOST_CHECK(replay_chain.head().block_num() == last_head_block_num);
 } FC_LOG_AND_RETHROW()
 

--- a/unittests/checktime_tests.cpp
+++ b/unittests/checktime_tests.cpp
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE( checktime_interrupt_test) { try {
 
    std::thread th( [&c=*other.control]() {
       std::this_thread::sleep_for( std::chrono::milliseconds(50) );
-      c.interrupt_transaction();
+      c.interrupt_apply_block_transaction();
    } );
 
    // apply block, caught in an "infinite" loop

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -163,6 +163,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_restart_from_block_log, T, testers ) {
    remove_existing_states(copied_config);
 
    tester from_block_log_chain(copied_config, *genesis);
+   from_block_log_chain.apply_blocks();
 
    BOOST_REQUIRE_NO_THROW(from_block_log_chain.get_account("replay1"_n));
    BOOST_REQUIRE_NO_THROW(from_block_log_chain.get_account("replay2"_n));
@@ -221,7 +222,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_light_validation_restart_from_block_log, T, 
                                              other_trace = t;
                                           }
                                        });
-
+   from_block_log_chain.apply_blocks();
 
    BOOST_REQUIRE(other_trace);
    BOOST_REQUIRE(other_trace->receipt);

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -63,6 +63,7 @@ class replay_tester : public base_tester {
          control->applied_transaction().connect(on_applied_trx);
          control->startup( [](){}, []() { return false; }, genesis );
       });
+      apply_blocks();
    }
    using base_tester::produce_block;
 
@@ -163,7 +164,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_restart_from_block_log, T, testers ) {
    remove_existing_states(copied_config);
 
    tester from_block_log_chain(copied_config, *genesis);
-   from_block_log_chain.apply_blocks();
 
    BOOST_REQUIRE_NO_THROW(from_block_log_chain.get_account("replay1"_n));
    BOOST_REQUIRE_NO_THROW(from_block_log_chain.get_account("replay2"_n));
@@ -222,7 +222,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_light_validation_restart_from_block_log, T, 
                                              other_trace = t;
                                           }
                                        });
-   from_block_log_chain.apply_blocks();
 
    BOOST_REQUIRE(other_trace);
    BOOST_REQUIRE(other_trace->receipt);

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -263,7 +263,6 @@ namespace savanna_cluster {
       void open_from_snapshot(const std::string& snapshot) {
          dlog("node ${i} - restoring from snapshot", ("i", _node_idx));
          open(buffered_snapshot_suite::get_reader(snapshot));
-         apply_blocks();
       }
 
       std::vector<uint8_t> save_fsi() const {

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -263,6 +263,7 @@ namespace savanna_cluster {
       void open_from_snapshot(const std::string& snapshot) {
          dlog("node ${i} - restoring from snapshot", ("i", _node_idx));
          open(buffered_snapshot_suite::get_reader(snapshot));
+         apply_blocks();
       }
 
       std::vector<uint8_t> save_fsi() const {


### PR DESCRIPTION
Provide a mechanism to auto recover from "poison" blocks. Poison blocks are blocks with transactions which take an unexpectedly long time to execute. Poison block validation will automatically be interrupted when a better block is received from the network. 

If a BP node, always produce when scheduled to do so. Interrupting any block validation in progress. This restores the old behavior of "drop late blocks". When a producer is scheduled to produce it will interrupt any validation in progress and produce on top of the previous block.

- For BP nodes, interrupt block validation when scheduled to produce
  - Moved `producer_plugin` timer off the main thread executor and onto its own thread.
- Interrupt block validation when a new best head* is received from the network.
  - Do not apply blocks from the fork database on startup. Blocks in the fork database have not been validated. If one of them would happen to be a poison block then a node would be stuck attempting to validate the block. By allowing network blocks to begin flowing into the node immediately on startup, a new best head can be received and interrupt block validation of blocks being processed out of the fork database.
- Ctrl-c/signal interrupt now leaves block in the fork database instead of purging it and its descendants.
  - The block and its descendants can be left in the fork database because a node now auto recovers when a new block is received from the network. Or is interrupted if a BP and is scheduled to produce. 

* New best head means that a fork switch is required. If the new best head is a descendant of the current block being validated then validation is not interrupted. Only when the new block is on an alternative fork is validation be interrupted.

Resolves #1039 
Resolves #1040