### PR TITLE
Fix a warning of comparison of integer expressions of different signedness in nonprune_to_prune_on_start test

### DIFF
--- a/tests/block_log.cpp
+++ b/tests/block_log.cpp
@@ -652,7 +652,7 @@ BOOST_DATA_TEST_CASE(nonprune_to_prune_on_start, bdata::make({1, 1500}) * bdata:
 
    const unsigned num_blocks_to_add = prune_blocks*3;
    unsigned next_block = starting_block == 1 ? 2 : starting_block;
-   for(unsigned i = 0; i < prune_blocks*3; ++i)
+   for(auto i = 0; i < prune_blocks*3; ++i)
       t.add(next_block++, payload_size(), 'z');
    t.check_n_bounce([&]() {});
 


### PR DESCRIPTION
Fix
```
/home/lh/work/warning/tests/block_log.cpp:655:26: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
  655 |    for(unsigned i = 0; i < prune_blocks*3; ++i)
```