### PR TITLE
[1.0.4] set cdt version used in CI to 4.1.x

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
     "cdt":{
-       "target":"main",
+       "target":"4.1",
        "prerelease":true
     },
     "referencecontracts":{


### PR DESCRIPTION
The latest `main` artifact has expired. We could go regenerate that, but nominally this should really be set to a released version.