### PR TITLE
Switch to using `eos-system-contracts` in libtester tests

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -3,7 +3,7 @@
        "target":"4.1",
        "prerelease":true
     },
-    "referencecontracts":{
-       "ref":"main"
+    "eossystemcontracts":{
+       "ref":"release/3.2"
     }
  }

--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -4,6 +4,6 @@
        "prerelease":true
     },
     "eossystemcontracts":{
-       "ref":"release/3.2"
+       "ref":"main"
     }
  }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,8 +18,8 @@ on:
         - default
         - true
         - false
-      override-reference-contracts:
-        description: 'Override reference contracts ref'
+      override-eos-system-contracts:
+        description: 'Override eos-system-contracts ref'
         type: string
 
 permissions:
@@ -57,9 +57,9 @@ jobs:
     outputs:
       cdt-target: ${{steps.versions.outputs.cdt-target}}
       cdt-prerelease: ${{steps.versions.outputs.cdt-prerelease}}
-      reference-contracts-ref: ${{steps.versions.outputs.reference-contracts-ref}}
+      eos-system-contracts-ref: ${{steps.versions.outputs.eos-system-contracts-ref}}
     steps:
-      - name: Setup cdt and reference-contracts versions
+      - name: Setup cdt and eos-system-contracts versions
         id: versions
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -67,7 +67,7 @@ jobs:
           DEFAULTS_JSON=$(curl -sSfL $(gh api https://api.github.com/repos/${{github.repository}}/contents/.cicd/defaults.json?ref=${{github.sha}} --jq .download_url))
           echo cdt-target=$(echo "$DEFAULTS_JSON" | jq -r '.cdt.target') >> $GITHUB_OUTPUT
           echo cdt-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '.cdt.prerelease') >> $GITHUB_OUTPUT
-          echo reference-contracts-ref=$(echo "$DEFAULTS_JSON" | jq -r '.referencecontracts.ref') >> $GITHUB_OUTPUT
+          echo eos-system-contracts-ref=$(echo "$DEFAULTS_JSON" | jq -r '.eossystemcontracts.ref') >> $GITHUB_OUTPUT
 
           if [[ "${{inputs.override-cdt}}" != "" ]]; then
             echo cdt-target=${{inputs.override-cdt}} >> $GITHUB_OUTPUT
@@ -75,8 +75,8 @@ jobs:
           if [[ "${{inputs.override-cdt-prerelease}}" == +(true|false) ]]; then
             echo cdt-prerelease=${{inputs.override-cdt-prerelease}} >> $GITHUB_OUTPUT
           fi
-          if [[ "${{inputs.override-reference-contracts}}" != "" ]]; then
-            echo reference-contracts-ref=${{inputs.override-reference-contracts}} >> $GITHUB_OUTPUT
+          if [[ "${{inputs.override-eos-system-contracts}}" != "" ]]; then
+            echo eos-system-contracts-ref=${{inputs.override-eos-system-contracts}} >> $GITHUB_OUTPUT
           fi
 
   package:
@@ -328,21 +328,21 @@ jobs:
           rm ./*.deb
 
       # Reference Contracts
-      - name: checkout reference-contracts
+      - name: checkout eos-system-contracts
         uses: actions/checkout@v4
         with:
-          repository: AntelopeIO/reference-contracts
-          path: reference-contracts
-          ref: '${{needs.v.outputs.reference-contracts-ref}}'
+          repository: eosnetworkfoundation/eos-system-contracts
+          path: eos-system-contracts
+          ref: '${{needs.v.outputs.eos-system-contracts-ref}}'
       - if: ${{ matrix.test == 'deb-install' }}
-        name: Install reference-contracts deps
+        name: Install eos-system-contracts deps
         run: |
           apt-get -y install cmake build-essential
-      - name: Build & Test reference-contracts
+      - name: Build & Test eos-system-contracts
         run: |
-          cmake -S reference-contracts -B reference-contracts/build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=On -DSYSTEM_ENABLE_SPRING_VERSION_CHECK=Off -DSYSTEM_ENABLE_CDT_VERSION_CHECK=Off
-          cmake --build reference-contracts/build -- -j $(nproc)
-          cd reference-contracts/build/tests
+          cmake -S eos-system-contracts -B eos-system-contracts/build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=On -DSYSTEM_ENABLE_SPRING_VERSION_CHECK=Off -DSYSTEM_ENABLE_CDT_VERSION_CHECK=Off
+          cmake --build eos-system-contracts/build -- -j $(nproc)
+          cd eos-system-contracts/build/tests
           ctest --output-on-failure -j $(nproc)
 
   all-passing:


### PR DESCRIPTION
Resolves #1177.

Now that we are not updating the `reference-contracts` repo anymore, switch the libtester tests to using `eos-system-contracts`.

This reverts commit 3fdc35407f9eb3ee2b08e4982052629123a5ce6a.