### PR TITLE
[1.1.1] fix flat to pruned block log conversion

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -1160,6 +1160,7 @@ namespace eosio { namespace chain {
             // convert from  non-pruned block log to pruned if necessary
             if (!preamble.is_currently_pruned()) {
                block_file.open(fc::cfile::update_rw_mode);
+               index_file.open(fc::cfile::update_rw_mode);
                update_head(read_head());
                first_block_number = preamble.first_block_num;
                // need to convert non-pruned log to pruned log. prune any blocks to start with

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -597,7 +597,7 @@ namespace eosio { namespace chain {
                uint64_t pos = block_file.tellp();
 
                EOS_ASSERT(index_file.tellp() == sizeof(uint64_t) * (b->block_num() - preamble.first_block_num),
-                          block_log_append_fail, "Append to index file occuring at wrong position.",
+                          block_log_append_fail, "Append to index file occurring at wrong position.",
                           ("position", (uint64_t)index_file.tellp())(
                                 "expected", (b->block_num() - preamble.first_block_num) * sizeof(uint64_t)));
                block_file.write(packed_block.data(), packed_block.size());

--- a/tests/block_log.cpp
+++ b/tests/block_log.cpp
@@ -643,4 +643,26 @@ BOOST_DATA_TEST_CASE(empty_prune_to_partitioned_transitions, bdata::xrange(1, 11
 
 }  FC_LOG_AND_RETHROW() }
 
+//This test adds "a lot" more blocks to the log before transitioning from flat to pruned.
+BOOST_DATA_TEST_CASE(nonprune_to_prune_on_start, bdata::make({1, 1500}) * bdata::make({10, 50}), starting_block, prune_blocks)  { try {
+   //start non pruned
+   block_log_fixture t(true, true, false, std::optional<uint32_t>());
+   t.startup(starting_block);
+
+   const unsigned num_blocks_to_add = prune_blocks*3;
+   unsigned next_block = starting_block == 1 ? 2 : starting_block;
+   for(unsigned i = 0; i < prune_blocks*3; ++i)
+      t.add(next_block++, payload_size(), 'z');
+   t.check_n_bounce([&]() {});
+
+   //now switch over to pruned mode
+   t.prune_blocks = prune_blocks;
+   t.check_n_bounce([&]() {});
+
+   if(starting_block == 1)
+      t.check_range_present(num_blocks_to_add-prune_blocks+2, next_block-1);
+   else
+      t.check_range_present(starting_block+num_blocks_to_add-prune_blocks, next_block-1);
+}  FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Conversion of non-trivially long block logs from flat to pruned has been broken for quite some time. I suspect as early as leap 4.0 via AntelopeIO/leap#532. Unfortunately despite there being a lot of tests around pruned logs, none of them were "big" enough to stumble on the problem because they'd effectively only prune new entries -- not existing entries. A new test has been added that adds enough blocks to demonstrate the failure. And the fix is as simple as ensuring the blog index is opened before performing pruning.

Combination of simple fix + reported in wild: should go to stable.