### PR TITLE
remove a log message when OC compilation completes for running contract

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -115,7 +115,6 @@ struct eosvmoc_tier {
       void async_compile_complete(boost::asio::io_context& ctx, const digest_type& code_id, fc::time_point queued_time) {
          if (executing_code_hash.load() == code_id) { // is action still executing?
             auto elapsed = fc::time_point::now() - queued_time;
-            ilog("EOS VM OC tier up for ${id} compile complete ${t}ms", ("id", code_id)("t", elapsed.count()/1000));
             auto expire_in = std::max(fc::microseconds(0), fc::milliseconds(500) - elapsed);
             std::shared_ptr<boost::asio::steady_timer> timer = std::make_shared<boost::asio::steady_timer>(ctx);
             timer->expires_from_now(std::chrono::microseconds(expire_in.count()));


### PR DESCRIPTION
When I start from snapshot I can sometimes see this log once or twice. imo this ends up being deceptive because it looks like OC only tiered up 1 or 2 contracts (at least based on the current wording of the message). We already have another ilog a few lines down that logs when an interruption actually occurs. So, I don't really think we need this one.