### PR TITLE
[1.1.0] disable boringssl debug symbols on release builds; restore reproducible builds in CI

### DIFF
--- a/libraries/libfc/libraries/boringssl/CMakeLists.txt
+++ b/libraries/libfc/libraries/boringssl/CMakeLists.txt
@@ -3,6 +3,13 @@ target_compile_options(fipsmodule PRIVATE -Wno-error)
 target_compile_options(crypto PRIVATE -Wno-error)
 target_compile_options(decrepit PRIVATE -Wno-error)
 
+# boringssl's forced-on debug symbols interfere with reproducibility due to path differences; disable on Release builds
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+   target_compile_options(fipsmodule PRIVATE -g0)
+   target_compile_options(crypto PRIVATE -g0)
+   target_compile_options(decrepit PRIVATE -g0)
+endif()
+
 #paranoia for when a dependent library depends on openssl (such as libcurl)
 set_target_properties(fipsmodule PROPERTIES C_VISIBILITY_PRESET hidden)
 set_target_properties(crypto PROPERTIES C_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
boringssl's upstream cmake file always adds `-ggdb` to the compile which damages our reproducibility due to a path difference. We might want to rectify the path difference if possible and/or masquerade the difference via compiler options, but disabling the debug symbol generation is far easier by negating the `-ggdb` with `-g0`