### PR TITLE
SC:  Implement the core functionalities of sync calls

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -287,10 +287,8 @@ void apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<c
    } catch (const boost::interprocess::bad_alloc&) {
       throw;
    } catch(const fc::exception& e) {
-      ilog("fc::exceptio");
       handle_exception(e);
    } catch (const std::exception& e) {
-      ilog("std::exception");
       auto wrapper = fc::std_exception_wrapper::from_current_exception(e);
       handle_exception(wrapper);
    }

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -248,6 +248,8 @@ void apply_context::exec()
 
 void apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<const char> data)
 {
+   assert(sync_call_ctx.has_value() ^ (act != nullptr)); // can be only one of action and sync call
+
    dlog("receiver: ${r}, flags: ${f}, data size: ${s}",
         ("r", receiver)("f", flags)("s", data.size()));
 

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -293,6 +293,12 @@ void apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<c
       handle_exception(wrapper);
    }
 }
+
+action_name apply_context::get_sync_call_sender() const {
+   // Current context's receiver is the sender of next sync call
+   return sync_call_ctx ? sync_call_ctx->receiver : get_receiver();
+}
+
 bool apply_context::is_account( const account_name& account )const {
    return nullptr != db.find<account_object,by_name>( account );
 }
@@ -1147,11 +1153,6 @@ action_name apply_context::get_sender() const {
       const action_trace& creator_trace = trx_context.get_action_trace( trace.creator_action_ordinal );
       return creator_trace.receiver;
    }
-   return action_name();
-}
-
-action_name apply_context::get_sync_call_sender() const {
-   // TBD implement with sync call trace implementation
    return action_name();
 }
 

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -292,6 +292,8 @@ void apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<c
       auto wrapper = fc::std_exception_wrapper::from_current_exception(e);
       handle_exception(wrapper);
    }
+
+   trx_context.checktime(); // protect against the case where during the removal of the callback, the timer expires.
 }
 
 action_name apply_context::get_sync_call_sender() const {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -278,9 +278,9 @@ void apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<c
          try {
             // use a new apply_context for a new sync call
             apply_context a_ctx(control, trx_context);
-            a_ctx.sync_call_info = sync_call{.sender   = get_sync_call_sender(),
-                                             .receiver = receiver,
-                                             .data     = std::move(data)};
+            a_ctx.sync_call_ctx = sync_call_context{.sender   = get_sync_call_sender(),
+                                                    .receiver = receiver,
+                                                    .data     = std::move(data)};
 
             control.get_wasm_interface().do_sync_call(receiver_account->code_hash, receiver_account->vm_type, receiver_account->vm_version, a_ctx);
          } catch( const wasm_exit&) {}

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -296,8 +296,10 @@ void apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<c
    trx_context.checktime(); // protect against the case where during the removal of the callback, the timer expires.
 }
 
+// Returns the sender of any sync call initiated by this apply_context or sync_call_ctx
 action_name apply_context::get_sync_call_sender() const {
-   // Current context's receiver is the sender of next sync call
+   // The sync call is initiated by this apply_context or its sync_call_ctx.
+   // That's why the context's receiver is the sender of the sync call.
    return sync_call_ctx ? sync_call_ctx->receiver : get_receiver();
 }
 

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -269,7 +269,7 @@ void apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<c
    try {
       try {
          const account_metadata_object* receiver_account = &db.get<account_metadata_object, by_name>( receiver);
-         if (receiver_account->code_hash == digest_type()) {
+         if (receiver_account->code_hash.empty()) {
             // TBD store the info in sync call trace
             ilog("receiver_account->code_hash empty");
             return;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4914,8 +4914,12 @@ struct controller_impl {
 #endif
 
    // Only called from read-only trx execution threads when producer_plugin
-   // starts them. Only OC requires initialize thread specific data.
+   // starts them.
    void init_thread_local_data() {
+#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
+      sync_call_wasm_alloc.resize(16);
+      sync_call_wasm_alloc_index = 0;
+#endif
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
       if ( is_eos_vm_oc_enabled() ) {
          wasmif.init_thread_local_data();

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1014,7 +1014,7 @@ struct controller_impl {
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
    thread_local static vm::wasm_allocator wasm_alloc; // a copy for main thread and each read-only thread
    thread_local static std::vector<vm::wasm_allocator> sync_call_wasm_alloc; // used for sync call. expensive to create one for each call
-   uint32_t            sync_call_wasm_alloc_index;
+   thread_local static uint32_t sync_call_wasm_alloc_index;
 #endif
    wasm_interface wasmif;
    app_window_type app_window = app_window_type::write;
@@ -1303,8 +1303,10 @@ struct controller_impl {
          if( shutdown ) shutdown();
       } );
 
+#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
       sync_call_wasm_alloc.resize(16); // Will change to use max_sync_call_depth of global property object in future version
       sync_call_wasm_alloc_index = 0;
+#endif
 
       set_activation_handler<builtin_protocol_feature_t::preactivate_feature>();
       set_activation_handler<builtin_protocol_feature_t::replace_deferred>();
@@ -5070,7 +5072,7 @@ thread_local platform_timer controller_impl::timer;
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
 thread_local eosio::vm::wasm_allocator controller_impl::wasm_alloc;
 thread_local std::vector<eosio::vm::wasm_allocator> controller_impl::sync_call_wasm_alloc;
-thread_local uint32_t sync_call_wasm_alloc_index = 0;
+thread_local uint32_t controller_impl::sync_call_wasm_alloc_index = 0;
 #endif
 
 const resource_limits_manager&   controller::get_resource_limits_manager()const

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1013,6 +1013,8 @@ struct controller_impl {
    thread_local static platform_timer timer; // a copy for main thread and each read-only thread
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
    thread_local static vm::wasm_allocator wasm_alloc; // a copy for main thread and each read-only thread
+   thread_local static std::vector<vm::wasm_allocator> sync_call_wasm_alloc; // used for sync call. expensive to create one for each call
+   uint32_t            sync_call_wasm_alloc_index;
 #endif
    wasm_interface wasmif;
    app_window_type app_window = app_window_type::write;
@@ -1300,6 +1302,9 @@ struct controller_impl {
          elog( "Exception in vote thread pool, exiting: ${e}", ("e", e.to_detail_string()) );
          if( shutdown ) shutdown();
       } );
+
+      sync_call_wasm_alloc.resize(16); // Will change to use max_sync_call_depth of global property object in future version
+      sync_call_wasm_alloc_index = 0;
 
       set_activation_handler<builtin_protocol_feature_t::preactivate_feature>();
       set_activation_handler<builtin_protocol_feature_t::replace_deferred>();
@@ -5064,6 +5069,8 @@ struct controller_impl {
 thread_local platform_timer controller_impl::timer;
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
 thread_local eosio::vm::wasm_allocator controller_impl::wasm_alloc;
+thread_local std::vector<eosio::vm::wasm_allocator> controller_impl::sync_call_wasm_alloc;
+thread_local uint32_t sync_call_wasm_alloc_index = 0;
 #endif
 
 const resource_limits_manager&   controller::get_resource_limits_manager()const
@@ -5970,6 +5977,15 @@ uint32_t controller::earliest_available_block_num() const{
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
 vm::wasm_allocator& controller::get_wasm_allocator() {
    return my->wasm_alloc;
+}
+
+vm::wasm_allocator& controller::get_sync_call_wasm_allocator() {
+   EOS_ASSERT( my->sync_call_wasm_alloc_index < 16, misc_exception, "sync_call_wasm_alloc_index ${i} must be less than ${m}", ("i", my->sync_call_wasm_alloc_index) ("m", 16) ); // will change to use max_sync_call_depth
+   return my->sync_call_wasm_alloc[my->sync_call_wasm_alloc_index++];
+}
+
+void controller::return_sync_call_wasm_allocator() {
+   --my->sync_call_wasm_alloc_index;
 }
 #endif
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -4,7 +4,7 @@
 #include <eosio/chain/transaction.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain/contract_table_objects.hpp>
-#include <eosio/chain/sync_call.hpp>
+#include <eosio/chain/sync_call_context.hpp>
 #include <eosio/chain/deep_mind.hpp>
 #include <fc/utility.hpp>
 #include <sstream>
@@ -602,7 +602,7 @@ class apply_context {
       action_name get_receiver()const { return receiver; }
       const action& get_action()const { return *act; }
       const action* get_action_ptr()const { return act; }
-      std::optional<sync_call> get_sync_call()const { return sync_call_info; }
+      std::optional<sync_call_context> get_sync_call_ctx()const { return sync_call_ctx; }
 
       action_name get_sender() const;
       action_name get_sync_call_sender() const;
@@ -628,7 +628,7 @@ class apply_context {
       bool                          privileged   = false;
       bool                          context_free = false;
 
-      std::optional<sync_call>      sync_call_info;  // only one of act and sync_call_info can be present
+      std::optional<sync_call_context> sync_call_ctx{};  // only one of act and sync_call_ctx can be present
 
    public:
       std::vector<char>             action_return_value;

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -4,6 +4,7 @@
 #include <eosio/chain/transaction.hpp>
 #include <eosio/chain/transaction_context.hpp>
 #include <eosio/chain/contract_table_objects.hpp>
+#include <eosio/chain/sync_call.hpp>
 #include <eosio/chain/deep_mind.hpp>
 #include <fc/utility.hpp>
 #include <sstream>
@@ -494,12 +495,15 @@ class apply_context {
    /// Constructor
    public:
       apply_context(controller& con, transaction_context& trx_ctx, uint32_t action_ordinal, uint32_t depth=0);
+      apply_context(controller& con, transaction_context& trx_ctx);
 
    /// Execution methods:
    public:
 
       void exec_one();
       void exec();
+      void execute_sync_call(name receiver, uint64_t flags, std::span<const char> data
+);
       void execute_inline( action&& a );
       void execute_context_free_inline( action&& a );
       void schedule_deferred_transaction( const uint128_t& sender_id, account_name payer, transaction&& trx, bool replace_existing );
@@ -597,8 +601,11 @@ class apply_context {
       bool is_privileged()const { return privileged; }
       action_name get_receiver()const { return receiver; }
       const action& get_action()const { return *act; }
+      const action* get_action_ptr()const { return act; }
+      std::optional<sync_call> get_sync_call()const { return sync_call_info; }
 
       action_name get_sender() const;
+      action_name get_sync_call_sender() const;
 
       bool is_applying_block() const { return trx_context.explicit_billed_cpu_time; }
       bool is_eos_vm_oc_whitelisted() const;
@@ -620,6 +627,8 @@ class apply_context {
       uint32_t                      action_ordinal = 0;
       bool                          privileged   = false;
       bool                          context_free = false;
+
+      std::optional<sync_call>      sync_call_info;  // only one of act and sync_call_info can be present
 
    public:
       std::vector<char>             action_return_value;

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -602,7 +602,7 @@ class apply_context {
       action_name get_receiver()const { return receiver; }
       const action& get_action()const { return *act; }
       const action* get_action_ptr()const { return act; }
-      std::optional<sync_call_context> get_sync_call_ctx()const { return sync_call_ctx; }
+      const std::optional<sync_call_context>& get_sync_call_ctx()const { return sync_call_ctx; }
 
       action_name get_sender() const;
 

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -495,7 +495,7 @@ class apply_context {
    /// Constructor
    public:
       apply_context(controller& con, transaction_context& trx_ctx, uint32_t action_ordinal, uint32_t depth=0);
-      apply_context(controller& con, transaction_context& trx_ctx);
+      apply_context(controller& con, transaction_context& trx_ctx, name sender, name receiver, std::span<const char> data);  // used to construct sync call context
 
    /// Execution methods:
    public:

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -605,7 +605,6 @@ class apply_context {
       std::optional<sync_call_context> get_sync_call_ctx()const { return sync_call_ctx; }
 
       action_name get_sender() const;
-      action_name get_sync_call_sender() const;
 
       bool is_applying_block() const { return trx_context.explicit_billed_cpu_time; }
       bool is_eos_vm_oc_whitelisted() const;
@@ -629,6 +628,9 @@ class apply_context {
       bool                          context_free = false;
 
       std::optional<sync_call_context> sync_call_ctx{};  // only one of act and sync_call_ctx can be present
+
+      // Returns the sender of any sync call initiated by this apply_context or its sync_call_ctx
+      action_name get_sync_call_sender() const;
 
    public:
       std::vector<char>             action_return_value;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -449,6 +449,8 @@ namespace eosio::chain {
 
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
          vm::wasm_allocator&  get_wasm_allocator();
+         vm::wasm_allocator&  get_sync_call_wasm_allocator();
+         void                 return_sync_call_wasm_allocator();
 #endif
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
          bool is_eos_vm_oc_enabled() const;

--- a/libraries/chain/include/eosio/chain/platform_timer.hpp
+++ b/libraries/chain/include/eosio/chain/platform_timer.hpp
@@ -26,17 +26,21 @@ struct platform_timer {
       callback still execute if the timer expires and stop() is called nearly simultaneously.
       However, set_expiration_callback() is synchronized with the callback.
    */
-   void set_expiration_callback(void(*func)(void*), void* user) {
+   void set_expiration_callback(void(*func)(void*), void* user, bool appending = false) {
       bool expect_false = false;
       while(!atomic_compare_exchange_strong(&_callback_variables_busy, &expect_false, true))
          expect_false = false;
       auto reset_busy = fc::make_scoped_exit([this]() {
          _callback_variables_busy.store(false, std::memory_order_release);
       });
-      EOS_ASSERT(!(func && _expiration_callback), misc_exception, "Setting a platform_timer callback when one already exists");
+      EOS_ASSERT(!(!appending && func && !_expiration_callbacks.empty()), misc_exception, "Setting a platform_timer callback when one already exists");
 
-      _expiration_callback = func;
-      _expiration_callback_data = user;
+      if (!func && !_expiration_callbacks.empty()) {
+         _expiration_callbacks.pop_back();
+         return;
+      }
+
+      _expiration_callbacks.push_back({func, user});
    }
 
    enum class state_t {
@@ -60,18 +64,18 @@ private:
    void call_expiration_callback() {
       bool expect_false = false;
       if(atomic_compare_exchange_strong(&_callback_variables_busy, &expect_false, true)) {
-         void(*cb)(void*) = _expiration_callback;
-         void* cb_data = _expiration_callback_data;
-         if(cb) {
-            cb(cb_data);
+         for (auto it = _expiration_callbacks.rbegin(); it != _expiration_callbacks.rend(); ++it) {
+            if (it->first) {
+               it->first(it->second);
+            }
          }
+
          _callback_variables_busy.store(false, std::memory_order_release);
       }
    }
 
    std::atomic_bool _callback_variables_busy = false;
-   void(*_expiration_callback)(void*) = nullptr;
-   void* _expiration_callback_data;
+   std::vector<std::pair<void(*)(void*), void*>> _expiration_callbacks;
 };
 
 }}

--- a/libraries/chain/include/eosio/chain/sync_call.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <eosio/chain/types.hpp>
+
+namespace eosio { namespace chain {
+   struct sync_call {
+      account_name           sender{};
+      account_name           receiver{};
+      std::span<const char>  data{}; // includes function name, arguments, and other information
+   };
+} } /// namespace eosio::chain
+
+FC_REFLECT(eosio::chain::sync_call, (sender)(receiver)(data))

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -3,11 +3,11 @@
 #include <eosio/chain/types.hpp>
 
 namespace eosio { namespace chain {
-   struct sync_call {
+   struct sync_call_context {
       account_name           sender{};
       account_name           receiver{};
       std::span<const char>  data{}; // includes function name, arguments, and other information
    };
 } } /// namespace eosio::chain
 
-FC_REFLECT(eosio::chain::sync_call, (sender)(receiver)(data))
+FC_REFLECT(eosio::chain::sync_call_context, (sender)(receiver)(data))

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -25,7 +25,7 @@ namespace eosio::chain {
          /* Sets a callback for when timer expires. Be aware this could might fire from a signal handling context and/or
             on any particular thread. Only a single callback can be registered at once; trying to register more will
             result in an exception. Use nullptr to disable a previously set callback. */
-         void set_expiration_callback(void(*func)(void*), void* user);
+         void set_expiration_callback(void(*func)(void*), void* user, bool appending = false);
 
       private:
          platform_timer& _timer;

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -76,6 +76,8 @@ namespace eosio { namespace chain {
          //Calls apply or error on a given code
          void apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context);
 
+         void do_sync_call(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context);
+
          //Returns true if the code is cached
          bool is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const;
 

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -196,6 +196,10 @@ struct eosvmoc_tier {
          }
       }
 
+      void do_sync_call( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
+         get_instantiated_module(code_hash, vm_type, vm_version, context.trx_context)->do_sync_call(context);
+      }
+
       // used for testing
       uint64_t get_eos_vm_oc_compile_interrupt_count() const { return eos_vm_oc_compile_interrupt_count; }
 

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -13,6 +13,7 @@ class apply_context;
 class wasm_instantiated_module_interface {
    public:
       virtual void apply(apply_context& context) = 0;
+      virtual void do_sync_call(apply_context& context) = 0;
 
       virtual ~wasm_instantiated_module_interface();
 };

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -25,8 +25,8 @@ namespace eosio::chain {
       _timer.stop();
    }
 
-   void transaction_checktime_timer::set_expiration_callback(void(*func)(void*), void* user) {
-      _timer.set_expiration_callback(func, user);
+   void transaction_checktime_timer::set_expiration_callback(void(*func)(void*), void* user, bool appending) {
+      _timer.set_expiration_callback(func, user, appending);
    }
 
    transaction_checktime_timer::~transaction_checktime_timer() {

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -91,6 +91,11 @@ namespace eosio { namespace chain {
       my->apply( code_hash, vm_type, vm_version, context );
    }
 
+   void wasm_interface::do_sync_call( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
+      ilog("wasm_interface::do_sync_call");
+      my->do_sync_call( code_hash, vm_type, vm_version, context );
+   }
+
    bool wasm_interface::is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const {
       return my->is_code_cached(code_hash, vm_type, vm_version);
    }

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -92,7 +92,6 @@ namespace eosio { namespace chain {
    }
 
    void wasm_interface::do_sync_call( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
-      ilog("wasm_interface::do_sync_call");
       my->do_sync_call( code_hash, vm_type, vm_version, context );
    }
 

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -40,6 +40,10 @@ class eosvmoc_instantiated_module : public wasm_instantiated_module_interface {
             _eosvmoc_runtime.exec_thread_local->execute(*cd, *_eosvmoc_runtime.mem_thread_local, context);
       }
 
+      void do_sync_call(apply_context& context) override {
+         ;
+      }
+
       const digest_type              _code_hash;
       const uint8_t                  _vm_version;
       eosvmoc_runtime&               _eosvmoc_runtime;

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -133,7 +133,7 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
       void do_sync_call(apply_context& context) override {
          backend_t                                bkend;
          typename eos_vm_runtime<Impl>::context_t exec_ctx;
-         vm::wasm_allocator                       wasm_alloc;
+         vm::wasm_allocator                       wasm_alloc = context.control.get_sync_call_wasm_allocator(); // get the top free wasm allocator from the pool
 
          const std::optional<sync_call_context> sync_call_ctx  = context.get_sync_call_ctx();
          assert(sync_call_ctx.has_value());
@@ -152,6 +152,7 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          };
 
          execute(context, bkend, exec_ctx, wasm_alloc, fn, true);
+         context.control.return_sync_call_wasm_allocator(); // return the wasm_allocator obtainded by get_sync_wasm_allocator back to the pool
       }
 
       void apply(apply_context& context) override {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -135,6 +135,9 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          typename eos_vm_runtime<Impl>::context_t exec_ctx;
          vm::wasm_allocator                       wasm_alloc = context.control.get_sync_call_wasm_allocator(); // get the top free wasm allocator from the pool
 
+         // always return the wasm_allocator obtainded by get_sync_wasm_allocator back to the pool
+         auto ensure = fc::make_scoped_exit([&]() { context.control.return_sync_call_wasm_allocator(); });
+
          const std::optional<sync_call_context> sync_call_ctx  = context.get_sync_call_ctx();
          assert(sync_call_ctx.has_value());
          assert(!context.get_action_ptr());
@@ -152,7 +155,6 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          };
 
          execute(context, bkend, exec_ctx, wasm_alloc, fn, true);
-         context.control.return_sync_call_wasm_allocator(); // return the wasm_allocator obtainded by get_sync_wasm_allocator back to the pool
       }
 
       void apply(apply_context& context) override {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -198,6 +198,10 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          } catch(eosio::vm::exception& e) {
             FC_THROW_EXCEPTION(wasm_execution_error, "eos-vm system failure: ${d}", ("d", e.detail()));
          }
+
+         if (multi_expr_callbacks_allowed) {
+            context.trx_context.checktime(); // protect against the case where during the removal of the callback, the timer expires.
+         }
       }
 
       apply_options get_apply_options(const apply_context& context) const {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -199,10 +199,6 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          } catch(eosio::vm::exception& e) {
             FC_THROW_EXCEPTION(wasm_execution_error, "eos-vm system failure: ${d}", ("d", e.detail()));
          }
-
-         if (multi_expr_callbacks_allowed) {
-            context.trx_context.checktime(); // protect against the case where during the removal of the callback, the timer expires.
-         }
       }
 
       apply_options get_apply_options(const apply_context& context) const {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -140,8 +140,8 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
             const wasm_config& config = context.control.get_global_properties().wasm_configuration;
             opts = {config.max_pages, config.max_call_depth};
          }
-         const std::optional<sync_call> scall  = context.get_sync_call();
-         assert(scall.has_value());
+         const std::optional<sync_call_context> sync_call_ctx  = context.get_sync_call_ctx();
+         assert(sync_call_ctx.has_value());
          assert(!context.get_action_ptr());
 
          auto fn = [&]() {
@@ -149,9 +149,9 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
             bkend.initialize(&iface, opts);
             bkend.call(
                 iface, "env", "sync_call",
-                scall->sender.to_uint64_t(),
-                scall->receiver.to_uint64_t(),
-                static_cast<uint64_t>(scall->data.size())); // size_t can be uint32_t or uint64_t depending on architecture. Safely cast to uint64_t to always match the type expected by sync_call entry point.
+                sync_call_ctx->sender.to_uint64_t(),
+                sync_call_ctx->receiver.to_uint64_t(),
+                static_cast<uint64_t>(sync_call_ctx->data.size())); // size_t can be uint32_t or uint64_t depending on architecture. Safely cast to uint64_t to always match the type expected by sync_call entry point.
          };
 
          execute(context, bkend, exec_ctx, wasm_alloc, fn);

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -133,12 +133,12 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
       void do_sync_call(apply_context& context) override {
          backend_t                                bkend;
          typename eos_vm_runtime<Impl>::context_t exec_ctx;
-         vm::wasm_allocator                       wasm_alloc = context.control.get_sync_call_wasm_allocator(); // get the top free wasm allocator from the pool
+         vm::wasm_allocator&                      wasm_alloc = context.control.get_sync_call_wasm_allocator(); // get the top free wasm allocator from the pool
 
          // always return the wasm_allocator obtainded by get_sync_wasm_allocator back to the pool
          auto ensure = fc::make_scoped_exit([&]() { context.control.return_sync_call_wasm_allocator(); });
 
-         const std::optional<sync_call_context> sync_call_ctx  = context.get_sync_call_ctx();
+         const std::optional<sync_call_context>& sync_call_ctx  = context.get_sync_call_ctx();
          assert(sync_call_ctx.has_value());
          assert(!context.get_action_ptr());
 

--- a/libraries/chain/webassembly/sync_call.cpp
+++ b/libraries/chain/webassembly/sync_call.cpp
@@ -1,8 +1,9 @@
 #include <eosio/chain/webassembly/interface.hpp>
+#include <eosio/chain/apply_context.hpp>
 
 namespace eosio { namespace chain { namespace webassembly {
-   void interface::call(name /* receiver */, uint64_t /* flags */, span<const char> /* data */) {
-      ;
+   void interface::call(name receiver, uint64_t flags, std::span<const char> data) {
+      context.execute_sync_call(receiver, flags, data);
    }
 
    uint32_t interface::get_call_data(span<char> /* memory */) const {

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -2323,9 +2323,13 @@ static const char basic_sync_call_host_funcs_wast[] = R"=====(
    (import "env" "get_call_data" (func $get_call_data (param i32 i32)(result i32)))
    (import "env" "set_call_return_value" (func $set_call_return_value (param i32 i32)))
    (memory $0 1)
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64))
+
    (export "apply" (func $apply))
-   (func $apply (param i64 i64 i64)
-      (call $call (i64.const 0) (i64.const 0) (i32.const 8) (i32.const 16))
+   (func $apply (param $receiver i64) (param $account i64) (param  $action_name i64)
+      (call $call (get_local $receiver) (i64.const 0) (i32.const 8) (i32.const 16))
       (drop (call $get_call_data (i32.const 8) (i32.const 16)))
       (call $set_call_return_value (i32.const 8) (i32.const 16))
    )

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -1,0 +1,504 @@
+#include <eosio/testing/tester.hpp>
+
+using namespace eosio::chain;
+using namespace eosio::testing;
+
+BOOST_AUTO_TEST_SUITE(sync_call_tests)
+
+// Generic ABI
+static const char* doit_abi = R"=====(
+{
+   "version": "eosio::abi/1.2",
+   "types": [],
+   "structs": [{ "name": "doit", "base": "", "fields": [] }],
+   "actions": [{ "name": "doit", "type": "doit", "ricardian_contract": ""},
+               { "name": "doit1", "type": "doit", "ricardian_contract": ""}],
+   "tables": [],
+   "ricardian_clauses": []
+}
+)=====";
+
+// Make a sync call to a function in the same account
+static const char sync_call_in_same_account_wast[] = R"=====(
+(module
+   (import "env" "eosio_assert" (func $assert (param i32 i32)))
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+
+   (func $callee
+      (call $assert (i32.const 0) (i32.const 0)) ;; the test checks this assert to make sure this function was called
+   )
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $callee) 
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (call $call (get_local $receiver) (i64.const 0)(i32.const 0)(i32.const 8)) ;; using the same receiver
+   )
+
+   (data (i32.const 0) "sync_call in same contract called")
+)
+)=====";
+
+// Verify sync call to a function in the same account works
+BOOST_AUTO_TEST_CASE(same_account) { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   const auto& acct = account_name("synccall");
+   t.create_account(acct);
+   t.set_code(acct, sync_call_in_same_account_wast);
+   t.set_abi(acct, doit_abi);
+
+   BOOST_CHECK_EXCEPTION(t.push_action(acct, "doit"_n, acct, {}),
+                         eosio_assert_message_exception,
+                         fc_exception_message_contains("sync_call in same contract called"));
+                         
+} FC_LOG_AND_RETHROW() }
+
+// Make a sync call to a function in "callee"_n account
+static const char caller_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8))
+   )
+)
+)=====";
+
+// Provide the called function via "sync_call" entry point calling the function
+static const char callee_wast[] = R"=====(
+(module
+   (import "env" "eosio_assert" (func $assert (param i32 i32)))
+   (memory $0 1)
+   (export "memory" (memory $0))
+
+   (func $callee
+      (call $assert (i32.const 0) (i32.const 0)) ;; the test checks this assert to make sure this function  was called
+   )
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $callee) 
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+
+   (data (i32.const 0) "sync_call in different contract called")
+)
+)=====";
+
+// Verify sync call works for called function in a different account
+BOOST_AUTO_TEST_CASE(different_account) { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   const auto& caller = account_name("caller");
+   t.create_account(caller);
+   t.set_code(caller, caller_wast);
+   t.set_abi(caller, doit_abi);
+
+   const auto& callee = account_name("callee");
+   t.create_account(callee);
+   t.set_code(callee, callee_wast);
+
+   BOOST_CHECK_EXCEPTION(t.push_action(caller, "doit"_n, caller, {}),
+                         eosio_assert_message_exception,
+                         fc_exception_message_contains("sync_call in different contract called"));
+} FC_LOG_AND_RETHROW() }
+
+// Calls "callee1"_n
+static const char call_depth_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $callee1 i64 (i64.const 4729647295748898816)) ;; "calllee1"_n uint64 value
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8))
+   )
+)
+)=====";
+
+// Calls "callee2"_n
+static const char callee1_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $callee2 i64 (i64.const 4729647296285769728)) ;; "calllee2"_n uint64 value
+
+   ;; callee intentionally asserts such that the test can check it was called
+   (func $callee
+      (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8))
+   )
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $callee) 
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+)
+)=====";
+
+// The final function to be called
+static const char callee2_wast[] = R"=====(
+(module
+   (import "env" "eosio_assert" (func $assert (param i32 i32)))
+   (memory $0 1)
+   (export "memory" (memory $0))
+
+   ;; callee intentionally asserts such that the test can check it was called
+   (func $callee
+      (call $assert (i32.const 0) (i32.const 0))
+   )
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $callee) 
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+
+   (data (i32.const 0) "multiple level call")
+)
+)=====";
+
+// Verify multiple levels sync calls work
+BOOST_AUTO_TEST_CASE(multi_level_call_depth) { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   const auto& caller = account_name("caller");
+   t.create_account(caller);
+   t.set_code(caller, call_depth_wast);
+   t.set_abi(caller, doit_abi);
+
+   const auto& callee1 = account_name("callee1");
+   t.create_account(callee1);
+   t.set_code(callee1, callee1_wast);
+
+   const auto& callee2 = account_name("callee2");
+   t.create_account(callee2);
+   t.set_code(callee2, callee2_wast);
+
+   BOOST_CHECK_EXCEPTION(t.push_action(caller, "doit"_n, caller, {}),
+                         eosio_assert_message_exception,
+                         fc_exception_message_contains("multiple level call"));
+} FC_LOG_AND_RETHROW() }
+
+// Call "callee1"_n and "callee2"_n in sequence
+static const char seq_caller_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $callee1 i64 (i64.const 4729647295748898816))
+   (global $callee2 i64 (i64.const 4729647296285769728))
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8))
+      (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8))
+   )
+)
+)=====";
+
+static const char seq_callee1_wast[] = R"=====(
+(module
+   (memory $0 1)
+   (export "memory" (memory $0))
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64))
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+)
+)=====";
+
+// The final function to be called
+static const char seq_callee2_wast[] = R"=====(
+(module
+   (import "env" "eosio_assert" (func $assert (param i32 i32)))
+   (memory $0 1)
+   (export "memory" (memory $0))
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $assert (i32.const 0) (i32.const 0))
+   )
+
+   ;; not used but needed for set_code validation
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+
+   (data (i32.const 0) "calls in sequence")
+)
+)=====";
+
+// Verify sequential sync calls work
+BOOST_AUTO_TEST_CASE(seq_sync_calls) { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   const auto& caller = account_name("caller");
+   t.create_account(caller);
+   t.set_code(caller, seq_caller_wast);
+   t.set_abi(caller, doit_abi);
+
+   const auto& callee1 = account_name("callee1");
+   t.create_account(callee1);
+   t.set_code(callee1, seq_callee1_wast);
+
+   const auto& callee2 = account_name("callee2");
+   t.create_account(callee2);
+   t.set_code(callee2, seq_callee2_wast);
+
+   t.produce_block();
+
+   BOOST_CHECK_EXCEPTION(t.push_action(caller, "doit"_n, caller, {}),
+                         eosio_assert_message_exception,
+                         fc_exception_message_contains("calls in sequence"));
+} FC_LOG_AND_RETHROW() }
+
+// Make sync calls from different actions
+static const char different_actions_caller_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $doit_value i64 (i64.const 5556755844919459840))
+   (global $callee1    i64 (i64.const 4729647295748898816))
+   (global $callee2    i64 (i64.const 4729647296285769728))
+
+   ;; sync call a function in "callee1"_n
+   (func $doit
+      (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8))
+   )
+
+   ;; sync call a function in "callee2"_n
+   (func $doit1
+      (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8))
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (get_global $doit_value)
+      (get_local  $action_name)
+      i64.eq
+      if
+         call $doit
+      else
+         call $doit1
+      end
+   )
+)
+)=====";
+
+// called from `doit` action
+static const char different_actions_callee1_wast[] = R"=====(
+(module
+   (import "env" "eosio_assert" (func $assert (param i32 i32)))
+   (memory $0 1)
+   (export "memory" (memory $0))
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $assert (i32.const 0) (i32.const 0))
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+
+   (data (i32.const 0) "call from doit")
+)
+)=====";
+
+// called from `doit1` action
+static const char different_actions_callee2_wast[] = R"=====(
+(module
+   (import "env" "eosio_assert" (func $assert (param i32 i32)))
+   (memory $0 1)
+   (export "memory" (memory $0))
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $assert (i32.const 0) (i32.const 0))
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+
+   (data (i32.const 0) "call from doit1")
+)
+)=====";
+
+// Verify calls from different actions work
+BOOST_AUTO_TEST_CASE(calls_from_different_actions) { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   const auto& caller = account_name("caller");
+   t.create_account(caller);
+   t.set_code(caller, different_actions_caller_wast);
+   t.set_abi(caller, doit_abi);
+
+   const auto& callee1 = account_name("callee1");
+   t.create_account(callee1);
+   t.set_code(callee1, different_actions_callee1_wast);
+
+   const auto& callee2 = account_name("callee2");
+   t.create_account(callee2);
+   t.set_code(callee2, different_actions_callee2_wast);
+
+   t.produce_block();
+
+   // Do a sync call from action "doit"_n
+   BOOST_CHECK_EXCEPTION(t.push_action(caller, "doit"_n, caller, {}),
+                         eosio_assert_message_exception,
+                         fc_exception_message_contains("call from doit"));
+
+   // Do another sync call from action "doit1"_n
+   BOOST_CHECK_EXCEPTION(t.push_action(caller, "doit1"_n, caller, {}),
+                         eosio_assert_message_exception,
+                         fc_exception_message_contains("call from doit1"));
+} FC_LOG_AND_RETHROW() }
+
+// Make recursive sync calls
+static const char recursive_caller_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "eosio_assert" (func $assert (param i32 i32)))
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $callee i64 (i64.const 4729647295212027904))
+
+   ;; sync call a function in "callee"_n
+   (func $doit (param $first_time i32)
+      (i32.const 1)
+      (get_local $first_time)
+      i32.eq  ;; if $first_time is 1, call callee, otherwise exit
+      if
+         (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8))
+      else
+         (call $assert (i32.const 0) (i32.const 0))  ;; called recursive from sync_call
+      end
+   )
+
+   ;; called recursively from callee
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $doit (i32.const 0)) ;; argument 0 to request doit to exit
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (call $doit (i32.const 1)) ;; argument 1 to request doit to call callee
+   )
+
+   (data (i32.const 0) "recursively called")
+)
+)=====";
+
+static const char recursive_callee_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $caller i64 (i64.const 4729647518550327296))
+
+   ;; called from caller and calls caller again
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $call (get_global $caller) (i64.const 0)(i32.const 0)(i32.const 8))
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+)
+)=====";
+
+// Verify recursive calls abort
+BOOST_AUTO_TEST_CASE(recursive_calls) { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+   ilog("!!! caller: ${c}", ("c", "caller"_n.to_uint64_t()));
+
+   const auto& caller = account_name("caller");
+   t.create_account(caller);
+   t.set_code(caller, recursive_caller_wast);
+   t.set_abi(caller, doit_abi);
+
+   const auto& callee = account_name("callee");
+   t.create_account(callee);
+   t.set_code(callee, recursive_callee_wast);
+
+   t.produce_block();
+
+   // Do a sync call from action "doit"_n
+   BOOST_CHECK_EXCEPTION(t.push_action(caller, "doit"_n, caller, {}),
+                         eosio_assert_message_exception,
+                         fc_exception_message_contains("recursively called"));
+} FC_LOG_AND_RETHROW() }
+
+// Verify sync call fails if receiver account does not exist
+BOOST_AUTO_TEST_CASE(receiver_account_not_existent) { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   const auto& caller = account_name("caller");
+   t.create_account(caller);
+   t.set_code(caller, caller_wast);
+   t.set_abi(caller, doit_abi);
+
+   // The caller intends to call a function in "callee"_n account, which is not created. 
+   BOOST_CHECK_EXCEPTION(t.push_action(caller, "doit"_n, caller, {}),
+                         action_validate_exception,
+                         fc_exception_message_contains("does not exist"));
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -293,6 +293,72 @@ BOOST_AUTO_TEST_CASE(seq_sync_calls) { try {
                          fc_exception_message_contains("calls in sequence"));
 } FC_LOG_AND_RETHROW() }
 
+// Make a large number of sync calls in a loop
+static const char loop_caller_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+       (local $n i32)
+       (i32.const 500)
+       set_local $n      ;; n = 500;
+       (loop $loop
+          (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8))
+
+          get_local $n
+          i32.const 1
+          i32.sub        ;; top_of_stack = n - 1;
+          tee_local $n   ;; n = top_of_stack;
+          br_if $loop  ;; if (n != 0) { goto loop; }
+       )
+   )
+)
+)=====";
+
+// A dummy callee
+static const char loop_callee_wast[] = R"=====(
+(module
+   (memory $0 1)
+   (export "memory" (memory $0))
+
+   (func $callee)
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+      (call $callee)
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+)
+)=====";
+
+// Verify a large number of sequential calls can be made, to make sure resources
+// are not exhausted (like wasm allocators)
+BOOST_AUTO_TEST_CASE(large_number_of_sequential_test) { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   const auto& caller = account_name("caller");
+   t.create_account(caller);
+   t.set_code(caller, loop_caller_wast);
+   t.set_abi(caller, doit_abi);
+
+   const auto& callee = account_name("callee");
+   t.create_account(callee);
+   t.set_code(callee, loop_callee_wast);
+
+   BOOST_REQUIRE_NO_THROW(t.push_action(caller, "doit"_n, caller, {}));
+} FC_LOG_AND_RETHROW() }
+
 // Make sync calls from different actions
 static const char different_actions_caller_wast[] = R"=====(
 (module


### PR DESCRIPTION
This PR implements the core functionalities of sync calls, in particular the  `call` host function. The Unit tests show basic call flows are working:
* Sync calls whose receivers are the same as the senders
* Sync calls whose receivers are different from the senders
* Nested sync calls
* Recursive sync calls
* Sequential sync calls

Notes for reviewing:
* Please roughly follow the order of `libraries/chain/webassembly/sync_call.cpp`, `libraries/chain/apply_context.cpp` and `libraries/chain/webassembly/runtimes/eos-vm.cpp` to review
* `eosvm-oc` not working yet. https://github.com/AntelopeIO/spring/issues/1043  (sync call unit tests skip eosvm-oc)
* Please double check if `transaction_checktime_timer` related changes are correct
* Tests will be updated using return values and console output after sync call return value and call trace are implemented (next immediate tasks)
* Reset of apply_context iterator caches is tracked by a separate issue for keeping this PR focused on main call flow https://github.com/AntelopeIO/spring/issues/1252

Resolves https://github.com/AntelopeIO/spring/issues/1214