### PR TITLE
Fix upacking() issues for std::optional, std::shared_ptr, std::set, and std::list

### DIFF
--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -207,7 +207,7 @@ namespace fc {
          auto tmp = std::make_shared<std::remove_const_t<T>>();
          fc::raw::unpack( s, *tmp );
          v = std::move(tmp);
-      }
+      } else { v.reset(); }
     } FC_RETHROW_EXCEPTIONS( warn, "std::shared_ptr<T>", ("type",fc::get_typename<T>::name()) ) }
 
     template<typename Stream> inline void pack( Stream& s, const signed_int& v ) {
@@ -285,6 +285,7 @@ namespace fc {
     { try {
       bool b; fc::raw::unpack( s, b );
       if( b ) { v = T(); fc::raw::unpack( s, *v ); }
+      else { v.reset(); } // in case v has already has a value
     } FC_RETHROW_EXCEPTIONS( warn, "optional<${type}>", ("type",fc::get_typename<T>::name() ) ) }
 
     // std::vector<char>
@@ -635,6 +636,7 @@ namespace fc {
     inline void unpack( Stream& s, std::list<T>& value ) {
       unsigned_int size; fc::raw::unpack( s, size );
       FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
+      value.clear();
       while( size.value-- ) {
          T i;
          fc::raw::unpack( s, i );
@@ -658,6 +660,7 @@ namespace fc {
     inline void unpack( Stream& s, std::set<T>& value ) {
       unsigned_int size; fc::raw::unpack( s, size );
       FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
+      value.clear();
       for( uint64_t i = 0; i < size.value; ++i )
       {
         T tmp;


### PR DESCRIPTION
This PR fixes a number of `unpacking()` issues:

1. `std::optional`: the target is not reset if the source does not have a value. This will causes mismatch of source and target if the target already has a value, as that value is kept.
2. `std::shared_ptr`: the target is not reset if the source is null_ptr.
3. `std::set`: the target is not set to empty if the source is empty, and the target is not clear if the source is not empty ending up with elements from both source and target.
4. `std::list`: the target is not set to empty if the source is empty, and the target is not clear if the source is not empty ending up with elements from both source and target.

The PR adds comprehensive tests for packing/unpacking `std::optional`, `std::shared_ptr`, `std::set`, and `std::list`.

Resolves https://github.com/AntelopeIO/spring/issues/1103