### PR TITLE
P2P: Block propagation optimization

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -100,6 +100,11 @@ class bp_connection_manager {
       config.my_bp_accounts.insert(accounts.begin(), accounts.end());
    }
 
+   // thread safe, my_bp_accounts only modified during plugin startup
+   bool is_producer(account_name account) const {
+      return config.my_bp_accounts.count(account) != 0;
+   }
+
    // Only called at plugin startup
    void set_bp_peers(const std::vector<std::string>& peers) {
       try {

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -134,6 +134,14 @@ namespace eosio {
       uint32_t end_block{0};
    };
 
+   struct block_nack_message {
+      block_id_type id;
+   };
+
+   struct block_notice_message {
+      block_id_type id;
+   };
+
    using net_message = std::variant<handshake_message,
                                     chain_size_message,
                                     go_away_message,
@@ -143,7 +151,9 @@ namespace eosio {
                                     sync_request_message,
                                     signed_block,
                                     packed_transaction,
-                                    vote_message>;
+                                    vote_message,
+                                    block_nack_message,
+                                    block_notice_message>;
 
 } // namespace eosio
 
@@ -162,6 +172,8 @@ FC_REFLECT( eosio::time_message, (org)(rec)(xmt)(dst) )
 FC_REFLECT( eosio::notice_message, (known_trx)(known_blocks) )
 FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
+FC_REFLECT( eosio::block_nack_message, (id) )
+FC_REFLECT( eosio::block_notice_message, (id) )
 
 /**
  *

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -112,6 +112,8 @@ namespace eosio {
     uint32_t       pending{0};
     vector<T>      ids;
     bool           empty () const { return (mode == none || ids.empty()); }
+    auto operator<=>(const select_ids<T>&) const noexcept = default;
+    bool operator==(const select_ids<T>&) const noexcept = default;
   };
 
   using ordered_txn_ids = select_ids<transaction_id_type>;
@@ -127,6 +129,9 @@ namespace eosio {
     request_message() : req_trx(), req_blocks() {}
     ordered_txn_ids req_trx;
     ordered_blk_ids req_blocks;
+
+    auto operator<=>(const request_message&) const noexcept = default;
+    bool operator==(const request_message&) const noexcept = default;
   };
 
    struct sync_request_message {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -921,7 +921,7 @@ namespace eosio {
       std::chrono::nanoseconds         connection_start_time{0};
 
       // block nack support
-      static constexpr uint16_t consecutive_block_nacks_threshold{3}; // stop sending blocks when reached
+      static constexpr uint16_t consecutive_block_nacks_threshold{0}; // stop sending blocks when reached
       uint16_t        consecutive_blocks_nacks{0};
       block_id_type   last_block_nack;
       block_id_type   last_block_notice;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1328,7 +1328,7 @@ namespace eosio {
          return;
       if (s == connection_state::connected && curr != connection_state::connecting)
          return;
-      fc_dlog(logger, "old connection ${id} state ${os} becoming ${ns}", ("id", connection_id)("os", state_str(curr))("ns", state_str(s)));
+      fc_dlog(logger, "old connection - ${c} state ${os} becoming ${ns}", ("c", connection_id)("os", state_str(curr))("ns", state_str(s)));
 
       conn_state = s;
    }
@@ -1510,9 +1510,12 @@ namespace eosio {
          no_retry = benign_other;
          enqueue( go_away_message( benign_other ) );
       } else {
-         if( on_fork ) msg_head_num = 0;
          // if peer on fork, start at their last fork_db_root_num, otherwise we can start at msg_head+1, unless include_msg_head
-         if (include_msg_head) --msg_head_num;
+         if (on_fork) {
+            msg_head_num = 0;
+         } else if (include_msg_head) {
+            --msg_head_num;
+         }
          blk_send_branch( msg_head_num, fork_db_root_num, head_num );
       }
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1522,12 +1522,12 @@ namespace eosio {
    void connection::blk_send_branch( uint32_t msg_head_num, uint32_t fork_db_root_num, uint32_t head_num ) {
       if( !peer_requested ) {
          auto last = msg_head_num != 0 ? msg_head_num : fork_db_root_num;
-         if (peer_requested->start_block <= last+1 && peer_requested->end_block >= head_num)
-            return; // nothing to do, send in progress
          peer_requested = peer_sync_state( last+1, head_num, last );
       } else {
          auto last = msg_head_num != 0 ? msg_head_num : std::min( peer_requested->last, fork_db_root_num );
-         uint32_t end   = std::max( peer_requested->end_block, head_num );
+         uint32_t end = std::max( peer_requested->end_block, head_num );
+         if (peer_requested->start_block <= last+1 && peer_requested->end_block >= end)
+            return; // nothing to do, send in progress
          peer_requested = peer_sync_state( last+1, end, last );
       }
       if( peer_requested->start_block <= peer_requested->end_block ) {
@@ -3790,7 +3790,7 @@ namespace eosio {
    void connection::handle_message( const block_nack_message& msg ) {
       auto block_num = block_header::num_from_id(msg.id);
 
-      peer_dlog(this, "received block nack #${bn}:${id}, consecutive ${c}", ("bn", block_num)("id", msg.id)("c", consecutive_blocks_nacks));
+      peer_elog(this, "received block nack #${bn}:${id}, consecutive ${c}", ("bn", block_num)("id", msg.id)("c", consecutive_blocks_nacks));
 
       if (block_num == 0) { // peer requested reset
          consecutive_blocks_nacks = 0;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2761,7 +2761,6 @@ namespace eosio {
                boost::asio::post(cp->strand, [cp, send_buffer{std::move(send_buffer)}, bnum]() {
                   cp->latest_blk_time = std::chrono::steady_clock::now();
                   peer_dlog( cp, "bcast block_notice ${b}", ("b", bnum) );
-                  cp->enqueue_buffer( msg_type_t::block_notice_message, send_buffer, 0, no_reason );
                   cp->enqueue_buffer( msg_type_t::block_notice_message, false, send_buffer, 0, no_reason );
                });
                return;
@@ -2775,7 +2774,6 @@ namespace eosio {
             bool has_block = cp->peer_fork_db_root_num >= bnum;
             if( !has_block ) {
                peer_dlog( cp, "bcast block ${b}", ("b", bnum) );
-               cp->enqueue_buffer( msg_type_t::signed_block, sb, bnum, no_reason );
                cp->enqueue_buffer( msg_type_t::signed_block, false, sb, bnum, no_reason );
             }
          });

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2750,9 +2750,13 @@ namespace eosio {
                   ("s", cp->socket_is_open())("c", connection::state_str(cp->state()))("ss", cp->peer_syncing_from_us.load())("cid", cp->connection_id) );
          if( !cp->current() ) return;
 
+         if( !add_peer_block( id, cp->connection_id ) ) {
+            fc_dlog( logger, "not bcast block ${b} to connection - ${cid}", ("b", bnum)("cid", cp->connection_id) );
+            return;
+         }
+
          if (cp->protocol_version >= proto_block_nack) {
             if (cp->consecutive_blocks_nacks > connection::consecutive_block_nacks_threshold) {
-               add_peer_block( id, cp->connection_id );
                auto send_buffer = block_id_buff_factory.get_send_buffer( block_notice_message{id} );
                boost::asio::post(cp->strand, [cp, send_buffer{std::move(send_buffer)}, bnum]() {
                   cp->latest_blk_time = std::chrono::steady_clock::now();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2764,7 +2764,7 @@ namespace eosio {
          if (cp->protocol_version >= proto_block_nack) {
             if (cp->consecutive_blocks_nacks > connection::consecutive_block_nacks_threshold) {
                // always broadcast our produced blocks, no need for block_notice if not in sync
-               if (!my_impl->is_producer(b->producer) && my_impl->sync_master->is_in_sync()) {
+               if (!my_impl->is_producer(b->producer)) {
                   auto send_buffer = block_id_buff_factory.get_send_buffer( block_notice_message{id} );
                   boost::asio::post(cp->strand, [cp, send_buffer{std::move(send_buffer)}, bnum]() {
                      cp->latest_blk_time = std::chrono::steady_clock::now();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2159,11 +2159,13 @@ namespace eosio {
       } );
    }
 
-// static, thread safe
-void sync_manager::send_block_nack_resets() {
-      my_impl->connections.for_each_block_connection( []( const connection_ptr& ci ) {
-         if( ci->current() ) {
-            ci->send_block_nack({});
+   // static, thread safe
+   void sync_manager::send_block_nack_resets() {
+      my_impl->connections.for_each_block_connection( []( const connection_ptr& cp ) {
+         if (cp->current()) {
+            boost::asio::post(cp->strand, [cp]() {
+               cp->send_block_nack({});
+            });
          }
       } );
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -627,6 +627,7 @@ namespace eosio {
       void reset() {
          fc::lock_guard g( _mtx );
          _write_queue.clear();
+         _sync_write_queue.clear();
          _trx_write_queue.clear();
          _write_queue_size = 0;
          _out_queue.clear();
@@ -635,6 +636,7 @@ namespace eosio {
       void clear_write_queue() {
          fc::lock_guard g( _mtx );
          _write_queue.clear();
+         _sync_write_queue.clear();
          _trx_write_queue.clear();
          _write_queue_size = 0;
       }
@@ -650,17 +652,13 @@ namespace eosio {
          return _write_queue_size;
       }
 
-      bool is_out_queue_empty() const {
-         fc::lock_guard g( _mtx );
-         return _out_queue.empty();
-      }
-
       // called from connection strand
       bool ready_to_send(uint32_t connection_id) const {
          fc::unique_lock g( _mtx );
          // if out_queue is not empty then async_write is in progress
-         bool async_write_in_progress = !_out_queue.empty();
-         bool ready = ((!_trx_write_queue.empty() || !_write_queue.empty()) && !async_write_in_progress);
+         const bool async_write_in_progress = !_out_queue.empty();
+         const bool ready = !async_write_in_progress &&
+            (!_sync_write_queue.empty() || !_write_queue.empty() || !_trx_write_queue.empty());
          g.unlock();
          if (async_write_in_progress) {
             fc_dlog(logger, "Connection - ${id} not ready to send data, async write in progress", ("id", connection_id));
@@ -669,12 +667,15 @@ namespace eosio {
       }
 
       // @param callback must not callback into queued_buffer
-      bool add_write_queue( const std::shared_ptr<vector<char>>& buff,
-                            std::function<void( boost::system::error_code, std::size_t )> callback,
-                            msg_type_t net_msg ) {
+      bool add_write_queue(msg_type_t net_msg,
+                           bool to_sync_queue,
+                           const std::shared_ptr<vector<char>>& buff,
+                           std::function<void(boost::system::error_code, std::size_t)> callback) {
          fc::lock_guard g( _mtx );
          if( net_msg == msg_type_t::packed_transaction ) {
             _trx_write_queue.push_back( {buff, std::move(callback)} );
+         } else if (to_sync_queue) {
+            _sync_write_queue.push_back( {buff, std::move(callback)} );
          } else {
             _write_queue.push_back( {buff, std::move(callback)} );
          }
@@ -687,11 +688,13 @@ namespace eosio {
 
       void fill_out_buffer( std::vector<boost::asio::const_buffer>& bufs ) {
          fc::lock_guard g( _mtx );
-         if( !_write_queue.empty() ) { // always send msgs from write_queue first
+         if (!_sync_write_queue.empty()) { // always send msgs from sync_write_queue first
+            fill_out_buffer( bufs, _sync_write_queue );
+         } else if (!_write_queue.empty()) { // always send msgs from write_queue before trx queue
             fill_out_buffer( bufs, _write_queue );
          } else {
             fill_out_buffer( bufs, _trx_write_queue );
-            assert(_trx_write_queue.empty() && _write_queue.empty() && _write_queue_size == 0);
+            assert(_trx_write_queue.empty() && _write_queue.empty() && _sync_write_queue.empty() && _write_queue_size == 0);
          }
       }
 
@@ -722,8 +725,9 @@ namespace eosio {
 
       alignas(hardware_destructive_interference_sz)
       mutable fc::mutex   _mtx;
-      uint32_t            _write_queue_size GUARDED_BY(_mtx) {0}; // size of _write_queue and _trx_write_queue
-      deque<queued_write> _write_queue      GUARDED_BY(_mtx); // queued messages, all messages except trxs
+      uint32_t            _write_queue_size GUARDED_BY(_mtx) {0}; // size of _write_queue + _sync_write_queue + _trx_write_queue
+      deque<queued_write> _write_queue      GUARDED_BY(_mtx); // queued messages, all messages except sync & trxs
+      deque<queued_write> _sync_write_queue GUARDED_BY(_mtx); // sync_write_queue blocks will be sent first
       deque<queued_write> _trx_write_queue  GUARDED_BY(_mtx); // queued trx messages, trx_write_queue will be sent last
       deque<queued_write> _out_queue        GUARDED_BY(_mtx); // currently being async_write
 
@@ -1006,8 +1010,9 @@ namespace eosio {
       void blk_send_branch( uint32_t msg_head_num, uint32_t fork_db_root_num, uint32_t head_num );
 
       void enqueue( const net_message& msg );
-      size_t enqueue_block( const std::vector<char>& sb, uint32_t block_num );
+      size_t enqueue_block( const std::vector<char>& sb, uint32_t block_num, bool to_sync_queue );
       void enqueue_buffer( msg_type_t net_msg,
+                           bool to_sync_queue,
                            const std::shared_ptr<std::vector<char>>& send_buffer,
                            block_num_type block_num,
                            go_away_reason close_after_send);
@@ -1020,6 +1025,7 @@ namespace eosio {
       void sync_wait();
 
       void queue_write(msg_type_t net_msg,
+                       bool to_sync_queue,
                        const std::shared_ptr<vector<char>>& buff,
                        std::function<void(boost::system::error_code, std::size_t)> callback);
       void do_queue_write();
@@ -1607,9 +1613,10 @@ namespace eosio {
 
    // called from connection strand
    void connection::queue_write(msg_type_t net_msg,
+                                bool to_sync_queue,
                                 const std::shared_ptr<vector<char>>& buff,
                                 std::function<void(boost::system::error_code, std::size_t)> callback) {
-      if( !buffer_queue.add_write_queue( buff, std::move(callback), net_msg )) {
+      if( !buffer_queue.add_write_queue( net_msg, to_sync_queue, buff, std::move(callback) )) {
          peer_wlog( this, "write_queue full ${s} bytes, giving up on connection", ("s", buffer_queue.write_queue_size()) );
          close();
          return;
@@ -1725,7 +1732,7 @@ namespace eosio {
             }
          }
          block_sync_throttling = false;
-         auto sent = enqueue_block( sb, num );
+         auto sent = enqueue_block( sb, num, true );
          block_sync_total_bytes_sent += sent;
          block_sync_frame_bytes_sent += sent;
          ++peer_requested->last;
@@ -1883,29 +1890,30 @@ namespace eosio {
 
       buffer_factory buff_factory;
       const auto& send_buffer = buff_factory.get_send_buffer( m );
-      enqueue_buffer( to_msg_type_t(m.index()), send_buffer, 0, close_after_send );
+      enqueue_buffer( to_msg_type_t(m.index()), false, send_buffer, 0, close_after_send );
    }
 
    // called from connection strand
-   size_t connection::enqueue_block( const std::vector<char>& b, uint32_t block_num ) {
+   size_t connection::enqueue_block( const std::vector<char>& b, uint32_t block_num, bool to_sync_queue ) {
       peer_dlog( this, "enqueue block ${num}", ("num", block_num) );
       verify_strand_in_this_thread( strand, __func__, __LINE__ );
 
       block_buffer_factory buff_factory;
       const auto& sb = buff_factory.get_send_buffer( b );
       latest_blk_time = std::chrono::steady_clock::now();
-      enqueue_buffer( msg_type_t::signed_block, sb, block_num, no_reason);
+      enqueue_buffer( msg_type_t::signed_block, to_sync_queue, sb, block_num, no_reason);
       return sb->size();
    }
 
    // called from connection strand
    void connection::enqueue_buffer( msg_type_t net_msg,
+                                    bool to_sync_queue,
                                     const std::shared_ptr<std::vector<char>>& send_buffer,
                                     block_num_type block_num, // only valid for net_msg == signed_block variant which
                                     go_away_reason close_after_send)
    {
       connection_ptr self = shared_from_this();
-      queue_write(net_msg, send_buffer,
+      queue_write(net_msg, to_sync_queue, send_buffer,
             [conn{std::move(self)}, close_after_send, net_msg, block_num](boost::system::error_code ec, std::size_t ) {
                         if (ec) {
                            fc_elog(logger, "Connection - ${cid} - send failed with: ${e}", ("cid", conn->connection_id)("e", ec.message()));
@@ -2750,14 +2758,10 @@ namespace eosio {
                   cp->latest_blk_time = std::chrono::steady_clock::now();
                   peer_dlog( cp, "bcast block_notice ${b}", ("b", bnum) );
                   cp->enqueue_buffer( msg_type_t::block_notice_message, send_buffer, 0, no_reason );
+                  cp->enqueue_buffer( msg_type_t::block_notice_message, false, send_buffer, 0, no_reason );
                });
                return;
             }
-         }
-
-         if( !add_peer_block( id, cp->connection_id ) ) {
-            fc_dlog( logger, "not bcast block ${b} to connection - ${cid}", ("b", bnum)("cid", cp->connection_id) );
-            return;
          }
 
          send_buffer_type sb = buff_factory.get_send_buffer( b );
@@ -2768,6 +2772,7 @@ namespace eosio {
             if( !has_block ) {
                peer_dlog( cp, "bcast block ${b}", ("b", bnum) );
                cp->enqueue_buffer( msg_type_t::signed_block, sb, bnum, no_reason );
+               cp->enqueue_buffer( msg_type_t::signed_block, false, sb, bnum, no_reason );
             }
          });
       } );
@@ -2781,7 +2786,7 @@ namespace eosio {
          boost::asio::post(cp->strand, [cp, msg]() {
             if (vote_logger.is_enabled(fc::log_level::debug))
                peer_dlog(cp, "sending vote msg");
-            cp->enqueue_buffer( msg_type_t::vote_message, msg, 0, no_reason );
+            cp->enqueue_buffer( msg_type_t::vote_message, false, msg, 0, no_reason );
          });
          return true;
       } );
@@ -2802,7 +2807,7 @@ namespace eosio {
          send_buffer_type sb = buff_factory.get_send_buffer( trx );
          fc_dlog( logger, "sending trx: ${id}, to connection - ${cid}", ("id", trx->id())("cid", cp->connection_id) );
          boost::asio::post(cp->strand, [cp, sb{std::move(sb)}]() {
-            cp->enqueue_buffer( msg_type_t::packed_transaction, sb, 0, no_reason );
+            cp->enqueue_buffer( msg_type_t::packed_transaction, false, sb, 0, no_reason );
          } );
       } );
    }
@@ -3250,7 +3255,7 @@ namespace eosio {
       buffer_factory buff_factory;
       auto send_buffer = buff_factory.get_send_buffer( block_nack_message{block_id} );
 
-      enqueue_buffer( msg_type_t::block_nack_message, send_buffer, 0, no_reason );
+      enqueue_buffer( msg_type_t::block_nack_message, false, send_buffer, 0, no_reason );
    }
 
    void net_plugin_impl::plugin_shutdown() {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3796,9 +3796,10 @@ namespace eosio {
          my_impl->dispatcher.add_peer_block(msg.id, connection_id);
       } else {
          if (block_header::num_from_id(last_block_notice) == block_header::num_from_id(msg.id) - 1) {
+            peer_ilog(this, "Received 2 unknown block notices, requesting blocks from ${bn}", ("bn", block_header::num_from_id(last_block_notice)));
             send_block_nack({});
             request_message req;
-            req.req_blocks.mode = normal;
+            req.req_blocks.mode = catch_up;
             req.req_blocks.ids.push_back(last_block_notice);
             enqueue( req );
          }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2757,7 +2757,8 @@ namespace eosio {
 
          if (cp->protocol_version >= proto_block_nack) {
             if (cp->consecutive_blocks_nacks > connection::consecutive_block_nacks_threshold) {
-               if (!my_impl->is_producer(b->producer)) { // always broadcast our produced blocks
+               // always broadcast our produced blocks, no need for block_notice if not in sync
+               if (!my_impl->is_producer(b->producer) && my_impl->sync_master->is_in_sync()) {
                   auto send_buffer = block_id_buff_factory.get_send_buffer( block_notice_message{id} );
                   boost::asio::post(cp->strand, [cp, send_buffer{std::move(send_buffer)}, bnum]() {
                      cp->latest_blk_time = std::chrono::steady_clock::now();

--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -193,7 +193,7 @@ class PerformanceTestBasic:
 
         Utils.Debug = self.testHelperConfig.verbose
         self.errorExit = Utils.errorExit
-        self.emptyBlockGoal = 1
+        self.emptyBlockGoal = 7
 
         self.testStart = datetime.utcnow()
         self.testEnd = self.testStart

--- a/tests/disaster_recovery_3.py
+++ b/tests/disaster_recovery_3.py
@@ -99,7 +99,7 @@ try:
     for node in [node2, node3]:
         assert node.waitForBlock(n_LIB, timeout=None, blockType=BlockType.lib), "Node did not advance LIB after shutdown of node0 and node1"
         currentLIB = node.getIrreversibleBlockNum()
-        assert currentLIB == n_LIB, f"Node advanced LIB {currentLIB} beyond N LIB {n_LIB}"
+        assert currentLIB == n_LIB, f"Node {node.nodeId} advanced LIB {currentLIB} beyond N LIB {n_LIB}"
 
     Print("Shutdown other two nodes")
     for node in [node2, node3]:


### PR DESCRIPTION
### New Block Nack Feature

Currently when a node has many connections, it can overwhelm its bandwidth when large blocks are created. A node will send every block it receives to all of its peers that it has not already received the block from. 

This PR adds a new P2P protocol version, which when both sides of a connection have the feature, it is enabled. For example, if a peer is running `nodeos` version 1.0.x then it will continue to always receive and send all blocks.

- Adds `block_nack_message` and `block_notice_message` to the P2P message protocol.
- Adds new option `p2p-disable-block-nack` which disables this functionality. It may be useful to disable on canary/relay nodes of producers so blocks are never missed requiring a block request. Or when absolute block latency desired. Note that latency can be hurt if many peers are configured. For large number of peers it is recommended to not disable the block nack.

#### Algorithm:

- `block_nack_message` sends `block_id` to peer when it receives a block it has already received from another peer.
- `block_notice_messsage` sent instead of a block when a threshold of `block_nack_message` are received.
  - A peer will respond to a `block_notice_message` with the existing `request_message` when two consecutive are received for blocks not received from other peers.
   