### PR TITLE
[1.1.1] Revert "P2P: Fix duplication connection logic #1108"

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3413,6 +3413,7 @@ namespace eosio {
       peer_fork_db_head_block_num = msg.fork_db_head_num;
       fc::unique_lock g_conn( conn_mtx );
       last_handshake_recv = msg;
+      auto c_time = last_handshake_sent.time;
       g_conn.unlock();
 
       set_state(connection_state::connected);
@@ -3456,7 +3457,35 @@ namespace eosio {
                fc::unique_lock g_check_conn( check->conn_mtx );
                fc_dlog( logger, "dup check: connected ${c}, ${l} =? ${r}",
                         ("c", check->connected())("l", check->last_handshake_recv.node_id)("r", msg.node_id) );
-               return check->connected() && check->last_handshake_recv.node_id == msg.node_id;
+               if(check->connected() && check->last_handshake_recv.node_id == msg.node_id) {
+                  if (net_version < proto_dup_goaway_resolution || msg.network_version < proto_dup_goaway_resolution) {
+                     // It's possible that both peers could arrive here at relatively the same time, so
+                     // we need to avoid the case where they would both tell a different connection to go away.
+                     // Using the sum of the initial handshake times of the two connections, we will
+                     // arbitrarily (but consistently between the two peers) keep one of them.
+
+                     auto check_time = check->last_handshake_sent.time + check->last_handshake_recv.time;
+                     g_check_conn.unlock();
+                     if (msg.time + c_time <= check_time)
+                        return false;
+                  } else if (net_version < proto_dup_node_id_goaway || msg.network_version < proto_dup_node_id_goaway) {
+                     if (listen_address < msg.p2p_address) {
+                        fc_dlog( logger, "listen_address '${lhs}' < msg.p2p_address '${rhs}'",
+                                 ("lhs", listen_address)( "rhs", msg.p2p_address ) );
+                        // only the connection from lower p2p_address to higher p2p_address will be considered as a duplicate,
+                        // so there is no chance for both connections to be closed
+                        return false;
+                     }
+                  } else if (my_impl->node_id < msg.node_id) {
+                     fc_dlog( logger, "not duplicate, my_impl->node_id '${lhs}' < msg.node_id '${rhs}'",
+                              ("lhs", my_impl->node_id)("rhs", msg.node_id) );
+                     // only the connection from lower node_id to higher node_id will be considered as a duplicate,
+                     // so there is no chance for both connections to be closed
+                     return false;
+                  }
+                  return true;
+               }
+               return false;
             };
             if (my_impl->connections.any_of_connections(std::move(is_duplicate))) {
                peer_dlog( this, "sending go_away duplicate, msg.p2p_address: ${add}", ("add", msg.p2p_address) );


### PR DESCRIPTION
Reverts #1108 

The simplified de-dup logic of #1108 allows for both sides to determine the other is duplicate if the connections happen at the same time. The previous more complicated logic does allow duplicate connections in about half the cases, but prevents the race-condition of both sides deciding the other is a duplicate.

I wonder with the new block-nack feature and future limit of connections if we should even attempt to remove duplicate connections. In one sense, it seems like if a user wants to configure both sides to connect to each other that we should just allow it. It is obviously an important connection. Also all the reconnects and determination of duplicate and disconnect is in itself wasteful.

Note the previous version support here is not really needed, but just kept this as a straight revert.