### PR TITLE
don't start kernel level platform timer when applying blocks

### DIFF
--- a/libraries/chain/include/eosio/chain/platform_timer.hpp
+++ b/libraries/chain/include/eosio/chain/platform_timer.hpp
@@ -13,13 +13,19 @@ struct platform_timer {
    platform_timer();
    ~platform_timer();
 
+   //start() & stop() are not thread safe to each other; i.e. do not overlap calls to start() and stop()
    void start(fc::time_point tp);
    void stop();
+   //interrupt_timer() can be called from any thread
    void interrupt_timer();
 
-   /* Sets a callback for when timer expires. Be aware this could might fire from a signal handling context and/or
+   /* Sets a callback for when timer expires. Be aware this could fire from a signal handling context and/or
       on any particular thread. Only a single callback can be registered at once; trying to register more will
-      result in an exception. Setting to nullptr disables any current set callback */
+      result in an exception. Setting to nullptr disables any current set callback.
+      Also, stop() is not perfectly synchronized with the callback. It is possible for stop() to return and the
+      callback still execute if the timer expires and stop() is called nearly simultaneously.
+      However, set_expiration_callback() is synchronized with the callback.
+   */
    void set_expiration_callback(void(*func)(void*), void* user) {
       bool expect_false = false;
       while(!atomic_compare_exchange_strong(&_callback_variables_busy, &expect_false, true))
@@ -45,6 +51,7 @@ private:
    void expire_now();
 
    std::atomic<state_t> _state = state_t::stopped;
+   bool timer_running_forever = false;
 
    struct impl;
    constexpr static size_t fwd_size = 8;

--- a/libraries/chain/platform_timer_asio_fallback.cpp
+++ b/libraries/chain/platform_timer_asio_fallback.cpp
@@ -56,11 +56,14 @@ platform_timer::~platform_timer() {
 }
 
 void platform_timer::start(fc::time_point tp) {
+   assert(_state == state_t::stopped);
    if(tp == fc::time_point::maximum()) {
       _state = state_t::running;
+      timer_running_forever = true;
       return;
    }
    fc::microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
+   timer_running_forever = false;
    if(x.count() <= 0)
       _state = state_t::timed_out;
    else {
@@ -89,11 +92,14 @@ void platform_timer::interrupt_timer() {
 }
 
 void platform_timer::stop() {
-   if(_state == state_t::stopped)
+   const state_t prior_state = _state;
+   if(prior_state == state_t::stopped)
+      return;
+   _state = state_t::stopped;
+   if(prior_state == state_t::timed_out || timer_running_forever)
       return;
 
    my->timer->cancel();
-   _state = state_t::stopped;
 }
 
 }}

--- a/libraries/chain/platform_timer_asio_fallback.cpp
+++ b/libraries/chain/platform_timer_asio_fallback.cpp
@@ -57,9 +57,9 @@ platform_timer::~platform_timer() {
 
 void platform_timer::start(fc::time_point tp) {
    assert(_state == state_t::stopped);
-   if(tp == fc::time_point::maximum()) {
+   timer_running_forever = tp == fc::time_point::maximum();
+   if(timer_running_forever) {
       _state = state_t::running;
-      timer_running_forever = true;
       return;
    }
    fc::microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();

--- a/libraries/chain/platform_timer_kqueue.cpp
+++ b/libraries/chain/platform_timer_kqueue.cpp
@@ -89,9 +89,9 @@ platform_timer::~platform_timer() {
 
 void platform_timer::start(fc::time_point tp) {
    assert(_state == state_t::stopped);
-   if(tp == fc::time_point::maximum()) {
+   timer_running_forever = tp == fc::time_point::maximum();
+   if(timer_running_forever) {
       _state = state_t::running;
-      timer_running_forever = true;
       return;
    }
    fc::microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();

--- a/libraries/chain/platform_timer_kqueue.cpp
+++ b/libraries/chain/platform_timer_kqueue.cpp
@@ -88,20 +88,23 @@ platform_timer::~platform_timer() {
 }
 
 void platform_timer::start(fc::time_point tp) {
+   assert(_state == state_t::stopped);
    if(tp == fc::time_point::maximum()) {
-      expired = false;
+      _state = state_t::running;
+      timer_running_forever = true;
       return;
    }
    fc::microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
+   timer_running_forever = false;
    if(x.count() <= 0)
-      expired = true;
+      _state = state_t::timed_out;
    else {
       struct kevent64_s aTimerEvent;
       EV_SET64(&aTimerEvent, my->timerid, EVFILT_TIMER, EV_ADD|EV_ENABLE|EV_ONESHOT, NOTE_USECONDS|NOTE_CRITICAL, x.count(), (uint64_t)this, 0, 0);
 
-      expired = false;
+      _state = state_t::running;
       if(kevent64(kqueue_fd, &aTimerEvent, 1, NULL, 0, KEVENT_FLAG_IMMEDIATE, NULL) != 0)
-         expired = true;
+         _state = state_t::timed_out;
    }
 }
 
@@ -120,7 +123,11 @@ void platform_timer::interrupt_timer() {
 }
 
 void platform_timer::stop() {
-   if(_state == state_t::stopped)
+   const state_t prior_state = _state;
+   if(prior_state == state_t::stopped)
+      return;
+   _state = state_t::stopped;
+   if(prior_state == state_t::timed_out || timer_running_forever)
       return;
 
    struct kevent64_s stop_timer_event;

--- a/libraries/chain/platform_timer_posix.cpp
+++ b/libraries/chain/platform_timer_posix.cpp
@@ -56,13 +56,12 @@ platform_timer::~platform_timer() {
 
 void platform_timer::start(fc::time_point tp) {
    assert(_state == state_t::stopped);
-   if(tp == fc::time_point::maximum()) {
+   timer_running_forever = tp == fc::time_point::maximum();
+   if(timer_running_forever) {
       _state = state_t::running;
-      timer_running_forever = true;
       return;
    }
    fc::microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
-   timer_running_forever = false;
    if(x.count() <= 0)
       _state = state_t::timed_out;
    else {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -111,7 +111,8 @@ namespace eosio::chain {
       init_net_usage = initial_net_usage;
 
       // set maximum to a semi-valid deadline to allow for pause math and conversion to dates for logging
-      if( block_deadline == fc::time_point::maximum() ) block_deadline = start + fc::hours(24*7*52);
+      const fc::time_point far_future_time = start + fc::days(7*52);
+      if( block_deadline == fc::time_point::maximum() ) block_deadline = far_future_time;
 
       const auto& cfg = control.get_global_properties().configuration;
       auto& rl = control.get_mutable_resource_limits_manager();
@@ -250,7 +251,10 @@ namespace eosio::chain {
          _deadline = block_deadline;
       }
 
-      transaction_timer.start( _deadline );
+      if(_deadline < far_future_time)
+         transaction_timer.start( _deadline );
+      else
+         transaction_timer.start( fc::time_point::maximum() );  //avoids overhead in starting the timer at all
       checktime(); // Fail early if deadline has already been exceeded
       is_initialized = true;
    }


### PR DESCRIPTION
When passing `fc::time_point::max()` to `platform_timer::start()`, `platform_timer` recognizes that,
https://github.com/AntelopeIO/spring/blob/909603c103e81744c6898e18f48cbcd1a08e542f/libraries/chain/platform_timer_posix.cpp#L57-L62
and pretends the timer is running without actually starting the timer. Then when `stop()` is called it would still make a request to the kernel to stop the never started timer. There is nothing logically wrong with that, it's just a wasteful syscall that isn't needed that can end up happening thousands of times a second.

My memory was that historically when applying a block, `transaction_context::init()` would effectively `platform_timer::start(fc::time_point::max())`. That would result in the condition above and it's why I wrote #1119 worded the way it is. But I can't actually find evidence of this in history so I may be misremembering it.

Instead, today, `transaction_context::init()` passes a time 1 year in the future when applying a block. This actually makes the situation _worse_ than what I thought: now for every transaction while applying a block a timer is entirely needlessly started and stopped.

So this PR,
1) Makes `transaction_context::init()` do `platform_timer::start(fc::time_point::max())`; the timer somehow needs to indicate `running` state for things like `checktime()` to work so unless wanting to touch a lot more code we can't just entirely be hands off the timer. We could also do something like a `platform_timer::start_forever()` instead if not liking overloading the meaning of `start()`.
2) The `platform_timer` now remembers when it was started with `fc::time_point::max()` and when stopped skips the kernel call.

There are a handful of ways to go about accomplishing various nuances in what this PR does. Any strong opinions for a different approach can be explored.