### PR TITLE
[1.1.3] P2P: Fix node stuck in head catchup

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2616,10 +2616,12 @@ namespace eosio {
             g_cp_conn.unlock();
             if( fork_db_head_id == null_id ) {
                // continue
-            } else if( c && (fork_db_head_num < blk_num || fork_db_head_id == blk_id) ) {
-               fc::lock_guard g_conn( c->conn_mtx );
-               c->conn_fork_db_head = null_id;
-               c->conn_fork_db_head_num = 0;
+            } else if( fork_db_head_num < blk_num || fork_db_head_id == blk_id ) {
+               if (c) {
+                  fc::lock_guard g_conn( c->conn_mtx );
+                  c->conn_fork_db_head = null_id;
+                  c->conn_fork_db_head_num = 0;
+               }
             } else {
                set_state_to_head_catchup = true;
             }


### PR DESCRIPTION
#688 introduced an incorrect handling of null connection when determining node catchup state.

Resolves #1239 