### PR TITLE
[1.0.4] Fix fetch block with no block log

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1149,14 +1149,14 @@ struct controller_impl {
 
    signed_block_ptr fork_db_fetch_block_by_id( const block_id_type& id ) const {
       return fork_db.apply<signed_block_ptr>([&](const auto& forkdb) {
-         auto bsp = forkdb.get_block(id);
+         auto bsp = forkdb.get_block(id, include_root_t::yes);
          return bsp ? bsp->block : signed_block_ptr{};
       });
    }
 
    signed_block_ptr fork_db_fetch_block_on_best_branch_by_num(uint32_t block_num) const {
       return fork_db.apply<signed_block_ptr>([&](const auto& forkdb) {
-         auto bsp = forkdb.search_on_head_branch(block_num);
+         auto bsp = forkdb.search_on_head_branch(block_num, include_root_t::yes);
          if (bsp) return bsp->block;
          return signed_block_ptr{};
       });

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -448,8 +448,8 @@ namespace eosio::chain {
    BSP fork_database_impl<BSP>::search_on_branch_impl( const block_id_type& h, uint32_t block_num, include_root_t include_root ) const {
       if (!root)
          return {};
-      if( include_root == include_root_t::yes && root->id() == h && root->block_num() == block_num ) {
-         return root;
+      if( include_root == include_root_t::yes && root->block_num() == block_num ) {
+         return root; // root is root of every branch, no need to check h
       }
       if (block_num <= root->block_num())
          return {};


### PR DESCRIPTION
The startup of `producer_plugin` uses `fetch_block_by_number` to prime `on_irreversible_block` with LIB.
https://github.com/AntelopeIO/spring/blob/838e885908aaa1f19aff9aaf4433a6f7904e86cb/plugins/producer_plugin/producer_plugin.cpp#L1612-L1613

When running without a block log, `fetch_block_by_number` always returned `nullptr` for LIB.

Update `fetch_block_by_number` and `fetch_block_by_id` to find LIB in fork database.

Resolves #1052 