### PR TITLE
[1.0.4 -> main] Fix fetch block with no block log

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1199,14 +1199,14 @@ struct controller_impl {
 
    signed_block_ptr fork_db_fetch_block_by_id( const block_id_type& id ) const {
       return fork_db_.apply<signed_block_ptr>([&](const auto& fork_db) {
-         auto bsp = fork_db.get_block(id);
+         auto bsp = fork_db.get_block(id, include_root_t::yes);
          return bsp ? bsp->block : signed_block_ptr{};
       });
    }
 
    signed_block_ptr fork_db_fetch_block_on_best_branch_by_num(uint32_t block_num) const {
       return fork_db_.apply<signed_block_ptr>([&](const auto& fork_db) {
-         auto bsp = fork_db.search_on_head_branch(block_num);
+         auto bsp = fork_db.search_on_head_branch(block_num, include_root_t::yes);
          if (bsp) return bsp->block;
          return signed_block_ptr{};
       });

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -459,8 +459,8 @@ namespace eosio::chain {
    BSP fork_database_impl<BSP>::search_on_branch_impl( const block_id_type& h, uint32_t block_num, include_root_t include_root ) const {
       if (!root)
          return {};
-      if( include_root == include_root_t::yes && root->id() == h && root->block_num() == block_num ) {
-         return root;
+      if( include_root == include_root_t::yes && root->block_num() == block_num ) {
+         return root; // root is root of every branch, no need to check h
       }
       if (block_num <= root->block_num())
          return {};
@@ -593,7 +593,7 @@ namespace eosio::chain {
    template<class BSP>
    BSP fork_database_impl<BSP>::get_block_impl(const block_id_type& id,
                                                include_root_t include_root /* = include_root_t::no */) const {
-      if( include_root == include_root_t::yes && root->id() == id ) {
+      if( include_root == include_root_t::yes && root && root->id() == id ) {
          return root;
       }
       auto itr = index.find( id );

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1609,12 +1609,12 @@ void producer_plugin_impl::plugin_startup() {
       const auto fork_db_root     = chain.fetch_block_by_number(fork_db_root_num);
       if (fork_db_root) {
          on_irreversible_block(fork_db_root);
+
+         if (!_is_savanna_active && irreversible_mode() && chain_plug->accept_transactions()) {
+            wlog("Legacy consensus active. Accepting speculative transaction execution not recommended in read-mode=irreversible");
+         }
       } else {
          _irreversible_block_time = fc::time_point::maximum();
-      }
-
-      if (!_is_savanna_active && irreversible_mode() && chain_plug->accept_transactions()) {
-         wlog("Legacy consensus active. Accepting speculative transaction execution not recommended in read-mode=irreversible");
       }
 
       if (is_configured_producer()) {


### PR DESCRIPTION
The startup of `producer_plugin` uses `fetch_block_by_number` to prime `on_irreversible_block` with LIB.
https://github.com/AntelopeIO/spring/blob/838e885908aaa1f19aff9aaf4433a6f7904e86cb/plugins/producer_plugin/producer_plugin.cpp#L1612-L1613

When running without a block log, `fetch_block_by_number` always returned `nullptr` for LIB.

Update `fetch_block_by_number` and `fetch_block_by_id` to find LIB in fork database.

Merges `release/1.0` into `main` including #1059. Adds commit 5c8ea40c65c12e1b4ff5466fc1d6710b5e4f3e56.

Resolves #1052 