### PR TITLE
Test: Update waitForBlock

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -188,7 +188,7 @@ class Node(Transactions):
         return ret
 
     def waitForBlock(self, blockNum, timeout=None, blockType=BlockType.head, reportInterval=None):
-        lam = lambda: self.getBlockNum(blockType=blockType) > blockNum
+        lam = lambda: self.getBlockNum(blockType=blockType) >= blockNum
         blockDesc = "head" if blockType == BlockType.head else "LIB"
         count = 0
 

--- a/tests/disaster_recovery_2.py
+++ b/tests/disaster_recovery_2.py
@@ -105,7 +105,7 @@ try:
 
     Print("Resume production on Node0")
     node0.processUrllibRequest("producer", "resume")
-    assert node0.waitForIrreversibleBlock(lib) # lib, not lib+1 because waitForIrreversibleBlock uses >
+    assert node0.waitForIrreversibleBlock(lib+1)
     libN = node0.getIrreversibleBlockNum()
     assert libN > lib
 

--- a/tests/disaster_recovery_3.py
+++ b/tests/disaster_recovery_3.py
@@ -96,8 +96,8 @@ try:
         assert not node.verifyAlive(), "Node did not shutdown"
 
     Print("Wait for lib to advance to LIB N on other 2 nodes")
-    for node in [node2, node3]: # waitForBlock uses > not >=. node2 & node3 have lib of n_LIB
-        assert node.waitForBlock(n_LIB-1, timeout=None, blockType=BlockType.lib), "Node did not advance LIB after shutdown of node0 and node1"
+    for node in [node2, node3]:
+        assert node.waitForBlock(n_LIB, timeout=None, blockType=BlockType.lib), "Node did not advance LIB after shutdown of node0 and node1"
         currentLIB = node.getIrreversibleBlockNum()
         assert currentLIB == n_LIB, f"Node advanced LIB {currentLIB} beyond N LIB {n_LIB}"
 

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -500,8 +500,8 @@ try:
     Print("Tracking the blocks from the divergence till there are 10*12 blocks on one chain and 10*12+1 on the other, from block %d to %d" % (killBlockNum, lastBlockNum))
 
     for blockNum in range(killBlockNum,lastBlockNum):
-        blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum)
-        blockProducer1=prodNodes[1].getBlockProducerByNum(blockNum)
+        blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum, timeout=70)
+        blockProducer1=prodNodes[1].getBlockProducerByNum(blockNum, timeout=70)
         blockProducers0.append({"blockNum":blockNum, "prod":blockProducer0})
         blockProducers1.append({"blockNum":blockNum, "prod":blockProducer1})
 


### PR DESCRIPTION
Modify python integration test `Node.waitForBlock` to wait on `blockNum` instead of `blockNum+1`.

Resolves #1055