### PR TITLE
fix 'Produced block' log pre-Savanna

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3515,7 +3515,7 @@ struct controller_impl {
       if (s == controller::block_status::incomplete) {
          const auto& new_b = chain_head.block();
          ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} "
-              "[trxs: ${count}, lib: ${lib}, confirmed: ${confs}, net: ${net}, cpu: ${cpu} us, elapsed: ${et} us, producing time: ${tt} us]",
+              "[trxs: ${count}, lib: ${lib}${confs}, net: ${net}, cpu: ${cpu} us, elapsed: ${et} us, producing time: ${tt} us]",
               ("id", chain_head.id().str().substr(8, 16))("n", new_b->block_num())("p", new_b->producer)("t", new_b->timestamp)
               ("count", new_b->transactions.size())("lib", chain_head.irreversible_blocknum())
               ("confs", new_b->is_proper_svnn_block() ? "" : ", confirmed: " + std::to_string(new_b->confirmed))


### PR DESCRIPTION
before,
```
Produced block 6523a6c556abae06... #2026 @ 2024-12-18T16:48:47.000 signed by eosio [trxs: 5, lib: 2025, confirmed: , confirmed: 0, net: 800, cpu: 760 us, elapsed: 679 us, producing time: 462528 us]
```
after,
```
Produced block 2c0550043bdc520e... #3080 @ 2024-12-18T16:58:38.500 signed by eosio [trxs: 6, lib: 3079, confirmed: 0, net: 960, cpu: 804 us, elapsed: 604 us, producing time: 462454 us]
```