### PR TITLE
Test: Create unique log files for nodeos

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -527,6 +527,11 @@ class Node(Transactions):
         err = dd / Path(f'stderr.{launch_time}.txt')
         pidf = dd / Path(f'{Utils.EosServerName}.pid')
 
+        i = 0
+        while err.is_file():
+            i = i + 1
+            err = dd / Path(f'stderr.{launch_time}-{i}.txt')
+
         Utils.Print(f'spawning child: {" ".join(cmd)}')
         dd.mkdir(parents=True, exist_ok=True)
         with out.open('w') as sout, err.open('w') as serr:

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -527,6 +527,7 @@ class Node(Transactions):
         err = dd / Path(f'stderr.{launch_time}.txt')
         pidf = dd / Path(f'{Utils.EosServerName}.pid')
 
+        # make sure unique file name to avoid overwrite of existing log file
         i = 0
         while err.is_file():
             i = i + 1


### PR DESCRIPTION
When `nodeos` is quickly relaunched in the integration tests, it is possible that a `nodeos` log file is overwritten because it has the same launch time and file name. This happens, for example, in `nodeos_read_terminate_at_block_test.py`. Make sure a unique log file name is created for each run of `nodeos`.