### PR TITLE
add `--dry-run` for `push action`

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3947,6 +3947,7 @@ int main( int argc, char** argv ) {
    actionsSubcommand->add_option("action", action,
                                  localized("A JSON string or filename defining the action to execute on the contract"))->required()->capture_default_str();
    actionsSubcommand->add_option("data", data, localized("The arguments to the contract"))->required();
+   actionsSubcommand->add_flag("--dry-run", tx_dry_run, localized("Specify an action is dry-run"));
    actionsSubcommand->add_flag("--read", tx_read, localized("Specify an action is read-only"));
 
    add_standard_transaction_options_plus_signing(actionsSubcommand);

--- a/tests/compute_transaction_test.py
+++ b/tests/compute_transaction_test.py
@@ -101,6 +101,10 @@ try:
 
     results = node.pushTransaction(trx, opts='--dry-run', permissions=account1.name)
     assert(results[0])
+
+    Print("Sending read-only transfer as action")
+    results = node.pushMessage('eosio.token', 'transfer', '{"from": "account1","to": "account2","quantity": "1.0001 SYS","memo": "act1"}', '--dry-run -p account1@active')
+    assert(results[0])
     node.waitForLibToAdvance(30)
 
     postBalances = node.getEosBalances([account1, account2])


### PR DESCRIPTION
Apparently just an oversight this was only available on `push transaction` and not also `push action`