### PR TITLE
don't pause billing timer when fetching EOS VM OC's `code_descriptor`

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -148,10 +148,6 @@ struct eosvmoc_tier {
                m.whitelisted = context.is_eos_vm_oc_whitelisted();
                m.high_priority = m.whitelisted && context.is_applying_block();
                m.write_window = context.control.is_write_window();
-               auto timer_pause = fc::make_scoped_exit([&](){
-                  context.trx_context.resume_billing_timer();
-               });
-               context.trx_context.pause_billing_timer();
                cd = eosvmoc->cc.get_descriptor_for_code(m, code_hash, vm_version, failure);
             } catch (...) {
                // swallow errors here, if EOS VM OC has gone in to the weeds we shouldn't bail: continue to try and run baseline


### PR DESCRIPTION
This pause & restart of the billing timer occurs for _every_ action executed by OC. It's a substantial amount of overhead (calling in to the kernel twice and doing whatever overhead needed to manage the timer) to be burdened with for every single action. I think this was added because in 1.1 `consume_compile_thread_queue()` is a wee bit heavier than prior releases (because it needs to take a lock a couple of times; for every action :disappointed: ). But since the number of outstanding compiles is limited to OC compile threads, the time spent in there is still very low. It wouldn't surprise me if this pause/resume is alone consuming more unaccounted for time than the nominal execution of `consume_compile_thread_queue()`.

Noticed during work of #1119 