### PR TITLE
avoid memset & memcpy on non-trivially copyable `fc::variant` to eliminate a bunch of warnings

### DIFF
--- a/libraries/libfc/include/fc/variant.hpp
+++ b/libraries/libfc/include/fc/variant.hpp
@@ -8,8 +8,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <string.h> // memset
-
 #include <fc/string.hpp>
 #include <fc/time.hpp>
 #include <fc/container/deque_fwd.hpp>
@@ -349,7 +347,6 @@ namespace fc
         template<typename T>
         explicit variant( const std::optional<T>& v )
         {
-           memset( this, 0, sizeof(*this) );
            if( v.has_value() ) *this = variant(*v);
         }
 
@@ -362,8 +359,8 @@ namespace fc
         void    clear();
       private:
         void    init();
-        double  _data;                ///< Alligned according to double requirements
-        char    _type[sizeof(void*)]; ///< pad to void* size
+        //enough room to store pointers, doubles, uint64s. doubled to allow 1 extra byte to store type at the end
+        alignas(double) std::array<char, std::max(sizeof(uintmax_t ), sizeof(double)) * 2> _data = {};
    };
 
    typedef std::optional<variant> ovariant;
@@ -615,14 +612,12 @@ namespace fc
    template<typename T>
    variant::variant( const T& val )
    {
-      memset( this, 0, sizeof(*this) );
       to_variant( val, *this );
    }
 
    template<typename T>
    variant::variant( const T& val, const fc::yield_function_t& yield )
    {
-      memset( this, 0, sizeof(*this) );
       to_variant( val, *this, yield );
    }
 

--- a/libraries/libfc/src/variant.cpp
+++ b/libraries/libfc/src/variant.cpp
@@ -212,13 +212,13 @@ variant::variant( const variant& v )
           set_variant_type( this, blob_type );
           return;
        default:
-          memcpy( this, &v, sizeof(v) );
+          _data = v._data;
    }
 }
 
 variant::variant( variant&& v )
 {
-   memcpy( this, &v, sizeof(v) );
+   _data = v._data;
    set_variant_type( &v, null_type );
 }
 
@@ -231,7 +231,7 @@ variant& variant::operator=( variant&& v )
 {
    if( this == &v ) return *this;
    clear();
-   memcpy( (char*)this, (char*)&v, sizeof(v) );
+   _data = v._data;
    set_variant_type( &v, null_type );
    return *this;
 }
@@ -259,7 +259,7 @@ variant& variant::operator=( const variant& v )
          *reinterpret_cast<blob**>(this)  = new blob((**reinterpret_cast<const const_blob_ptr*>(&v)) );
          break;
       default:
-         memcpy( this, &v, sizeof(v) );
+         _data = v._data;
    }
    set_variant_type( this, v.get_type() );
    return *this;


### PR DESCRIPTION
clang20 is firing off a megaton of warnings such as
```
warning: first argument in call to 'memset' is a pointer to non-trivially copyable type 'fc::variant'
```
and
```
warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'fc::variant'
```

Not sure if anyone has strong opinions on proper way to resolve the warning (besides a larger refactor). I think we could keep the memcpy/memset and explicitly cast the pointers but that seems more hacky than using a std::array like done here.