### PR TITLE
On interrupt do not attempt to apply blocks

### DIFF
--- a/tests/interrupt_trx_test.py
+++ b/tests/interrupt_trx_test.py
@@ -109,6 +109,7 @@ try:
     trans=prodNode.pushMessage(contract, action, data, opts)
     assert trans and trans[0], "Failed to push doitslow action"
 
+    assert prodNode.waitForHeadToAdvance(blocksToAdvance=3), "prodNode not advancing head after doitforever action"
     assert prodNode.waitForLibToAdvance(), "prodNode did not advance lib after doitforever action"
     assert prodNode2.waitForLibToAdvance(), "prodNode2 did not advance lib after doitforever action"
 


### PR DESCRIPTION
On shutdown the `interrupt_trx_test.py` sends a SIGTERM to all processes. The test timed out #1058 because the node was stuck trying to validate a block with an infinite transaction in it. The SIGTERM interrupted the block apply but there was a queued up process block which caused it to attempt the `apply_block` again. The fix for this is actually in #1064 which added a `check_shutdown()` to `should_terminate()`. With the `check_shutdown()` in `should_terminate()`, the node will check the `app().is_quitting()` before attempting to apply a block. This prevents it from attempting to apply a block that was interrupted via SIGTERM which sets the `app().is_quitting()` flag.

Also added to the test a verification that head is advancing before verifying that LIB is advancing as a clearer indication that LIB is advancing after recovering from the interrupted block.

Resolves #1058 

