### PR TITLE
Make eos-vm-oc-whitelist option multitoken

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -363,7 +363,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "'auto' - EOS VM OC tier-up is enabled for eosio.* accounts, read-only trxs, and except on producers applying blocks.\n"
           "'all'  - EOS VM OC tier-up is enabled for all contract execution.\n"
           "'none' - EOS VM OC tier-up is completely disabled.\n")
-         ("eos-vm-oc-whitelist", bpo::value<vector<string>>()->composing()->default_value(std::vector<string>{{"xsat"}}),
+         ("eos-vm-oc-whitelist", bpo::value<vector<string>>()->composing()->multitoken()->default_value(std::vector<string>{{"xsat"}}),
           "EOS VM OC tier-up whitelist account suffixes for tier-up runtime 'auto'.")
 #endif
          ("enable-account-queries", bpo::value<bool>()->default_value(false), "enable queries to find accounts by various metadata.")
@@ -533,6 +533,15 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
 
       LOAD_VALUE_SET( options, "trusted-producer", chain_config->trusted_producers );
 
+      if (!chain_config->eos_vm_oc_whitelist_suffixes.empty()) {
+         const auto& wl = chain_config->eos_vm_oc_whitelist_suffixes;
+         std::string s = std::accumulate(std::next(wl.begin()), wl.end(),
+                                         wl.begin()->to_string(),
+                                         [](std::string a, account_name b) -> std::string {
+                                            return std::move(a) + ", " + b.to_string();
+                                         });
+         ilog("eos-vm-oc-whitelist accounts: ${a}", ("a", s));
+      }
       if( options.count( "action-blacklist" )) {
          const std::vector<std::string>& acts = options["action-blacklist"].as<std::vector<std::string>>();
          auto& list = chain_config->action_blacklist;


### PR DESCRIPTION
All other whitelist options are multi-token.  This PR changes `eos-vm-oc-whitelist` to also be multi-token.

Multi-token allows for multiple values to be specified for `--eos-vm-oc-whitelist`; e.g. `--eos-vm-oc-whitelist xsat other another`.

Note: if any `eos-vm-oc-whitelist` option is specified then `xsat` needs to be explicitly added. The default is overridden if any value is specified. For example, to add `other`, use `--eos-vm-oc-whitelist xsat other`.

The default value of `eos-vm-oc-whitelist` is `xsat`. If `xsat` is not desired, then an alternative must be specified. If there is a desire to not whitelist any accounts, then use `eosio.null` or any other account without a contract.

Also adds a logging of `eos-vm-oc-whiltelist` accounts on startup.