### PR TITLE
[1.1.0 -> main] Test: Determine the failure of lib_advance_test using the number of unique unlinkable blocks

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -731,6 +731,30 @@ class Node(Transactions):
         else:
             return True
 
+    # Returns the number of unique unlinkable blocks in stderr.txt.
+    def numUniqueUnlinkableBlocks(self) -> int:
+        dataDir = Utils.getNodeDataDir(self.nodeId)
+        logFile = dataDir + "/stderr.txt"
+
+        pattern = re.compile(r"unlinkable_block\s(\d+)")
+
+        # Use set for uniqueness, as the same block can be unlinkable multiple
+        # times due to multiple connections.
+        uniqueBlocks = set()
+        with open(logFile, 'r') as f:
+            for line in f:
+                match = pattern.search(line)
+                if match:
+                    try:
+                        blockNum = int(match.group(1))
+                        uniqueBlocks.add(blockNum)
+                    except ValueError:
+                        Utils.Print(f"unlinkable block number cannot be converted into integer: in {line.strip()} of {f}")
+                        assert(False)  # Cannot happen. Fail the test.
+        numUnlinkableBlocks = len(uniqueBlocks)
+        Utils.Print(f"Number of unique unlinkable blocks: {numUnlinkableBlocks}")
+        return numUnlinkableBlocks
+
     # Verify that we have only one "Starting block" in the log for any block number unless:
     # - the block was restarted because it was exhausted,
     # - or the second "Starting block" is for a different block time than the first.

--- a/tests/lib_advance_test.py
+++ b/tests/lib_advance_test.py
@@ -143,11 +143,9 @@ try:
 
     # instant finality does not drop late blocks, but can still get unlinkable when syncing and getting a produced block
     allowedUnlinkableBlocks = afterBlockNum-beforeBlockNum
-    logFile = Utils.getNodeDataDir(prodNode3.nodeId) + "/stderr.txt"
-    f = open(logFile)
-    contents = f.read()
-    if contents.count("unlinkable_block") > (allowedUnlinkableBlocks):
-        errorExit(f"Node{prodNode3.nodeId} has more than {allowedUnlinkableBlocks} unlinkable blocks: {logFile}.")
+    numUnlinkableBlocks = prodNode3.numUniqueUnlinkableBlocks()
+    if numUnlinkableBlocks > allowedUnlinkableBlocks:
+        errorExit(f"Node{prodNode3.nodeId} has {numUnlinkableBlocks} unlinkable blocks which is more than allowed {allowedUnlinkableBlocks}.")
 
     testSuccessful=True
 finally:


### PR DESCRIPTION


`lib_advance_test` checks number of unlinkable blocks in `stderr.txt` to decide whethere the test fails or not. It scans `stderr.txt`, inserts any `unlinkable_block` it finds into a list, and uses the number of elements in the list as the number of unlinkable blocks. But the same unlinkable block can appear in `stderr.txt` multiple times due to multiple connections or repeated syncing:
```
debug 2025-02-10T18:01:07.023 net-3     net_plugin.cpp:3967           operator()           ] unlinkable_block 174 : 000000aedde07ade58031c2926de9c9ead20c35025d53ea973e50841c71504b0, previous 173 : 000000ad3ccc782661621ba4ea215907e103efaa8fe29b737a9c7910c118fed9
...
debug 2025-02-10T18:01:07.025 net-3     net_plugin.cpp:3967           operator()           ] unlinkable_block 174 : 000000aedde07ade58031c2926de9c9ead20c35025d53ea973e50841c71504b0, previous 173 : 000000ad3ccc782661621ba4ea215907e103efaa8fe29b737a9c7910c118fed9
```
That causes the same unlinkable block to be counted multiple times.

The fix is to count the number of the unique unlinkable blocks.

Merges release/1.1 into main including https://github.com/AntelopeIO/spring/pull/1174

Resolves https://github.com/AntelopeIO/spring/issues/1157