### PR TITLE
[1.0.4 -> main] Fast shutdown in irreversible mode

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1587,7 +1587,7 @@ struct controller_impl {
                packed_block_future f;
                if (irreversible_mode()) {
                   f = post_async_task( thread_pool.get_executor(), [b=(*bitr)->block]() { return fc::raw::pack(*b); } );
-                  if (!apply_irreversible_block(forkdb, *bitr) != controller::apply_blocks_result::complete)
+                  if (apply_irreversible_block(fork_db, *bitr) != controller::apply_blocks_result::complete)
                      break;
                }
 


### PR DESCRIPTION
Faster shutdown in response to ctrl-c/SIGINT/SIGTERM/SIGPIPE especially when syncing in irreversible mode.

Merges `release/1.0` into `main` including #1061 

Resolves #1053 
Resolves #1058