### PR TITLE
[1.1.1] Fix get_info available on non-chain API endpoints

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -127,7 +127,7 @@ void chain_api_plugin::plugin_startup() {
 
    // Run get_info on http thread only
    _http_plugin.add_async_api({
-      CHAIN_RO_CALL_WITH_400(get_info, 200, http_params_types::no_params)
+      CALL_WITH_400(chain, node, ro_api, chain_apis::read_only, get_info, 200, http_params_types::no_params)
    });
 
    _http_plugin.add_api({

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -128,8 +128,12 @@ class PluginHttpTest(unittest.TestCase):
         command = "get_info"
         endpoint=self.endpoint("chain_ro")
 
-        # get_info without parameter
+        # get_info without parameter with default chain_ro endpoint
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
+        self.assertIn("server_version", ret_json["payload"])
+        # get_info without parameter with an endpoint (catelog) other than chain_ro
+        # get_info should work on any end point
+        ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=self.endpoint("producer_ro"))
         self.assertIn("server_version", ret_json["payload"])
         # get_info with empty content parameter
         ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -1637,7 +1637,12 @@ if __name__ == "__main__":
     sys.argv[1:] = args.unittest_args
     suite = unittest.TestLoader().loadTestsFromTestCase(PluginHttpTest)
     results = unittest.TextTestRunner().run(suite)
+    testSuccessful = True
     if not results.wasSuccessful():
         keepLogs = True
+        testSuccessful = False
     if not keepLogs:
         PluginHttpTest().cleanEnv()
+
+    exitCode = 0 if testSuccessful else 1
+    exit(exitCode)


### PR DESCRIPTION
`get_info` was mistakenly removed from `node` category (https://github.com/AntelopeIO/spring/pull/920) and caused it not available on non-chain API endpoints

This PR
* Moves it back to `node` category
* Fixes a bug of `plugin_http_api_test` that it does not exit with an exit value. That causes `plugin_http_api_test` to always appear successful even though it fails
* Add a test of `get_info` on non-chain API endpoint

Resolves https://github.com/AntelopeIO/spring/issues/1194