### PR TITLE
[1.1.0] Test: Use EOS mainnet chain values for integration tests

### DIFF
--- a/tests/TestHarness/launcher.py
+++ b/tests/TestHarness/launcher.py
@@ -359,22 +359,22 @@ class cluster_generator:
                         'initial_key': self.network.nodes['bios'].keys[0].pubkey,
                         'initial_configuration': {
                             'max_block_net_usage': 1048576,
-                            'target_block_net_usage_pct': 1000,
+                            'target_block_net_usage_pct': 10000,
                             'max_transaction_net_usage': 524288,
                             'base_per_transaction_net_usage': 12,
                             'net_usage_leeway': 500,
                             'context_free_discount_net_usage_num': 20,
                             'context_free_discount_net_usage_den': 100,
-                            'max_block_cpu_usage': 500000 if self.args.max_block_cpu_usage is None else self.args.max_block_cpu_usage,
-                            'target_block_cpu_usage_pct': 1000,
+                            'max_block_cpu_usage': 200000 if self.args.max_block_cpu_usage is None else self.args.max_block_cpu_usage,
+                            'target_block_cpu_usage_pct': 10,
                             'max_transaction_cpu_usage': 150000 if self.args.max_transaction_cpu_usage is None else self.args.max_transaction_cpu_usage,
                             'min_transaction_cpu_usage': 100,
                             'max_transaction_lifetime': 3600,
                             'deferred_trx_expiration_window': 600,
                             'max_transaction_delay': 3888000,
-                            'max_inline_action_size': 524288,
-                            'max_inline_action_depth': 4,
-                            'max_authority_depth': 6
+                            'max_inline_action_size': 524287,
+                            'max_inline_action_depth': 10,
+                            'max_authority_depth': 10
                         }
                     }
         else:

--- a/tests/TestHarness/launcher.py
+++ b/tests/TestHarness/launcher.py
@@ -324,7 +324,7 @@ class cluster_generator:
         }.get(self.args.shape, self.make_custom)()
 
         if not self.args.nogen:
-            genesis = selfinit_genesis()
+            genesis = self.init_genesis()
             for node_name, node in self.network.nodes.items():
                 node.config_dir_name.mkdir(parents=True, exist_ok=True)
                 self.write_logging_config_file(node)

--- a/tests/TestHarness/launcher.py
+++ b/tests/TestHarness/launcher.py
@@ -324,7 +324,7 @@ class cluster_generator:
         }.get(self.args.shape, self.make_custom)()
 
         if not self.args.nogen:
-            genesis = self.init_genesis()
+            genesis = selfinit_genesis()
             for node_name, node in self.network.nodes.items():
                 node.config_dir_name.mkdir(parents=True, exist_ok=True)
                 self.write_logging_config_file(node)
@@ -367,7 +367,7 @@ class cluster_generator:
                             'context_free_discount_net_usage_den': 100,
                             'max_block_cpu_usage': 500000 if self.args.max_block_cpu_usage is None else self.args.max_block_cpu_usage,
                             'target_block_cpu_usage_pct': 1000,
-                            'max_transaction_cpu_usage': 475000 if self.args.max_transaction_cpu_usage is None else self.args.max_transaction_cpu_usage,
+                            'max_transaction_cpu_usage': 150000 if self.args.max_transaction_cpu_usage is None else self.args.max_transaction_cpu_usage,
                             'min_transaction_cpu_usage': 100,
                             'max_transaction_lifetime': 3600,
                             'deferred_trx_expiration_window': 600,


### PR DESCRIPTION
The prior `max_transaction_cpu_usage` of 475ms allowed for very long running speculative transactions. These could cause delays which, in some cases, would be long enough for a test to timeout. See #1151 for details.

To avoid other possible differences in tests and real-world, set all genesis values of integration tests to the current EOS mainnet values.

### EOS Mainnet eosio global table values
https://eosauthority.com/account/eosio?network=eos&scope=eosio&table=global&limit=10&index_position=1&key_type=i64&reverse=0&mode=contract&sub=tables

| max\_block\_net\_usage | target\_block\_net\_usage\_pct | max\_transaction\_net\_usage | base\_per\_transaction\_net\_usage | net\_usage\_leeway | context\_free\_discount\_net\_usage\_num | context\_free\_discount\_net\_usage\_den | max\_block\_cpu\_usage | target\_block\_cpu\_usage\_pct | max\_transaction\_cpu\_usage | min\_transaction\_cpu\_usage | max\_transaction\_lifetime | deferred\_trx\_expiration\_window | max\_transaction\_delay | max\_inline\_action\_size | max\_inline\_action\_depth | max\_authority\_depth |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1048576 | 10000 | 524288 | 12 | 500 | 20 | 100 | 200000 | 10 | 150000 | 100 | 3600 | 600 | 3888000 | 524287 | 10 | 10 |



Resolves #1151