### PR TITLE
[1.1.0 -> main] Fix account billing on eos-vm-oc interrupt

### DIFF
--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -64,7 +64,7 @@ namespace eosio::chain {
 
       auto sw = executed_action_receipts.store_which();
       executed_action_receipts = action_digests_t{sw};
-      bill_to_accounts.clear();
+      // bill_to_accounts should only be updated in init(), not updated during transaction execution
       validate_ram_usage.clear();
    }
 


### PR DESCRIPTION
Do not clear `bill_to_accounts` in `transaction_context::reset()` as `bill_to_accounts` is only modified during `transaction_context::init()`. This `clear()` was causing accounts to not be billed for CPU/NET when the transaction was interrupted by oc compile. This difference in recorded resource usage caused a difference in the integrity hash between a node that was interrupted vs one that was not.

Clean chicken-dance run with this PR.

Merges `release/1.1` into `main` including #1160 

Resolves #1152