### PR TITLE
Read-only transaction reporting

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3078,8 +3078,10 @@ struct controller_impl {
             } else {
                transaction_receipt_header r;
                r.status = transaction_receipt::executed;
-               r.cpu_usage_us = trx_context.billed_cpu_time_us;
-               r.net_usage_words = trace->net_usage / 8;
+               if (!trx->is_read_only()) {
+                  r.cpu_usage_us = trx_context.billed_cpu_time_us;
+                  r.net_usage_words = trace->net_usage / 8;
+               }
                trace->receipt = r;
             }
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -679,19 +679,32 @@ void print_result( const fc::variant& result ) { try {
          }
 
          cerr << status << " transaction: " << transaction_id << "  ";
-         if( net < 0 ) {
-            cerr << "<unknown>";
+         if (!tx_read) {
+            if( net < 0 ) {
+               cerr << "<unknown>";
+            } else {
+               cerr << net;
+            }
+            cerr << " bytes  ";
+            if( cpu < 0 ) {
+               cerr << "<unknown>";
+            } else {
+               cerr << cpu;
+            }
+            cerr << " us\n";
          } else {
-            cerr << net;
+            int64_t elapsed = -1;
+            if (processed.get_object().contains( "elapsed" )) {
+               elapsed = processed["elapsed"].as_int64();
+            }
+            cerr << " elapsed ";
+            if (elapsed < 0) {
+               cerr << "<unknown>";
+            } else {
+               cerr << elapsed;
+            }
+            cerr << " us\n";
          }
-         cerr << " bytes  ";
-         if( cpu < 0 ) {
-            cerr << "<unknown>";
-         } else {
-            cerr << cpu;
-         }
-
-         cerr << " us\n";
 
          if( status == "failed" ) {
             auto soft_except = processed["except"].as<std::optional<fc::exception>>();
@@ -703,7 +716,8 @@ void print_result( const fc::variant& result ) { try {
             for( const auto& a : actions ) {
                print_action_tree( a );
             }
-            wlog( "\rwarning: transaction executed locally, but may not be confirmed by the network yet" );
+            if (!tx_read && !tx_dry_run)
+               wlog( "\rwarning: transaction executed locally, but may not be confirmed by the network yet" );
          }
       } else {
          cerr << fc::json::to_pretty_string( result ) << endl;


### PR DESCRIPTION
- Report `cpu_usage_us` and `net_usage_words` as `0` in read-only transaction trace receipt.
  - Rational: read-only transactions are only executed locally on an API node. They have no on-chain billable CPU or billable NET. Could argue that there should be no `receipt` for read-only transactions. However, it is likely that existing tooling is expecting `receipt` for transactions that do not fail.
- Modify `cleos` to report `elapsed` instead of `cpu` and `net` for read-only transactions.
- Remove `cleos` `warning: transaction executed locally, but may not be confirmed by the network yet` for read-only and dry-run transactions.
- Note this PR does keep the `net_usage` in the receipt for read-only transactions. Since this is not in the receipt, I thought it might be useful for a user to know what the calculated net would be if the transaction was not read-only.

Examples:
```
./cleos --url http://localhost:8890 --wallet-url http://localhost:9899 --no-auto-keosd push action payloadless doit '{}' --read
executed transaction: af59a47ce5e00c0a778f88707f95969d4a90f044beecd2e18eef49ec2a042fd1   elapsed 192 us
#   payloadless <= payloadless::doit            ""
>> Im a payloadless action
```
```
./cleos --url http://localhost:8890 --wallet-url http://localhost:9899 --no-auto-keosd push action payloadless doit '{}' --read -j
{
  "transaction_id": "9b801e162ada0c416ebcc682d8855b4dfca9a7b8a99a392efa4e41929667ef98",
  "processed": {
    "id": "9b801e162ada0c416ebcc682d8855b4dfca9a7b8a99a392efa4e41929667ef98",
    "block_num": 435,
    "block_time": "2025-01-24T15:51:12.500",
    "producer_block_id": null,
    "receipt": {
      "status": "executed",
      "cpu_usage_us": 0,
      "net_usage_words": 0
    },
    "elapsed": 180,
    "net_usage": 64,
    "scheduled": false,
    "action_traces": [{
        "action_ordinal": 1,
        "creator_action_ordinal": 0,
        "closest_unnotified_ancestor_action_ordinal": 0,
        "receipt": {
          "receiver": "payloadless",
          "act_digest": "4f09a630d4456585ee4ec5ef96c14151587367ad381f9da445b6b6239aae82cf",
          "global_sequence": 0,
          "recv_sequence": 0,
          "auth_sequence": [],
          "code_sequence": 1,
          "abi_sequence": 1
        },
        "receiver": "payloadless",
        "act": {
          "account": "payloadless",
          "name": "doit",
          "authorization": [],
          "data": "",
          "hex_data": ""
        },
        "context_free": false,
        "elapsed": 75,
        "console": "Im a payloadless action",
        "trx_id": "9b801e162ada0c416ebcc682d8855b4dfca9a7b8a99a392efa4e41929667ef98",
        "block_num": 435,
        "block_time": "2025-01-24T15:51:12.500",
        "producer_block_id": null,
        "account_ram_deltas": [],
        "except": null,
        "error_code": null,
        "return_value_hex_data": ""
      }
    ],
    "account_ram_delta": null,
    "except": null,
    "error_code": null
  }

```

Resolves #1085 