### PR TITLE
Refactor for pause_at_block functionality

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4952,7 +4952,13 @@ struct controller_impl {
 
    bool should_pause() const {
       if (chain_head.block_num() == pause_at_block_num) {
-         ilog("Pausing at block #${b}", ("b", pause_at_block_num));
+         // when paused new blocks can come in which causes check if we are still paused, do not spam the log
+         static fc::time_point log_time;
+         fc::time_point now = fc::time_point::now();
+         if (log_time < now - fc::seconds(1)) {
+            ilog("Pausing at block #${b}", ("b", pause_at_block_num));
+            log_time = now;
+         }
          return true;
       }
       return false;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4413,7 +4413,8 @@ struct controller_impl {
                if (!switch_fork) {
                   if (check_shutdown()) {
                      shutdown();
-                     break; // result should be complete since we are shutting down
+                     result = controller::apply_blocks_result::incomplete; // doesn't really matter since we are shutting down
+                     break;
                   }
                   if (result == controller::apply_blocks_result::complete) {
                      // Break every ~500ms to allow other tasks (e.g. get_info, SHiP) opportunity to run. User expected

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4346,7 +4346,7 @@ struct controller_impl {
 
          log_irreversible();
          transition_to_savanna_if_needed();
-         return controller::apply_blocks_result::complete;
+         return should_pause() ? controller::apply_blocks_result::paused : controller::apply_blocks_result::complete;
       } catch (fc::exception& e) {
          if (e.code() != interrupt_exception::code_value) {
             wlog("${d}", ("d",e.to_detail_string()));

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -479,6 +479,9 @@ namespace eosio::chain {
       void set_producer_node(bool is_producer_node);
       bool is_producer_node()const; // thread safe, set at program initialization
 
+      void set_pause_at_block_num(block_num_type block_num);
+      block_num_type get_pause_at_block_num()const;
+
       void set_db_read_only_mode();
       void unset_db_read_only_mode();
       void init_thread_local_data();

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -244,8 +244,9 @@ namespace eosio::chain {
 
          /// Apply any blocks that are ready from the fork_db
          enum class apply_blocks_result {
-            complete,  // all ready blocks in forkdb have been applied
-            incomplete // time limit reached, additional blocks may be available in forkdb to process
+            complete,   // all ready blocks in forkdb have been applied
+            incomplete, // time limit reached, additional blocks may be available in forkdb to process
+            paused      // apply blocks currently paused
          };
          apply_blocks_result apply_blocks(const forked_callback_t& cb, const trx_meta_cache_lookup& trx_lookup);
 

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -609,6 +609,8 @@ namespace eosio { namespace chain {
                                     3170015, "Invalid snapshot request" )
       FC_DECLARE_DERIVED_EXCEPTION( snapshot_execution_exception,  producer_exception,
                                     3170016, "Snapshot execution exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( invalid_pause_at_block_request, producer_exception,
+                                    3170017, "Invalid pause at block request" )
 
    FC_DECLARE_DERIVED_EXCEPTION( reversible_blocks_exception,           chain_exception,
                                  3180000, "Reversible Blocks exception" )

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -119,7 +119,9 @@ void producer_api_plugin::plugin_startup() {
    app().get_plugin<http_plugin>().add_api({
        CALL_WITH_400(producer, producer_rw, producer, pause,
             INVOKE_V_V(producer, pause), 201),
-       CALL_WITH_400(producer, producer_rw, producer, resume,
+      CALL_WITH_400(producer, producer_rw, producer, pause_at_block,
+            INVOKE_V_R(producer, pause_at_block, producer_plugin::pause_at_block_params), 201),
+      CALL_WITH_400(producer, producer_rw, producer, resume,
             INVOKE_V_V(producer, resume), 201),
        CALL_WITH_400(producer, producer_rw, producer, update_runtime_options,
             INVOKE_V_R(producer, update_runtime_options, producer_plugin::runtime_options), 201),

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -119,8 +119,9 @@ void producer_api_plugin::plugin_startup() {
    app().get_plugin<http_plugin>().add_api({
        CALL_WITH_400(producer, producer_rw, producer, pause,
             INVOKE_V_V(producer, pause), 201),
-      CALL_WITH_400(producer, producer_rw, producer, pause_at_block,
-            INVOKE_V_R(producer, pause_at_block, producer_plugin::pause_at_block_params), 201),
+      // TODO: Enable for Spring 2.0.0
+      // CALL_WITH_400(producer, producer_rw, producer, pause_at_block,
+      //       INVOKE_V_R(producer, pause_at_block, producer_plugin::pause_at_block_params), 201),
       CALL_WITH_400(producer, producer_rw, producer, resume,
             INVOKE_V_V(producer, resume), 201),
        CALL_WITH_400(producer, producer_rw, producer, update_runtime_options,

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -83,7 +83,12 @@ public:
 
    controller::apply_blocks_result on_incoming_block();
 
+   struct pause_at_block_params {
+      chain::block_num_type block_num{0}; // block height to pause block evaluation/production
+   };
+
    void pause();
+   void pause_at_block(const pause_at_block_params& params);
    void resume();
    bool paused() const;
    void update_runtime_options(const runtime_options& options);
@@ -140,6 +145,9 @@ public:
 
    void log_failed_transaction(const transaction_id_type& trx_id, const chain::packed_transaction_ptr& packed_trx_ptr, const char* reason) const;
 
+   // initiate calls to process_incoming_block to process all queued blocks
+   void process_blocks();
+
    // thread-safe, called when a new block is received
    void received_block(uint32_t block_num, chain::fork_db_add_t fork_db_add_result);
 
@@ -168,3 +176,4 @@ FC_REFLECT(eosio::producer_plugin::get_account_ram_corrections_result, (rows)(mo
 FC_REFLECT(eosio::producer_plugin::get_unapplied_transactions_params, (lower_bound)(limit)(time_limit_ms))
 FC_REFLECT(eosio::producer_plugin::unapplied_trx, (trx_id)(expiration)(trx_type)(first_auth)(first_receiver)(first_action)(total_actions)(billed_cpu_time_us)(size))
 FC_REFLECT(eosio::producer_plugin::get_unapplied_transactions_result, (size)(incoming_size)(trxs)(more))
+FC_REFLECT(eosio::producer_plugin::pause_at_block_params, (block_num));


### PR DESCRIPTION
Proposing to merge this to `main` now as it includes some nice refactors.

Add functionality for `/v1/producer/pause_at_block` without enabling it. Since it is an interface change, it will not be added until Spring 2.0.0. See PR #1057.

See #570 