### PR TITLE
[1.1.0 -> main] Fix deferred trx processing

### DIFF
--- a/benchmark/bls.cpp
+++ b/benchmark/bls.cpp
@@ -78,7 +78,8 @@ struct interface_in_benchmark {
       timer = std::make_unique<platform_timer>();
       trx_timer = std::make_unique<transaction_checktime_timer>(*timer);
       trx_ctx = std::make_unique<transaction_context>(*chain->control.get(), *ptrx, ptrx->id(), std::move(*trx_timer),
-                                                      action_digests_t::store_which_t::legacy);
+                                                      action_digests_t::store_which_t::legacy, fc::time_point::now(),
+                                                      transaction_metadata::trx_type::input);
       trx_ctx->max_transaction_time_subjective = fc::microseconds::maximum();
       trx_ctx->init_for_input_trx( ptrx->get_unprunable_size(), ptrx->get_prunable_size() );
       trx_ctx->exec(); // this is required to generate action traces to be used by apply_context constructor

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -114,8 +114,8 @@ namespace eosio::chain {
                               const transaction_id_type& trx_id, // trx_id diff than t.id() before replace_deferred
                               transaction_checktime_timer&& timer,
                               action_digests_t::store_which_t sad,
-                              fc::time_point start = fc::time_point::now(),
-                              transaction_metadata::trx_type type = transaction_metadata::trx_type::input);
+                              fc::time_point start,
+                              transaction_metadata::trx_type type);
          ~transaction_context();
 
          void init_for_implicit_trx();
@@ -162,6 +162,8 @@ namespace eosio::chain {
          bool is_dry_run()const { return trx_type == transaction_metadata::trx_type::dry_run; };
          bool is_read_only()const { return trx_type == transaction_metadata::trx_type::read_only; };
          bool is_transient()const { return trx_type == transaction_metadata::trx_type::read_only || trx_type == transaction_metadata::trx_type::dry_run; };
+         bool is_implicit()const { return trx_type == transaction_metadata::trx_type::implicit; };
+         bool is_scheduled()const { return trx_type == transaction_metadata::trx_type::scheduled; };
          bool has_undo()const;
 
          int64_t set_proposed_producers(vector<producer_authority> producers);

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -164,7 +164,14 @@ struct eosvmoc_tier {
             }
          }
 #endif
-         const bool allow_oc_interrupt = attempt_tierup && context.is_applying_block() && context.trx_context.has_undo();
+         // Do not allow oc interrupt if no undo as the transaction needs to be undone to restart it.
+         // Do not allow oc interrupt if implicit or scheduled. There are two implicit trxs: onblock and onerror.
+         //   The onerror trx of deferred trxs is implicit. Interrupt needs to be disabled for deferred trxs because
+         //   they capture all exceptions, explicitly handle undo stack, and directly call trx_context.execute_action.
+         //   Not allowing interrupt for onblock seems rather harmless, so instead of distinguishing between onerror and
+         //   onblock, just disallow for all implicit.
+         const bool allow_oc_interrupt = attempt_tierup && context.is_applying_block() &&
+                                         context.trx_context.has_undo() && !context.trx_context.is_implicit() && !context.trx_context.is_scheduled();
          auto ex = fc::make_scoped_exit([&]() {
             if (allow_oc_interrupt) {
                eos_vm_oc_compile_interrupt = false;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -59,6 +59,7 @@ namespace eosio::chain {
       undo();
       *trace = transaction_trace{}; // reset trace
       initialize();
+      transaction_timer.stop();
       resume_billing_timer(start);
 
       auto sw = executed_action_receipts.store_which();

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
@@ -231,7 +231,6 @@ void executor::execute(const code_descriptor& code, memory& mem, apply_context& 
       syscall(SYS_mprotect, self->code_mapping, self->code_mapping_size, PROT_NONE);
       self->mapping_is_executable = false;
    }, this);
-   context.trx_context.checktime(); //catch any expiration that might have occurred before setting up callback
 
    auto cleanup = fc::make_scoped_exit([cb, &tt=context.trx_context.transaction_timer, &mem=mem](){
       cb->is_running = false;
@@ -244,6 +243,8 @@ void executor::execute(const code_descriptor& code, memory& mem, apply_context& 
                   (cb->current_linear_memory_pages - base_pages) * eosio::chain::wasm_constraints::wasm_page_size, PROT_NONE);
       }
    });
+
+   context.trx_context.checktime(); //catch any expiration that might have occurred before setting up callback
 
    void(*apply_func)(uint64_t, uint64_t, uint64_t) = (void(*)(uint64_t, uint64_t, uint64_t))(cb->running_code_base + code.apply_offset);
 


### PR DESCRIPTION
Currently with #1027 a long running trx is interrupted when the oc compile completes. This causes an issue with deferred trx processing in old blocks where deferred trxs exist. Disable interrupt of transaction when oc compile completes for implicit transactions. Implicit transactions include deferred `onerror` and `onblock`. Not interrupting `onblock` seems like an ok thing here as `onblock` is part of the main system contract.

Also stop() timer on oc interrupt so start() is always called on a stopped timer.
Also call `checktime()` after setup of cleanup in eos-vm-oc so that `set_expiration_callback(nullptr, nullptr);` is called on `checktime` exception.

chicken-dance mismatch still on this branch which is being tracked by https://github.com/AntelopeIO/spring/issues/1152

Merges `release/1.1` into `main` including #1150 

Resolves #1145 