### PR TITLE
SC: Implement `get_call_data`, `set_call_return_value` and `get_call_data` host functions

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -301,6 +301,22 @@ action_name apply_context::get_sync_call_sender() const {
    return sync_call_ctx ? sync_call_ctx->receiver : get_receiver();
 }
 
+uint32_t apply_context::get_call_data(std::span<char> memory) const {
+   assert(sync_call_ctx.has_value() ^ (act != nullptr)); // can be only one of action and sync call
+   EOS_ASSERT(sync_call_ctx.has_value(), wasm_serialization_error,
+              "get_call_data can be only used in sync call");
+
+   const auto& data      = sync_call_ctx->data;
+   auto        data_size = data.size();
+   auto        copy_size = std::min(memory.size(), data_size);
+
+   // Copy up to the length of memory of data to memory
+   std::memcpy(memory.data(), data.data(), copy_size);
+
+   // Return the number of bytes of the data that can be retrieved
+   return data_size;
+}
+
 bool apply_context::is_account( const account_name& account )const {
    return nullptr != db.find<account_object,by_name>( account );
 }

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -321,7 +321,7 @@ uint32_t apply_context::get_call_return_value(std::span<char> memory) const {
    const auto copy_size = std::min(memory.size(), data_size);
 
    if (copy_size == 0) {
-      return 0;
+      return data_size;
    }
 
    // Copy up to the length of memory of data to memory
@@ -341,7 +341,7 @@ uint32_t apply_context::get_call_data(std::span<char> memory) const {
    auto        copy_size = std::min(memory.size(), data_size);
 
    if (copy_size == 0) {
-      return 0;
+      return data_size;
    }
 
    // Copy up to the length of memory of data to memory
@@ -361,7 +361,7 @@ void apply_context::set_call_return_value(std::span<const char> return_value) {
               action_return_value_exception,
               "sync call return value size must be less or equal to ${s} bytes", ("s", max_sync_call_data_size));
 
-   sync_call_ctx->return_value.assign( return_value.data(), return_value.data() + return_value.size() );
+   sync_call_ctx->return_value.assign(return_value.data(), return_value.data() + return_value.size());
 }
 
 bool apply_context::is_account( const account_name& account )const {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -288,7 +288,6 @@ uint32_t apply_context::execute_sync_call(name receiver, uint64_t flags, std::sp
             if (a_ctx.sync_call_ctx.has_value()) {
                sync_call_return_value = std::move(a_ctx.sync_call_ctx->return_value);
                return_value_size = sync_call_return_value->size();
-               dlog("sync_call_return_value size: ${s}", ("s", return_value_size));
             }
          } catch( const wasm_exit&) {}
       } FC_RETHROW_EXCEPTIONS(warn, "sync call exception on ${receiver}", ("receiver", receiver))

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -6315,6 +6315,7 @@ template<>
 void controller_impl::on_activation<builtin_protocol_feature_t::sync_call>() {
    db.modify( db.get<protocol_state_object>(), [&]( auto& ps ) {
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "call" );
+      add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "get_call_return_value" );
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "get_call_data" );
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "set_call_return_value" );
    } );

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -503,6 +503,7 @@ class apply_context {
       void exec_one();
       void exec();
       uint32_t execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
+      uint32_t get_call_return_value(std::span<char> memory) const;
       uint32_t get_call_data(std::span<char> memory) const;
       void set_call_return_value(std::span<const char> return_value);
       void execute_inline( action&& a );

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -502,8 +502,8 @@ class apply_context {
 
       void exec_one();
       void exec();
-      void execute_sync_call(name receiver, uint64_t flags, std::span<const char> data
-);
+      void execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
+      uint32_t get_call_data(std::span<char> memory) const;
       void execute_inline( action&& a );
       void execute_context_free_inline( action&& a );
       void schedule_deferred_transaction( const uint128_t& sender_id, account_name payer, transaction&& trx, bool replace_existing );

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -502,7 +502,7 @@ class apply_context {
 
       void exec_one();
       void exec();
-      void execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
+      uint32_t execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
       uint32_t get_call_data(std::span<char> memory) const;
       void set_call_return_value(std::span<const char> return_value);
       void execute_inline( action&& a );
@@ -630,6 +630,7 @@ class apply_context {
       bool                          context_free = false;
 
       std::optional<sync_call_context> sync_call_ctx{};  // only one of act and sync_call_ctx can be present
+      std::optional<std::vector<char>> sync_call_return_value{};
 
    public:
       std::vector<char>             action_return_value;

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -504,6 +504,7 @@ class apply_context {
       void exec();
       void execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
       uint32_t get_call_data(std::span<char> memory) const;
+      void set_call_return_value(std::span<const char> return_value);
       void execute_inline( action&& a );
       void execute_context_free_inline( action&& a );
       void schedule_deferred_transaction( const uint128_t& sender_id, account_name payer, transaction&& trx, bool replace_existing );

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -679,4 +679,13 @@ namespace eosio { namespace chain {
                                  3260000, "Finalizer exception" )
       FC_DECLARE_DERIVED_EXCEPTION( finalizer_safety_exception, finalizer_exception,
                                     3260001, "Finalizer safety file exception" )
+
+   FC_DECLARE_DERIVED_EXCEPTION( sync_call_exception,    chain_exception,
+                                 3270000, "Sync call exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( sync_call_validate_exception, sync_call_exception,
+                                    3270001, "Sync call validation exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( sync_call_return_value_exception, sync_call_exception,
+                                    3270002, "Sync call return value exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( sync_call_call_data_exception, sync_call_exception,
+                                    3270003, "Sync call call data exception" )
 } } // eosio::chain

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -4,9 +4,13 @@
 
 namespace eosio { namespace chain {
    struct sync_call_context {
+      // input
       account_name           sender{};
       account_name           receiver{};
       std::span<const char>  data{}; // includes function name, arguments, and other information
+
+      // output
+      std::vector<char>      return_value{};
    };
 } } /// namespace eosio::chain
 

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic_mapping.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic_mapping.hpp
@@ -281,6 +281,7 @@ inline constexpr auto get_intrinsic_table() {
       "env.set_finalizers",
       "eosvmoc_internal.check_memcpy_params",
       "env.call",
+      "env.get_call_return_value",
       "env.get_call_data",
       "env.set_call_return_value"
    );

--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -694,9 +694,10 @@ namespace webassembly {
           *                the sync call. LSB bit indicates read-only. All other bits
           *                are reserved to be 0.
           * @param data - the data of the sync call, which may include function name, arguments and other information.
+          * @return the number of bytes of the return value of the call (to be used by next get_call_return_value) .
           *
          */
-         void call(name receiver, uint64_t flags, span<const char> data);
+         uint32_t call(name receiver, uint64_t flags, span<const char> data);
 
          /**
           * Copies the last sync call return value to `memory` up to the length of `memory`.

--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -699,7 +699,19 @@ namespace webassembly {
          void call(name receiver, uint64_t flags, span<const char> data);
 
          /**
-          * Copies the current sync call data up to the length of memory.
+          * Copies the last sync call return value to `memory` up to the length of `memory`.
+          * This should be called by the caller right after `call` host function.
+          * Otherwise the return value will be overwritten by future sync calls in the same action or function
+          *
+          * @ingroup sync call
+          * @param memory - a pointer where up to the size of memory will be copied
+          *
+          * @return the number of bytes of the return value that can be retrieved (the number of total bytes).
+         */
+         uint32_t get_call_return_value(span<char> memory) const;
+
+         /**
+          * Copies the current sync call data to `memory` up to the length of `memory`.
           *
           * @ingroup sync call
           * @param memory - a pointer where up to the size of memory will be copied

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -519,6 +519,7 @@ REGISTER_HOST_FUNCTION(set_action_return_value);
 
 // sync call api. sync calls are not allowed in context-free actions
 REGISTER_HOST_FUNCTION(call);
+REGISTER_HOST_FUNCTION(get_call_return_value);
 REGISTER_HOST_FUNCTION(get_call_data);
 REGISTER_HOST_FUNCTION(set_call_return_value);
 

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -148,7 +148,7 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
                 iface, "env", "sync_call",
                 sync_call_ctx->sender.to_uint64_t(),
                 sync_call_ctx->receiver.to_uint64_t(),
-                static_cast<uint64_t>(sync_call_ctx->data.size())); // size_t can be uint32_t or uint64_t depending on architecture. Safely cast to uint64_t to always match the type expected by sync_call entry point.
+                static_cast<uint32_t>(sync_call_ctx->data.size()));
          };
 
          execute(context, bkend, exec_ctx, wasm_alloc, fn, true);

--- a/libraries/chain/webassembly/sync_call.cpp
+++ b/libraries/chain/webassembly/sync_call.cpp
@@ -10,8 +10,8 @@ namespace eosio { namespace chain { namespace webassembly {
       return 0;
    }
 
-   uint32_t interface::get_call_data(span<char> /* memory */) const {
-      return 0;
+   uint32_t interface::get_call_data(span<char> memory) const {
+      return context.get_call_data(memory);
    }
 
    void interface::set_call_return_value(span<const char> /* value */) {

--- a/libraries/chain/webassembly/sync_call.cpp
+++ b/libraries/chain/webassembly/sync_call.cpp
@@ -6,6 +6,10 @@ namespace eosio { namespace chain { namespace webassembly {
       context.execute_sync_call(receiver, flags, data);
    }
 
+   uint32_t interface::get_call_return_value(span<char> /* memory */) const {
+      return 0;
+   }
+
    uint32_t interface::get_call_data(span<char> /* memory */) const {
       return 0;
    }
@@ -13,5 +17,4 @@ namespace eosio { namespace chain { namespace webassembly {
    void interface::set_call_return_value(span<const char> /* value */) {
       ;
    }
-
 }}} // ns eosio::chain::webassembly

--- a/libraries/chain/webassembly/sync_call.cpp
+++ b/libraries/chain/webassembly/sync_call.cpp
@@ -6,8 +6,8 @@ namespace eosio { namespace chain { namespace webassembly {
       return context.execute_sync_call(receiver, flags, data);
    }
 
-   uint32_t interface::get_call_return_value(span<char> /* memory */) const {
-      return 0;
+   uint32_t interface::get_call_return_value(span<char> memory) const {
+      return context.get_call_return_value(memory);;
    }
 
    uint32_t interface::get_call_data(std::span<char> memory) const {

--- a/libraries/chain/webassembly/sync_call.cpp
+++ b/libraries/chain/webassembly/sync_call.cpp
@@ -10,11 +10,11 @@ namespace eosio { namespace chain { namespace webassembly {
       return 0;
    }
 
-   uint32_t interface::get_call_data(span<char> memory) const {
+   uint32_t interface::get_call_data(std::span<char> memory) const {
       return context.get_call_data(memory);
    }
 
-   void interface::set_call_return_value(span<const char> /* value */) {
-      ;
+   void interface::set_call_return_value(std::span<const char> return_value) {
+      context.set_call_return_value(return_value);;
    }
 }}} // ns eosio::chain::webassembly

--- a/libraries/chain/webassembly/sync_call.cpp
+++ b/libraries/chain/webassembly/sync_call.cpp
@@ -2,8 +2,8 @@
 #include <eosio/chain/apply_context.hpp>
 
 namespace eosio { namespace chain { namespace webassembly {
-   void interface::call(name receiver, uint64_t flags, std::span<const char> data) {
-      context.execute_sync_call(receiver, flags, data);
+   uint32_t interface::call(name receiver, uint64_t flags, std::span<const char> data) {
+      return context.execute_sync_call(receiver, flags, data);
    }
 
    uint32_t interface::get_call_return_value(span<char> /* memory */) const {

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -2319,19 +2319,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(set_finalizers_test, T, testers) { try {
 // A basic contract to show new host functions can be called.
 static const char basic_sync_call_host_funcs_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32)))
+   (import "env" "call" (func $call (param i64 i64 i32 i32)(result i32)))
    (import "env" "get_call_data" (func $get_call_data (param i32 i32)(result i32)))
    (import "env" "set_call_return_value" (func $set_call_return_value (param i32 i32)))
    (memory $0 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32))
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param  $action_name i64)
-      (call $call (get_local $receiver) (i64.const 0) (i32.const 8) (i32.const 16))
-      (drop (call $get_call_data (i32.const 8) (i32.const 16)))
-      (call $set_call_return_value (i32.const 8) (i32.const 16))
+      (drop (call $call (get_local $receiver) (i64.const 0) (i32.const 8) (i32.const 16)))
    )
 )
 )=====";

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -526,10 +526,14 @@ static const char basic_params_return_value_caller_wast[] = R"=====(
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
-      (drop (call $read_action_data(i32.const 0)(i32.const 4)))       ;; read action input into address 0
-      (drop (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 4))) ;; make a sync call with data starting at address 0
-      (drop (call $get_call_return_value (i32.const 8)(i32.const 4))) ;; save return value at address 8
-      (call $set_action_return_value (i32.const 8) (i32.const 4))     ;; set the return value to action_return_value so test can check in action trace
+      (local $input_size i32)
+      (local $return_value_size i32)
+      (call $read_action_data(i32.const 0)(i32.const 4))       ;; read action input into address 0
+      set_local $input_size
+      (call $call (get_global $callee) (i64.const 0)(i32.const 0)(get_local $input_size)) ;; make a sync call with data starting at address 0
+      set_local $return_value_size
+      (drop (call $get_call_return_value (i32.const 8)(get_local $return_value_size))) ;; save return value at address 8
+      (call $set_action_return_value (i32.const 8) (get_local $return_value_size))     ;; set the return value to action_return_value so test can check in action trace
    )
 )
 )=====";

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(receiver_account_not_existent) { try {
 
    // The caller intends to call a function in "callee"_n account, which is not created. 
    BOOST_CHECK_EXCEPTION(t.push_action(caller, "doit"_n, caller, {}),
-                         action_validate_exception,
+                         sync_call_validate_exception,
                          fc_exception_message_contains("does not exist"));
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -22,7 +22,7 @@ static const char* doit_abi = R"=====(
 static const char sync_call_in_same_account_wast[] = R"=====(
 (module
    (import "env" "eosio_assert" (func $assert (param i32 i32)))
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
 
@@ -37,7 +37,7 @@ static const char sync_call_in_same_account_wast[] = R"=====(
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
-      (call $call (get_local $receiver) (i64.const 0)(i32.const 0)(i32.const 8)) ;; using the same receiver
+      (drop (call $call (get_local $receiver) (i64.const 0)(i32.const 0)(i32.const 8))) ;; using the same receiver
    )
 
    (data (i32.const 0) "sync_call in same contract called")
@@ -67,14 +67,14 @@ BOOST_AUTO_TEST_CASE(same_account) { try {
 // Make a sync call to a function in "callee"_n account
 static const char caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
-      (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8))
+      (drop (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8)))
    )
 )
 )=====";
@@ -128,14 +128,14 @@ BOOST_AUTO_TEST_CASE(different_account) { try {
 // Calls "callee1"_n
 static const char call_depth_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee1 i64 (i64.const 4729647295748898816)) ;; "calllee1"_n uint64 value
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
-      (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8))
+      (drop (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8)))
    )
 )
 )=====";
@@ -143,14 +143,14 @@ static const char call_depth_wast[] = R"=====(
 // Calls "callee2"_n
 static const char callee1_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee2 i64 (i64.const 4729647296285769728)) ;; "calllee2"_n uint64 value
 
    ;; callee intentionally asserts such that the test can check it was called
    (func $callee
-      (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8))
+      (drop (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8)))
    )
 
    (export "sync_call" (func $sync_call))
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(multi_level_call_depth) { try {
 // Call "callee1"_n and "callee2"_n in sequence
 static const char seq_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee1 i64 (i64.const 4729647295748898816))
@@ -225,8 +225,8 @@ static const char seq_caller_wast[] = R"=====(
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
-      (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8))
-      (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8))
+      (drop (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8)))
+      (drop (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8)))
    )
 )
 )=====";
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(seq_sync_calls) { try {
 // Make sync calls from different actions
 static const char different_actions_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $doit_value i64 (i64.const 5556755844919459840))
@@ -305,12 +305,12 @@ static const char different_actions_caller_wast[] = R"=====(
 
    ;; sync call a function in "callee1"_n
    (func $doit
-      (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8))
+      (drop (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 8)))
    )
 
    ;; sync call a function in "callee2"_n
    (func $doit1
-      (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8))
+      (drop (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 8)))
    )
 
    (export "apply" (func $apply))
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(calls_from_different_actions) { try {
 // Make recursive sync calls
 static const char recursive_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (import "env" "eosio_assert" (func $assert (param i32 i32)))
    (memory $0 1)
    (export "memory" (memory $0))
@@ -415,7 +415,7 @@ static const char recursive_caller_wast[] = R"=====(
       (get_local $first_time)
       i32.eq  ;; if $first_time is 1, call callee, otherwise exit
       if
-         (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8))
+         (drop (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8)))
       else
          (call $assert (i32.const 0) (i32.const 0))  ;; called recursive from sync_call
       end
@@ -438,7 +438,7 @@ static const char recursive_caller_wast[] = R"=====(
 
 static const char recursive_callee_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $caller i64 (i64.const 4729647518550327296))
@@ -446,7 +446,7 @@ static const char recursive_callee_wast[] = R"=====(
    ;; called from caller and calls caller again
    (export "sync_call" (func $sync_call))
    (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
-      (call $call (get_global $caller) (i64.const 0)(i32.const 0)(i32.const 8))
+      (drop (call $call (get_global $caller) (i64.const 0)(i32.const 0)(i32.const 8)))
    )
 
    (export "apply" (func $apply))

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(seq_sync_calls) { try {
 // Make a large number of sync calls in a loop
 static const char loop_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
@@ -316,13 +316,13 @@ static const char loop_caller_wast[] = R"=====(
        (i32.const 500)
        set_local $n      ;; n = 500;
        (loop $loop
-          (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8))
+          (drop (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8)))
 
           get_local $n
           i32.const 1
           i32.sub        ;; top_of_stack = n - 1;
           tee_local $n   ;; n = top_of_stack;
-          br_if $loop  ;; if (n != 0) { goto loop; }
+          br_if $loop    ;; if (n != 0) { goto loop; }
        )
    )
 )
@@ -337,7 +337,7 @@ static const char loop_callee_wast[] = R"=====(
    (func $callee)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
       (call $callee)
    )
 


### PR DESCRIPTION
This PR implements the remaining sync call host functions. Basic sync call protocol level functionalities are in place. 

Unit test `basic_params_return_value_passing` shows a complete end to end sync call in WASM code using the host functions in the following steps
1. making a sync call, 
2. passing arguments, 
3. saving return value, 
4. retrieving return value

Resolves https://github.com/AntelopeIO/spring/issues/1215