### PR TITLE
relax `checktime_hashing_fail` contract caching timing to eliminate spurious test failures

### DIFF
--- a/unittests/checktime_tests.cpp
+++ b/unittests/checktime_tests.cpp
@@ -466,12 +466,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checktime_hashing_fail, T, validating_testers) { t
 	chain.produce_block();
 
         BOOST_TEST( !chain.is_code_cached("testapi"_n) );
-
-        //hit deadline exception, but cache the contract
-        BOOST_CHECK_EXCEPTION( call_test( chain, test_api_action<WASM_TEST_ACTION("test_checktime", "checktime_sha1_failure")>{},
-                                          5000, 8, 8 ),
-                               deadline_exception, is_deadline_exception );
-
+        //run a simple action to cache the contract
+        CALL_TEST_FUNCTION(chain, "test_checktime", "checktime_pass", {});
         BOOST_TEST( chain.is_code_cached("testapi"_n) );
 
         //the contract should be cached, now we should get deadline_exception because of calls to checktime() from hashing function


### PR DESCRIPTION
On a fast Zen5 CPU, I see spurious failures on this line about 5% of the time (the action completes faster than 8ms resulting in the exception not firing). Reducing the limit to 6ms resolves the problem. But this is rather fragile and has been tweaked a number of times in the past. Since the purpose of this first action is to just get the contract cached, why not run a simple action that is guaranteed to pass to prime the cache?