### PR TITLE
P2P: Update p2p-auto-bp-peer for Savanna

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -7,11 +7,8 @@
 namespace eosio::auto_bp_peering {
 
 ///
-/// This file implements the functionality for block producers automatically establishing p2p connections to their
-/// neighbors on the producer schedule.
+/// This file implements the functionality for block producers automatically establishing p2p connections to other bps.
 ///
-
-
 
 template <typename Derived, typename Connection>
 class bp_connection_manager {
@@ -31,8 +28,8 @@ class bp_connection_manager {
    } config; // thread safe only because modified at plugin startup currently
 
    // the following member are only accessed from main thread
-   flat_set<account_name> pending_neighbors;
-   flat_set<account_name> active_neighbors;
+   flat_set<account_name> pending_configured_bps;
+   flat_set<account_name> active_configured_bps;
    uint32_t               pending_schedule_version = 0;
    uint32_t               active_schedule_version  = 0;
 
@@ -44,56 +41,21 @@ class bp_connection_manager {
       return boost::algorithm::join(peers | boost::adaptors::transformed([](auto& p) { return p.to_string(); }), ",");
    }
 
-   class neighbor_finder_type {
-
-      const config_t&                               config;
-      const std::vector<chain::producer_authority>& schedule;
-      chain::flat_set<std::size_t>                  my_schedule_indices;
-
-    public:
-      neighbor_finder_type(const config_t& config,
-                           const std::vector<chain::producer_authority>& schedule)
-          : config(config), schedule(schedule) {
-         for (auto account : config.my_bp_accounts) {
-            auto itr = std::find_if(schedule.begin(), schedule.end(),
-                                    [account](auto& e) { return e.producer_name == account; });
-            if (itr != schedule.end())
-               my_schedule_indices.insert(itr - schedule.begin());
+   // Only called from main thread
+   chain::flat_set<account_name> configured_bp_accounts(const config_t& config,
+                                                        const std::vector<chain::producer_authority>& schedule) const
+   {
+      chain::flat_set<account_name> result;
+      for (const auto& auth : schedule) {
+         if (config.bp_peer_addresses.contains(auth.producer_name)) {
+            result.insert(auth.producer_name);
          }
       }
-
-      void add_neighbors_with_distance(chain::flat_set<account_name>& result, int distance) const {
-         for (auto schedule_index : my_schedule_indices) {
-            auto i = (schedule_index + distance) % schedule.size();
-            if (!my_schedule_indices.count(i)) {
-               auto name = schedule[i].producer_name;
-               if (config.bp_peer_addresses.count(name))
-                  result.insert(name);
-            }
-         }
-      }
-
-      flat_set<account_name> downstream_neighbors() const {
-         chain::flat_set<account_name> result;
-         for (std::size_t i = 0; i < proximity_count; ++i) { add_neighbors_with_distance(result, i + 1); }
-         return result;
-      }
-
-      void add_upstream_neighbors(chain::flat_set<account_name>& result) const {
-         for (std::size_t i = 0; i < proximity_count; ++i) { add_neighbors_with_distance(result, -1 - i); }
-      }
-
-      flat_set<account_name> neighbors() const {
-         flat_set<account_name> result = downstream_neighbors();
-         add_upstream_neighbors(result);
-         return result;
-      }
-   };
+      return result;
+   }
 
  public:
-   const static std::size_t proximity_count = 2;
-
-   bool auto_bp_peering_enabled() const { return config.bp_peer_addresses.size() && config.my_bp_accounts.size(); }
+   bool auto_bp_peering_enabled() const { return !config.bp_peer_addresses.empty(); }
 
    // Only called at plugin startup
    void set_producer_accounts(const std::set<account_name>& accounts) {
@@ -117,6 +79,7 @@ class bp_connection_manager {
 
             config.bp_peer_accounts[addr]     = account;
             config.bp_peer_addresses[account] = std::move(addr);
+            fc_dlog(self()->get_logger(), "Setting auto-bp-peer ${a} -> ${d}", ("a", account)("d", config.bp_peer_addresses[account]));
          }
       } catch (eosio::chain::name_type_exception&) {
          EOS_ASSERT(false, chain::plugin_config_exception, "the account supplied by --auto-bp-peer option is invalid");
@@ -168,66 +131,63 @@ class bp_connection_manager {
    }
 
    // Only called from main thread
-   neighbor_finder_type neighbor_finder(const std::vector<chain::producer_authority>& schedule) const {
-      return neighbor_finder_type(config, schedule);
-   }
-
-   // Only called from main thread
    void on_pending_schedule(const chain::producer_authority_schedule& schedule) {
+      fc_dlog(self()->get_logger(), "pending v ${v}, pending_configured_bps: ${a}", ("v", schedule.version)("a", to_string(pending_configured_bps)));
       if (auto_bp_peering_enabled() && self()->in_sync()) {
          if (schedule.producers.size()) {
             if (pending_schedule_version != schedule.version) {
-               /// establish connection to the BPs within our pending scheduling proximity
+               /// establish connection to our configured BPs, resolve_and_connect ignored if already connected
 
                fc_dlog(self()->get_logger(), "pending producer schedule switches from version ${old} to ${new}",
                        ("old", pending_schedule_version)("new", schedule.version));
 
-               auto finder                       = neighbor_finder(schedule.producers);
-               auto pending_downstream_neighbors = finder.downstream_neighbors();
+               auto pending_connections = configured_bp_accounts(config, schedule.producers);
 
-               fc_dlog(self()->get_logger(), "pending_downstream_neighbors: ${pending_downstream_neighbors}",
-                       ("pending_downstream_neighbors", to_string(pending_downstream_neighbors)));
-               for (auto neighbor : pending_downstream_neighbors) { self()->connections.resolve_and_connect(config.bp_peer_addresses[neighbor], self()->get_first_p2p_address() ); }
+               fc_dlog(self()->get_logger(), "pending_connections: ${c}", ("c", to_string(pending_connections)));
+               for (auto i : pending_connections) {
+                  self()->connections.resolve_and_connect(config.bp_peer_addresses[i], self()->get_first_p2p_address() );
+               }
 
-               pending_neighbors = std::move(pending_downstream_neighbors);
-               finder.add_upstream_neighbors(pending_neighbors);
+               pending_configured_bps = std::move(pending_connections);
 
                pending_schedule_version = schedule.version;
             }
          } else {
-            fc_dlog(self()->get_logger(), "pending producer schedule version ${v} has being cleared",
-                    ("v", schedule.version));
-            pending_neighbors.clear();
+            fc_dlog(self()->get_logger(), "pending producer schedule version ${v} has being cleared", ("v", schedule.version));
+            pending_configured_bps.clear();
          }
       }
    }
 
    // Only called from main thread
    void on_active_schedule(const chain::producer_authority_schedule& schedule) {
+      fc_dlog(self()->get_logger(), "v ${v}, active_configured_bps: ${a}", ("v", schedule.version)("a", to_string(active_configured_bps)));
       if (auto_bp_peering_enabled() && active_schedule_version != schedule.version && self()->in_sync()) {
          /// drops any BP connection which is no longer within our scheduling proximity
+         fc_dlog(self()->get_logger(), "active_configured_bps: ${a}", ("a", to_string(active_configured_bps)));
 
          fc_dlog(self()->get_logger(), "active producer schedule switches from version ${old} to ${new}",
                  ("old", active_schedule_version)("new", schedule.version));
 
-         auto old_neighbors = std::move(active_neighbors);
-         active_neighbors   = neighbor_finder(schedule.producers).neighbors();
+         auto old_bps = std::move(active_configured_bps);
+         active_configured_bps   = configured_bp_accounts(config, schedule.producers);
 
-         fc_dlog(self()->get_logger(), "active_neighbors: ${active_neighbors}",
-                 ("active_neighbors", to_string(active_neighbors)));
+         fc_dlog(self()->get_logger(), "active_configured_bps: ${a}", ("a", to_string(active_configured_bps)));
 
          flat_set<account_name> peers_to_stay;
-         std::set_union(active_neighbors.begin(), active_neighbors.end(), pending_neighbors.begin(),
-                        pending_neighbors.end(), std::inserter(peers_to_stay, peers_to_stay.begin()));
+         std::set_union(active_configured_bps.begin(), active_configured_bps.end(), pending_configured_bps.begin(), pending_configured_bps.end(),
+                        std::inserter(peers_to_stay, peers_to_stay.begin()));
 
-         fc_dlog(self()->get_logger(), "peers_to_stay: ${peers_to_stay}", ("peers_to_stay", to_string(peers_to_stay)));
+         fc_dlog(self()->get_logger(), "peers_to_stay: ${p}", ("p", to_string(peers_to_stay)));
 
          std::vector<account_name> peers_to_drop;
-         std::set_difference(old_neighbors.begin(), old_neighbors.end(), peers_to_stay.begin(), peers_to_stay.end(),
+         std::set_difference(old_bps.begin(), old_bps.end(), peers_to_stay.begin(), peers_to_stay.end(),
                              std::back_inserter(peers_to_drop));
-         fc_dlog(self()->get_logger(), "peers to drop: ${peers_to_drop}", ("peers_to_drop", to_string(peers_to_drop)));
+         fc_dlog(self()->get_logger(), "peers to drop: ${p}", ("p", to_string(peers_to_drop)));
 
-         for (auto account : peers_to_drop) { self()->connections.disconnect(config.bp_peer_addresses[account]); }
+         for (auto account : peers_to_drop) {
+            self()->connections.disconnect(config.bp_peer_addresses[account]);
+         }
          active_schedule_version = schedule.version;
       }
    }

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -132,7 +132,6 @@ class bp_connection_manager {
 
    // Only called from main thread
    void on_pending_schedule(const chain::producer_authority_schedule& schedule) {
-      fc_dlog(self()->get_logger(), "pending v ${v}, pending_configured_bps: ${a}", ("v", schedule.version)("a", to_string(pending_configured_bps)));
       if (auto_bp_peering_enabled() && self()->in_sync()) {
          if (schedule.producers.size()) {
             if (pending_schedule_version != schedule.version) {
@@ -161,11 +160,8 @@ class bp_connection_manager {
 
    // Only called from main thread
    void on_active_schedule(const chain::producer_authority_schedule& schedule) {
-      fc_dlog(self()->get_logger(), "v ${v}, active_configured_bps: ${a}", ("v", schedule.version)("a", to_string(active_configured_bps)));
       if (auto_bp_peering_enabled() && active_schedule_version != schedule.version && self()->in_sync()) {
          /// drops any BP connection which is no longer within our scheduling proximity
-         fc_dlog(self()->get_logger(), "active_configured_bps: ${a}", ("a", to_string(active_configured_bps)));
-
          fc_dlog(self()->get_logger(), "active producer schedule switches from version ${old} to ${new}",
                  ("old", active_schedule_version)("new", schedule.version));
 

--- a/plugins/net_plugin/tests/auto_bp_peering_unittest.cpp
+++ b/plugins/net_plugin/tests/auto_bp_peering_unittest.cpp
@@ -58,6 +58,16 @@ struct mock_net_plugin : eosio::auto_bp_peering::bp_connection_manager<mock_net_
    fc::logger get_logger() { return fc::logger::get(DEFAULT_LOGGER); }
 };
 
+const std::vector<std::string> peer_addresses{
+   "127.0.0.1:8001:blk"s, "127.0.0.1:8002:trx"s, "127.0.0.1:8003"s,
+   "127.0.0.1:8004"s, "127.0.0.1:8005"s, "127.0.0.1:8006"s, "127.0.0.1:8007"s,
+   "127.0.0.1:8008"s, "127.0.0.1:8009"s, "127.0.0.1:8010"s,
+   // prodk is intentionally skipped
+   "127.0.0.1:8012"s, "127.0.0.1:8013"s, "127.0.0.1:8014"s, "127.0.0.1:8015"s,
+   "127.0.0.1:8016"s, "127.0.0.1:8017"s, "127.0.0.1:8018"s, "127.0.0.1:8019"s,
+   // prodt is intentionally skipped
+   "127.0.0.1:8021"s};
+
 BOOST_AUTO_TEST_CASE(test_set_bp_peers) {
 
    mock_net_plugin plugin;
@@ -121,53 +131,30 @@ const eosio::chain::producer_authority_schedule test_schedule1{
    { { "proda"_n, {} }, { "prodb"_n, {} }, { "prodc"_n, {} }, { "prodd"_n, {} }, { "prode"_n, {} }, { "prodf"_n, {} },
      { "prodg"_n, {} }, { "prodh"_n, {} }, { "prodi"_n, {} }, { "prodj"_n, {} }, { "prodk"_n, {} }, { "prodl"_n, {} },
      { "prodm"_n, {} }, { "prodn"_n, {} }, { "prodo"_n, {} }, { "prodp"_n, {} }, { "prodq"_n, {} }, { "prodr"_n, {} },
-     { "prods"_n, {} }, { "prodt"_n, {} }, { "produ"_n, {} } }
+     { "prods"_n, {} }, /*{ "prodt"_n, {} },*/ { "produ"_n, {} } }
 };
 
 const eosio::chain::producer_authority_schedule test_schedule2{
    2,
    { { "proda"_n, {} }, { "prode"_n, {} }, { "prodi"_n, {} }, { "prodm"_n, {} }, { "prodp"_n, {} }, { "prods"_n, {} },
-     { "prodb"_n, {} }, { "prodf"_n, {} }, { "prodj"_n, {} }, { "prodn"_n, {} }, { "prodq"_n, {} }, { "prodt"_n, {} },
+     { "prodb"_n, {} }, { "prodf"_n, {} }, { "prodj"_n, {} }, { "prodn"_n, {} }, { "prodq"_n, {} }, /*{ "prodt"_n, {} },*/
      { "prodc"_n, {} }, { "prodg"_n, {} }, { "prodk"_n, {} }, { "prodo"_n, {} }, { "prodr"_n, {} }, { "produ"_n, {} },
      { "prodd"_n, {} }, { "prodh"_n, {} }, { "prodl"_n, {} } }
 };
 
+const fc::flat_set<eosio::chain::account_name> producers_minus_prodkt{
+   "proda"_n, "prodb"_n, "prodc"_n, "prodd"_n, "prode"_n, "prodf"_n,
+   "prodg"_n, "prodh"_n, "prodi"_n, "prodj"_n, /*"prodk"_n,*/ "prodl"_n,
+   "prodm"_n, "prodn"_n, "prodo"_n, "prodp"_n, "prodq"_n, "prodr"_n,
+   "prods"_n, /*"prodt"_n,*/ "produ"_n };
+
 const eosio::chain::producer_authority_schedule reset_schedule1{ 1, {} };
-
-BOOST_AUTO_TEST_CASE(test_neighbor_finder) {
-
-   {
-      mock_net_plugin plugin;
-      plugin.setup_test_peers();
-
-      plugin.config.my_bp_accounts = { "prodd"_n, "produ"_n };
-      BOOST_CHECK_EQUAL(plugin.neighbor_finder(test_schedule1.producers).downstream_neighbors(),
-                        (fc::flat_set<eosio::chain::account_name>{ "proda"_n, "prodb"_n, "prode"_n, "prodf"_n }));
-
-      BOOST_CHECK_EQUAL(plugin.neighbor_finder(test_schedule1.producers).neighbors(),
-                        (fc::flat_set<eosio::chain::account_name>{ "proda"_n, "prodb"_n, "prodc"_n, "prode"_n,
-                                                                   "prodf"_n, "prods"_n, "prodt"_n }));
-   }
-   {
-      mock_net_plugin plugin;
-      plugin.setup_test_peers();
-
-      plugin.config.my_bp_accounts = { "prodj"_n };
-      // make sure it doesn't return any producer not on the bp peer list
-      BOOST_CHECK_EQUAL(plugin.neighbor_finder(test_schedule1.producers).downstream_neighbors(),
-                        (fc::flat_set<eosio::chain::account_name>{ "prodl"_n }));
-
-      BOOST_CHECK_EQUAL(plugin.neighbor_finder(test_schedule1.producers).neighbors(),
-                        (fc::flat_set<eosio::chain::account_name>{ "prodh"_n, "prodi"_n, "prodl"_n }));
-   }
-}
 
 BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
 
    mock_net_plugin plugin;
    plugin.setup_test_peers();
-   plugin.config.my_bp_accounts = { "prodd"_n, "produ"_n };
-   plugin.pending_neighbors     = { "prodj"_n, "prodm"_n };
+   plugin.pending_configured_bps = { "prodj"_n, "prodm"_n };
 
    std::vector<std::string> connected_hosts;
 
@@ -178,21 +165,18 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    plugin.on_pending_schedule(test_schedule1);
 
    BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{}));
-   BOOST_CHECK_EQUAL(plugin.pending_neighbors, (fc::flat_set<eosio::chain::account_name>{ "prodj"_n, "prodm"_n }));
+   BOOST_CHECK_EQUAL(plugin.pending_configured_bps, (fc::flat_set<eosio::chain::account_name>{ "prodj"_n, "prodm"_n }));
    BOOST_CHECK_EQUAL(plugin.pending_schedule_version, 0u);
 
    // when it is in sync and on_pending_schedule is called
    plugin.is_in_sync = true;
    plugin.on_pending_schedule(test_schedule1);
 
-   // the downstream neighbors
-   BOOST_CHECK_EQUAL(plugin.pending_neighbors,
-                     (fc::flat_set<eosio::chain::account_name>{ "proda"_n, "prodb"_n, "prodc"_n, "prode"_n, "prodf"_n,
-                                                                "prods"_n, "prodt"_n }));
+   // the pending are connected to
+   BOOST_CHECK_EQUAL(plugin.pending_configured_bps, producers_minus_prodkt);
 
-   // all connect to downstream bp peers should be invoked
-   BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{ "127.0.0.1:8001:blk"s, "127.0.0.1:8002:trx"s,
-                                                                 "127.0.0.1:8005"s, "127.0.0.1:8006"s }));
+   // all connect to bp peers should be invoked
+   BOOST_CHECK_EQUAL(connected_hosts, peer_addresses);
 
    BOOST_CHECK_EQUAL(plugin.pending_schedule_version, 1u);
 
@@ -205,16 +189,15 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{}));
 
    plugin.on_pending_schedule(reset_schedule1);
-   BOOST_CHECK_EQUAL(plugin.pending_neighbors, (fc::flat_set<eosio::chain::account_name>{}));
+   BOOST_CHECK_EQUAL(plugin.pending_configured_bps, (fc::flat_set<eosio::chain::account_name>{}));
 }
 
 BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
 
    mock_net_plugin plugin;
    plugin.setup_test_peers();
-   plugin.config.my_bp_accounts = { "prodd"_n, "produ"_n };
 
-   plugin.active_neighbors = { "proda"_n, "prodh"_n, "prodn"_n };
+   plugin.active_configured_bps = { "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n };
    plugin.connections.resolve_and_connect = [](std::string host, std::string p2p_address) {};
 
    std::vector<std::string> disconnected_hosts;
@@ -225,20 +208,18 @@ BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
    plugin.on_active_schedule(test_schedule1);
 
    BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{}));
-   BOOST_CHECK_EQUAL(plugin.active_neighbors,
-                     (fc::flat_set<eosio::chain::account_name>{ "proda"_n, "prodh"_n, "prodn"_n }));
+   BOOST_CHECK_EQUAL(plugin.active_configured_bps,
+                     (fc::flat_set<eosio::chain::account_name>{ "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n }));
    BOOST_CHECK_EQUAL(plugin.active_schedule_version, 0u);
 
    // when it is in sync and on_active_schedule is called
    plugin.is_in_sync = true;
    plugin.on_pending_schedule(test_schedule1);
    plugin.on_active_schedule(test_schedule1);
-   // then disconnect to prodh and prodn should be invoked
-   BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{ "127.0.0.1:8008"s, "127.0.0.1:8014"s }));
+   // then disconnect to prodt
+   BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{ "127.0.0.1:8020"s }));
 
-   BOOST_CHECK_EQUAL(plugin.active_neighbors,
-                     (fc::flat_set<eosio::chain::account_name>{ "proda"_n, "prodb"_n, "prodc"_n, "prode"_n, "prodf"_n,
-                                                                "prods"_n, "prodt"_n }));
+   BOOST_CHECK_EQUAL(plugin.active_configured_bps, producers_minus_prodkt);
 
    // make sure we change the active_schedule_version
    BOOST_CHECK_EQUAL(plugin.active_schedule_version, 1u);
@@ -248,24 +229,20 @@ BOOST_AUTO_TEST_CASE(test_on_active_schedule2) {
 
    mock_net_plugin plugin;
    plugin.setup_test_peers();
-   plugin.config.my_bp_accounts = { "prodd"_n, "produ"_n };
 
-   plugin.active_neighbors = { "proda"_n, "prodh"_n, "prodn"_n };
+   plugin.active_configured_bps = { "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n };
    plugin.connections.resolve_and_connect = [](std::string host, std::string p2p_address) {};
    std::vector<std::string> disconnected_hosts;
    plugin.connections.disconnect = [&disconnected_hosts](std::string host) { disconnected_hosts.push_back(host); };
 
-   // when pending and active schedules are changed simultaneosly
+   // when pending and active schedules are changed simultaneously
    plugin.is_in_sync = true;
    plugin.on_pending_schedule(test_schedule2);
    plugin.on_active_schedule(test_schedule1);
-   // then disconnect to  prodn should be invoked while prodh shouldn't, because prodh is in the
-   // pending_neighbors
-   BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{ "127.0.0.1:8014"s }));
+   // then disconnect prodt
+   BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{ "127.0.0.1:8020"s }));
 
-   BOOST_CHECK_EQUAL(plugin.active_neighbors,
-                     (fc::flat_set<eosio::chain::account_name>{ "proda"_n, "prodb"_n, "prodc"_n, "prode"_n, "prodf"_n,
-                                                                "prods"_n, "prodt"_n }));
+   BOOST_CHECK_EQUAL(plugin.active_configured_bps, producers_minus_prodkt);
 
    // make sure we change the active_schedule_version
    BOOST_CHECK_EQUAL(plugin.active_schedule_version, 1u);
@@ -274,7 +251,7 @@ BOOST_AUTO_TEST_CASE(test_on_active_schedule2) {
 BOOST_AUTO_TEST_CASE(test_exceeding_connection_limit) {
    mock_net_plugin plugin;
    plugin.setup_test_peers();
-   plugin.config.my_bp_accounts = { "prodd"_n, "produ"_n };
+//   plugin.config.my_bp_accounts = { "prodd"_n, "produ"_n };
    plugin.connections.max_client_count = 1;
    plugin.connections.connections = {
       std::make_shared<mock_connection>( true, true, true ),   // 0

--- a/tests/auto_bp_peering_test.py
+++ b/tests/auto_bp_peering_test.py
@@ -9,7 +9,7 @@ from TestHarness import Cluster, TestHelper, Utils, WalletMgr
 #
 # This test sets up  a cluster with 21 producers nodeos, each nodeos is configured with only one producer and only connects to the bios node.
 # Moreover, each producer nodeos is also configured with a list of p2p-auto-bp-peer so that each one can automatically establish p2p connections to
-# their downstream two neighbors based on producer schedule on the chain and tear down the connections which are no longer in the scheduling neighborhood.
+# other bps. Test verifies connections are established when producer schedule is active.
 #
 ###############################################################
 
@@ -57,17 +57,6 @@ for nodeId in range(0, producerNodes):
     auto_bp_peer_args += (" --p2p-auto-bp-peer " + producer_name + "," + hostname)
 
 
-def neighbors_in_schedule(name, schedule):
-    index = schedule.index(name)
-    result = []
-    num = len(schedule)
-    result.append(schedule[(index+1) % num])
-    result.append(schedule[(index+2) % num])
-    result.append(schedule[(index-1) % num])
-    result.append(schedule[(index-2) % num])
-    return result.sort()
-
-
 peer_names["localhost:9776"] = "bios"
 
 testSuccessful = False
@@ -93,22 +82,20 @@ try:
 
     # wait until produceru is seen by every node
     for nodeId in range(0, producerNodes):
-        print("Wait for node ", nodeId)
-        cluster.nodes[nodeId].waitForProducer(
-            "defproduceru", exitOnError=True, timeout=300)
+        Utils.Print("Wait for node ", nodeId)
+        cluster.nodes[nodeId].waitForProducer("defproduceru", exitOnError=True, timeout=300)
 
     # retrieve the producer stable producer schedule
     scheduled_producers = []
-    schedule = cluster.nodes[0].processUrllibRequest(
-        "chain", "get_producer_schedule")
+    schedule = cluster.nodes[0].processUrllibRequest("chain", "get_producer_schedule")
     for prod in schedule["payload"]["active"]["producers"]:
         scheduled_producers.append(prod["producer_name"])
+    scheduled_producers.sort()
 
-    connection_check_failures = 0
+    connection_failure = False
     for nodeId in range(0, producerNodes):
-        # retrieve the connections in each node and check if each only connects to their neighbors in the schedule
-        connections = cluster.nodes[nodeId].processUrllibRequest(
-            "net", "connections")
+        # retrieve the connections in each node and check if each connects to the other bps in the schedule
+        connections = cluster.nodes[nodeId].processUrllibRequest("net", "connections")
         peers = []
         for conn in connections["payload"]:
             peer_addr = conn["peer"]
@@ -120,17 +107,22 @@ try:
                 peers.append(peer_names[peer_addr])
                 if not conn["is_bp_peer"]:
                     Utils.Print("Error: expected connection to {} with is_bp_peer as true".format(peer_addr))
-                    connection_check_failures = connection_check_failures+1
+                    connection_failure = True
 
-        peers = peers.sort()
+        if not peers:
+            Utils.Print(f"ERROR: found no connected peers for node {nodeId}")
+            connection_failure = True
+            break
         name = "defproducer" + chr(ord('a') + nodeId)
-        expected_peers = neighbors_in_schedule(name, scheduled_producers)
-        if peers != expected_peers:
-            Utils.Print("ERROR: expect {} has connections to {}, got connections to {}".format(
-                name, expected_peers, peers))
-            connection_check_failures = connection_check_failures+1
+        peers.append(name) # add ourselves so matches schedule_producers
+        peers = list(set(peers))
+        peers.sort()
+        if peers != scheduled_producers:
+            Utils.Print(f"ERROR: expect {name} has connections to {scheduled_producers}, got connections to {peers}")
+            connection_failure = True
+            break
 
-    testSuccessful = connection_check_failures == 0
+    testSuccessful = not connection_failure
 
 finally:
     TestHelper.shutdown(


### PR DESCRIPTION
Change `p2p-auto-bp-peer` to remain connected to the current active producer schedule instead of just the next 2 in the schedule. With Savanna, it is important to have connections to all finalizers. Currently block proposers are also block finalizers.

Block producers can configure their BP canary p2p node with `p2p-auto-bp-peer` entries for all p2p nodes they know are associated with corresponding block producer. As the active producer schedule changes, the `net_plugin` will connect to peers that are in the pending producer schedule and disconnect from peers when they drop out of the active schedule.

Resolves #1227 