### PR TITLE
P2P: Prioritize blocks, votes, and all messages over trxs

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -630,7 +630,7 @@ namespace eosio {
          bool ready = ((!_trx_write_queue.empty() || !_write_queue.empty()) && !async_write_in_progress);
          g.unlock();
          if (async_write_in_progress) {
-            fc_elog(logger, "Connection - ${id} not ready to send data, async write in progress", ("id", connection_id));
+            fc_dlog(logger, "Connection - ${id} not ready to send data, async write in progress", ("id", connection_id));
          }
          return ready;
       }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3172,7 +3172,7 @@ namespace eosio {
       auto ds = pending_message_buffer.create_datastream();
       unsigned_int which{};
       fc::raw::unpack( ds, which );
-      assert(which == vote_message_which);
+      assert(to_msg_type_t(which) == msg_type_t::vote_message); // verified by caller
       vote_message_ptr ptr = std::make_shared<vote_message>();
       fc::raw::unpack( ds, *ptr );
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1566,24 +1566,6 @@ namespace eosio {
       std::vector<boost::asio::const_buffer> bufs;
       buffer_queue.fill_out_buffer( bufs );
 
-      boost::asio::post(strand, [c{std::move(c)}, bufs{std::move(bufs)}]() {
-         boost::asio::async_write( *c->socket, bufs,
-            boost::asio::bind_executor( c->strand, [c, socket=c->socket]( boost::system::error_code ec, std::size_t w ) {
-            try {
-               c->buffer_queue.clear_out_queue();
-               // May have closed connection and cleared buffer_queue
-               if (!c->socket->is_open() && c->socket_is_open()) { // if socket_open then close not called
-                  peer_ilog(c, "async write socket closed before callback");
-                  c->close();
-                  return;
-               }
-               if (socket != c->socket ) { // different socket, c must have created a new socket, make sure previous is closed
-                  peer_ilog( c, "async write socket changed before callback");
-                  boost::system::error_code ec;
-                  socket->shutdown( tcp::socket::shutdown_both, ec );
-                  socket->close( ec );
-                  return;
-               }
       boost::asio::async_write( *c->socket, bufs,
          boost::asio::bind_executor( c->strand, [c, socket=c->socket]( boost::system::error_code ec, std::size_t w ) {
          try {


### PR DESCRIPTION
- Send all messages including blocks and votes over transactions. This prevents large trxs or large number of trxs from delaying block or vote propagation. 
- Includes a fix for `buffer_queue.out_callback()` called before `clear_out_queue()`. Long standing bug where the callbacks were never called because they were cleared before being called.
- Do not post `async_write` to connection strand as the call is already on the connection strand.
- Move serialization of votes off the main thread.

Resolves #1071 
