### PR TITLE
[1.1.0] Do not allow replay-blockchain without snapshot

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -511,8 +511,8 @@ namespace eosio { namespace chain {
                head = {};
          }
 
-         static block_log_preamble extract_block_log_preamble(const std::filesystem::path& block_dir,
-                                                              const std::filesystem::path& retained_dir);
+         static std::optional<block_log_preamble> extract_block_log_preamble(const std::filesystem::path& block_dir,
+                                                                             const std::filesystem::path& retained_dir);
       }; // block_log_impl
 
       /// Would remove pre-existing block log and index, never write blocks into disk.
@@ -1462,8 +1462,8 @@ namespace eosio { namespace chain {
    }
 
    // static
-   block_log_preamble detail::block_log_impl::extract_block_log_preamble(const std::filesystem::path& block_dir,
-                                                                         const std::filesystem::path& retained_dir) {
+   std::optional<block_log_preamble> detail::block_log_impl::extract_block_log_preamble(const std::filesystem::path& block_dir,
+                                                                                        const std::filesystem::path& retained_dir) {
       std::filesystem::path first_block_file;
       if (!retained_dir.empty() && std::filesystem::exists(retained_dir)) {
          for_each_file_in_dir_matches(retained_dir, R"(blocks-1-\d+\.log)",
@@ -1501,7 +1501,11 @@ namespace eosio { namespace chain {
    // static
    std::optional<block_log::chain_context> block_log::extract_chain_context(const std::filesystem::path& block_dir,
                                                                             const std::filesystem::path& retained_dir) {
-      return detail::block_log_impl::extract_block_log_preamble(block_dir, retained_dir).chain_context;
+      auto preamble = detail::block_log_impl::extract_block_log_preamble(block_dir, retained_dir);
+      if (preamble) {
+         return preamble->chain_context;
+      }
+      return {};
    }
 
    // static
@@ -1528,7 +1532,11 @@ namespace eosio { namespace chain {
    // static
    uint32_t block_log::extract_first_block_num(const std::filesystem::path& block_dir,
                                                const std::filesystem::path& retained_dir) {
-      return detail::block_log_impl::extract_block_log_preamble(block_dir, retained_dir).first_block_num;
+      auto preamble = detail::block_log_impl::extract_block_log_preamble(block_dir, retained_dir);
+      if (preamble) {
+         return preamble->first_block_num;
+      }
+      return 0;
    }
 
    // static

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -505,8 +505,8 @@ namespace eosio::chain {
       auto first_branch = (first == root->id()) ? root : get_block_impl(first);
       auto second_branch = (second == root->id()) ? root : get_block_impl(second);
 
-      EOS_ASSERT(first_branch, fork_db_block_not_found, "block ${id} does not exist", ("id", first));
-      EOS_ASSERT(second_branch, fork_db_block_not_found, "block ${id} does not exist", ("id", second));
+      EOS_ASSERT(first_branch, fork_db_block_not_found, "block #${n} ${id} does not exist", ("n", block_header::num_from_id(first))("id", first));
+      EOS_ASSERT(second_branch, fork_db_block_not_found, "block #${n} ${id} does not exist", ("n", block_header::num_from_id(second))("id", second));
 
       while( first_branch->block_num() > second_branch->block_num() )
       {

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -95,6 +95,9 @@ namespace eosio { namespace chain {
          extract_chain_id(const std::filesystem::path& data_dir,
                           const std::filesystem::path& retained_dir = std::filesystem::path{});
 
+         static uint32_t extract_first_block_num(const std::filesystem::path& block_dir,
+                                                 const std::filesystem::path& retained_dir = std::filesystem::path{});
+
          static void construct_index(const std::filesystem::path& block_file_name, const std::filesystem::path& index_file_name);
 
          static bool contains_genesis_state(uint32_t version, uint32_t first_block_num);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -778,6 +778,11 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
          ilog( "Replay requested: deleting state database" );
          if( options.at( "truncate-at-block" ).as<uint32_t>() > 0 )
             wlog( "The --truncate-at-block option does not work for a regular replay of the blockchain." );
+         if (!options.count( "snapshot" )) {
+            auto first_block = block_log::extract_first_block_num(blocks_dir, retained_dir);
+            EOS_ASSERT(first_block == 1, plugin_config_exception,
+                       "replay-blockchain without snapshot requested without a full block log, first block: ${n}", ("n", first_block));
+         }
          clear_directory_contents( chain_config->state_dir );
       } else if( options.at( "truncate-at-block" ).as<uint32_t>() > 0 ) {
          wlog( "The --truncate-at-block option can only be used with --hard-replay-blockchain." );


### PR DESCRIPTION
Do not allow `--replay-blockchain` option without `--snapshot` option unless a full block log is available as it will fail and leave the blockchain in a non-recoverable state.

While attempting to reproduce #1152, I kicked off a `--replay-blockchain` but forgot to add the `--snapshot` option. I didn't have a full block log. This resulted in the following:

```
info  2025-02-08T13:32:56.675 nodeos    chain_plugin.cpp:778          plugin_initialize    ] Replay requested: deleting state database
info  2025-02-08T13:32:57.062 nodeos    chain_plugin.cpp:933          plugin_initialize    ] Starting fresh blockchain state using default genesis state.
...
info  2025-02-08T13:32:57.915 nodeos    listener.hpp:150              log_listening        ] start listening on 127.0.0.1:7777 resolved from 127.0.0.1:7777 for API categories: all
warn  2025-02-08T13:32:57.916 nodeos    controller.cpp:4379           apply_blocks         ] 3020001 fork_db_block_not_found: Block can not be found
block 000000017c8ae6fcc236a1254b032f9b375971d88025e717fcba43aeee9aa41a does not exist
    {"id":"000000017c8ae6fcc236a1254b032f9b375971d88025e717fcba43aeee9aa41a"}
    nodeos  fork_database.cpp:509 fetch_branch_from_impl

warn  2025-02-08T13:32:57.916 nodeos    controller.cpp:4379           apply_blocks         ] 3020001 fork_db_block_not_found: Block can not be found
block 000000017c8ae6fcc236a1254b032f9b375971d88025e717fcba43aeee9aa41a does not exist
    {"id":"000000017c8ae6fcc236a1254b032f9b375971d88025e717fcba43aeee9aa41a"}
    nodeos  fork_database.cpp:509 fetch_branch_from_impl

error 2025-02-08T13:32:57.916 nodeos    producer_plugin.cpp:949       on_incoming_block    ] Cannot recover from 3020001 fork_db_block_not_found: Block can not be found
block 000000017c8ae6fcc236a1254b032f9b375971d88025e717fcba43aeee9aa41a does not exist
    {"id":"000000017c8ae6fcc236a1254b032f9b375971d88025e717fcba43aeee9aa41a"}
    nodeos  fork_database.cpp:509 fetch_branch_from_impl
rethrow
    {}
    nodeos  controller.cpp:4380 apply_blocks
. Shutting down.
```

At this point the the state directory has to be removed and restart is required from the snapshot.
