### PR TITLE
SC: Validate sync call entry point

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library( eosio_chain
               asset.cpp
               snapshot.cpp
               snapshot_scheduler.cpp
+              sync_call_context.cpp
               deep_mind.cpp
 
              ${CHAIN_EOSVMOC_SOURCES}

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -259,8 +259,8 @@ int32_t apply_context::execute_sync_call(name receiver, uint64_t flags, std::spa
    const auto max_sync_call_data_size = control.get_global_properties().configuration.max_sync_call_data_size;
    EOS_ASSERT(data.size() <= max_sync_call_data_size, sync_call_call_data_exception,
               "sync call call data size must be less or equal to ${s} bytes", ("s", max_sync_call_data_size));
-   EOS_ASSERT(flags <= static_cast<uint64_t>(sync_call_flags::last), sync_call_validate_exception,  // all but last `std::bit_width(sync_call_flags::last)` bits must be 0s
-              "only ${last} least significant bits of sync call's flags (${flags}) can be set", ("last", std::bit_width(static_cast<uint64_t>(sync_call_flags::last)))("flags", flags));
+   EOS_ASSERT(flags <= static_cast<uint64_t>(sync_call_flags::all_allowed_bits), sync_call_validate_exception,  // all but `std::bit_width(all_allowed_bits)` LSBs must be 0s
+              "only ${bits} least significant bits of sync call's flags (${flags}) can be set", ("bits", std::bit_width(static_cast<uint64_t>(sync_call_flags::all_allowed_bits)))("flags", flags));
 
    auto handle_exception = [&](const auto& e)
    {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -247,7 +247,7 @@ void apply_context::exec()
 
 } /// exec()
 
-int32_t apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<const char> data) {
+int64_t apply_context::execute_sync_call(name receiver, uint64_t flags, std::span<const char> data) {
    assert(sync_call_ctx.has_value() ^ (act != nullptr)); // can be only one of action and sync call
 
    dlog("receiver: ${r}, flags: ${f}, data size: ${s}",

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -259,8 +259,8 @@ uint32_t apply_context::execute_sync_call(name receiver, uint64_t flags, std::sp
    const auto max_sync_call_data_size = control.get_global_properties().configuration.max_sync_call_data_size;
    EOS_ASSERT(data.size() <= max_sync_call_data_size, sync_call_call_data_exception,
               "sync call call data size must be less or equal to ${s} bytes", ("s", max_sync_call_data_size));
-   EOS_ASSERT((flags & ~0b11) == 0, sync_call_validate_exception,  // all but last 2 bits are 0s
-              "only two least significant bits of sync call's flags (${flags}) can be set", ("flags", flags)); // bit 0 for read-only, bit 1 for no-op if no sync call entry point exists
+   EOS_ASSERT(flags <= static_cast<uint64_t>(sync_call_flags::last), sync_call_validate_exception,  // all but last `sync_call_flags::last` bits must be 0s
+              "only ${last} least significant bits of sync call's flags (${flags}) can be set", ("last", static_cast<uint64_t>(sync_call_flags::last))("flags", flags));
 
    auto handle_exception = [&](const auto& e)
    {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -259,8 +259,8 @@ int32_t apply_context::execute_sync_call(name receiver, uint64_t flags, std::spa
    const auto max_sync_call_data_size = control.get_global_properties().configuration.max_sync_call_data_size;
    EOS_ASSERT(data.size() <= max_sync_call_data_size, sync_call_call_data_exception,
               "sync call call data size must be less or equal to ${s} bytes", ("s", max_sync_call_data_size));
-   EOS_ASSERT(flags <= static_cast<uint64_t>(sync_call_flags::last), sync_call_validate_exception,  // all but last `sync_call_flags::last` bits must be 0s
-              "only ${last} least significant bits of sync call's flags (${flags}) can be set", ("last", static_cast<uint64_t>(sync_call_flags::last))("flags", flags));
+   EOS_ASSERT(flags <= static_cast<uint64_t>(sync_call_flags::last), sync_call_validate_exception,  // all but last `std::bit_width(sync_call_flags::last)` bits must be 0s
+              "only ${last} least significant bits of sync call's flags (${flags}) can be set", ("last", std::bit_width(static_cast<uint64_t>(sync_call_flags::last)))("flags", flags));
 
    auto handle_exception = [&](const auto& e)
    {

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -495,7 +495,7 @@ class apply_context {
    /// Constructor
    public:
       apply_context(controller& con, transaction_context& trx_ctx, uint32_t action_ordinal, uint32_t depth=0);
-      apply_context(controller& con, transaction_context& trx_ctx, name sender, name receiver, std::span<const char> data);  // used to construct sync call context
+      apply_context(controller& con, transaction_context& trx_ctx, name sender, name receiver, uint64_t flags, std::span<const char> data);  // used to construct sync call context
 
    /// Execution methods:
    public:
@@ -605,6 +605,7 @@ class apply_context {
       const action& get_action()const { return *act; }
       const action* get_action_ptr()const { return act; }
       const std::optional<sync_call_context>& get_sync_call_ctx()const { return sync_call_ctx; }
+      std::optional<sync_call_context>& get_mutable_sync_call_ctx() { return sync_call_ctx; }
 
       action_name get_sender() const;
 

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -502,7 +502,7 @@ class apply_context {
 
       void exec_one();
       void exec();
-      uint32_t execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
+      int32_t  execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
       uint32_t get_call_return_value(std::span<char> memory) const;
       uint32_t get_call_data(std::span<char> memory) const;
       void set_call_return_value(std::span<const char> return_value);

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -502,7 +502,7 @@ class apply_context {
 
       void exec_one();
       void exec();
-      int32_t  execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
+      int64_t execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
       uint32_t get_call_return_value(std::span<char> memory) const;
       uint32_t get_call_data(std::span<char> memory) const;
       void set_call_return_value(std::span<const char> return_value);

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -688,6 +688,4 @@ namespace eosio { namespace chain {
                                     3270002, "Sync call return value size is too large" )
       FC_DECLARE_DERIVED_EXCEPTION( sync_call_call_data_exception, sync_call_exception,
                                     3270003, "Sync call data size is too large" )
-      FC_DECLARE_DERIVED_EXCEPTION( sync_call_not_supported_by_receiver_exception, sync_call_exception,
-                                    3270004, "Sync call is not supported by the receiver" )
 } } // eosio::chain

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -685,7 +685,9 @@ namespace eosio { namespace chain {
       FC_DECLARE_DERIVED_EXCEPTION( sync_call_validate_exception, sync_call_exception,
                                     3270001, "Sync call validation exception" )
       FC_DECLARE_DERIVED_EXCEPTION( sync_call_return_value_exception, sync_call_exception,
-                                    3270002, "Sync call return value exception" )
+                                    3270002, "Sync call return value size is too large" )
       FC_DECLARE_DERIVED_EXCEPTION( sync_call_call_data_exception, sync_call_exception,
-                                    3270003, "Sync call call data exception" )
+                                    3270003, "Sync call data size is too large" )
+      FC_DECLARE_DERIVED_EXCEPTION( sync_call_not_supported_by_receiver_exception, sync_call_exception,
+                                    3270004, "Sync call is not supported by the receiver" )
 } } // eosio::chain

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -3,6 +3,12 @@
 #include <eosio/chain/types.hpp>
 
 namespace eosio { namespace chain {
+   enum class sync_call_flags {
+      read_only                               = 1ull<<0,
+      no_op_if_receiver_not_support_sync_call = 1ull<<1,
+      last                                    = no_op_if_receiver_not_support_sync_call
+   };
+
    struct sync_call_context {
       sync_call_context(account_name sender, account_name receiver, uint64_t flags, std::span<const char>  data);
       bool is_read_only()const;

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -8,9 +8,12 @@ namespace eosio { namespace chain {
       success                        = 0
    };
 
+   // A bitmap. Only least significant bits can be set. Other bits must be 0.
+   // When a new flag is added, its enum value must be 1 bit left shift from the last flag.
+   // Update all_allowed_bits to include the newly added enum value.
    enum class sync_call_flags {
-      read_only  = 1ull<<0,
-      last       = read_only
+      read_only         = 1ull<<0,
+      all_allowed_bits  = read_only
    };
 
    struct sync_call_context {

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -4,15 +4,13 @@
 
 namespace eosio { namespace chain {
    enum class sync_call_flags {
-      read_only                               = 1ull<<0,
-      no_op_if_receiver_not_support_sync_call = 1ull<<1,
-      last                                    = no_op_if_receiver_not_support_sync_call
+      read_only  = 1ull<<0,
+      last       = read_only
    };
 
    struct sync_call_context {
       sync_call_context(account_name sender, account_name receiver, uint64_t flags, std::span<const char>  data);
       bool is_read_only()const;
-      bool no_op_if_receiver_not_support_sync_call()const;
 
       // input
       account_name           sender{};

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -3,6 +3,11 @@
 #include <eosio/chain/types.hpp>
 
 namespace eosio { namespace chain {
+   enum class sync_call_return_code : int32_t {
+      receiver_not_support_sync_call = -1,  // no sync_call entry point or its signature is invalid
+      success                        = 0
+   };
+
    enum class sync_call_flags {
       read_only  = 1ull<<0,
       last       = read_only
@@ -20,7 +25,9 @@ namespace eosio { namespace chain {
 
       // output
       std::vector<char>      return_value{};
+
+      bool receiver_supports_sync_call = false; // the receiver contract has valid sync_call entry point
    };
 } } /// namespace eosio::chain
 
-FC_REFLECT(eosio::chain::sync_call_context, (sender)(receiver)(flags)(data)(return_value))
+FC_REFLECT(eosio::chain::sync_call_context, (sender)(receiver)(flags)(data)(return_value)(receiver_supports_sync_call))

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -5,7 +5,6 @@
 namespace eosio { namespace chain {
    struct sync_call_context {
       sync_call_context(account_name sender, account_name receiver, uint64_t flags, std::span<const char>  data);
-      void set_receiver_supports_sync_call(bool supported);
       bool is_read_only()const;
       bool no_op_if_receiver_not_support_sync_call()const;
 
@@ -17,10 +16,7 @@ namespace eosio { namespace chain {
 
       // output
       std::vector<char>      return_value{};
-
-      // temporary
-      bool                   receiver_supports_sync_call = false; // the receiver contract has valid sync_call entry point
    };
 } } /// namespace eosio::chain
 
-FC_REFLECT(eosio::chain::sync_call_context, (sender)(receiver)(flags)(data)(return_value)(receiver_supports_sync_call))
+FC_REFLECT(eosio::chain::sync_call_context, (sender)(receiver)(flags)(data)(return_value))

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -4,14 +4,23 @@
 
 namespace eosio { namespace chain {
    struct sync_call_context {
+      sync_call_context(account_name sender, account_name receiver, uint64_t flags, std::span<const char>  data);
+      void set_receiver_supports_sync_call(bool supported);
+      bool is_read_only()const;
+      bool no_op_if_receiver_not_support_sync_call()const;
+
       // input
       account_name           sender{};
       account_name           receiver{};
+      uint64_t               flags = 0;
       std::span<const char>  data{}; // includes function name, arguments, and other information
 
       // output
       std::vector<char>      return_value{};
+
+      // temporary
+      bool                   receiver_supports_sync_call = false; // the receiver contract has valid sync_call entry point
    };
 } } /// namespace eosio::chain
 
-FC_REFLECT(eosio::chain::sync_call_context, (sender)(receiver)(data))
+FC_REFLECT(eosio::chain::sync_call_context, (sender)(receiver)(flags)(data)(return_value)(receiver_supports_sync_call))

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -3,6 +3,7 @@
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/whitelisted_intrinsics.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/sync_call_context.hpp>
 #include <functional>
 
 namespace eosio { namespace chain {
@@ -76,7 +77,7 @@ namespace eosio { namespace chain {
          //Calls apply or error on a given code
          void apply(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context);
 
-         void do_sync_call(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context);
+         sync_call_return_code do_sync_call(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context);
 
          //Returns true if the code is cached
          bool is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const;

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -42,6 +42,7 @@ namespace eosio { namespace chain {
          std::unique_ptr<wasm_instantiated_module_interface>  module;
          uint8_t                                              vm_type = 0;
          uint8_t                                              vm_version = 0;
+         bool                                                 sync_call_supported = false;
       };
       struct by_hash;
       struct by_last_block_num;
@@ -181,7 +182,7 @@ struct eosvmoc_tier {
          if (allow_oc_interrupt)
             executing_code_hash.store(code_hash);
          try {
-            get_instantiated_module(code_hash, vm_type, vm_version, context.trx_context)->apply(context);
+            get_instantiated_module(code_hash, vm_type, vm_version, context)->apply(context);
          } catch (const interrupt_exception& e) {
             if (allow_oc_interrupt && eos_vm_oc_compile_interrupt && main_thread_timer.timer_state() == platform_timer::state_t::interrupted) {
                ++eos_vm_oc_compile_interrupt_count;
@@ -196,8 +197,8 @@ struct eosvmoc_tier {
          }
       }
 
-      void do_sync_call( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
-         get_instantiated_module(code_hash, vm_type, vm_version, context.trx_context)->do_sync_call(context);
+      sync_call_return_code do_sync_call( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
+         return get_instantiated_module(code_hash, vm_type, vm_version, context)->do_sync_call(context);
       }
 
       // used for testing
@@ -248,16 +249,16 @@ struct eosvmoc_tier {
          const digest_type&   code_hash,
          const uint8_t&       vm_type,
          const uint8_t&       vm_version,
-         transaction_context& trx_context)
+         apply_context&       context)
       {
-         if (trx_context.control.is_write_window()) {
+         if (context.trx_context.control.is_write_window()) {
             // When in write window (either read only threads are not enabled or
             // they are not schedued to run), only main thread is processing
             // transactions. No need to lock.
-            return get_or_build_instantiated_module(code_hash, vm_type, vm_version, trx_context);
+            return get_or_build_instantiated_module(code_hash, vm_type, vm_version, context);
          } else {
             std::lock_guard g(instantiation_cache_mutex);
-            return get_or_build_instantiated_module(code_hash, vm_type, vm_version, trx_context);
+            return get_or_build_instantiated_module(code_hash, vm_type, vm_version, context);
          }
       }
 
@@ -266,12 +267,15 @@ struct eosvmoc_tier {
          const digest_type&   code_hash,
          const uint8_t&       vm_type,
          const uint8_t&       vm_version,
-         transaction_context& trx_context)
+         apply_context&       context)
       {
          wasm_cache_index::iterator it = wasm_instantiation_cache.find( boost::make_tuple(code_hash, vm_type, vm_version) );
          if (it != wasm_instantiation_cache.end()) {
             // An instantiated module's module should never be null.
             assert(it->module);
+            if (context.get_sync_call_ctx().has_value()) {
+               context.get_mutable_sync_call_ctx()->receiver_supports_sync_call = it->sync_call_supported;
+            }
             return it->module;
          }
 
@@ -281,14 +285,21 @@ struct eosvmoc_tier {
             .last_block_num_used = UINT32_MAX,
             .module = nullptr,
             .vm_type = vm_type,
-            .vm_version = vm_version
+            .vm_version = vm_version,
+            .sync_call_supported = false
          } ).first;
          auto timer_pause = fc::make_scoped_exit([&](){
-            trx_context.resume_billing_timer();
+            context.trx_context.resume_billing_timer();
          });
-         trx_context.pause_billing_timer();
+         context.trx_context.pause_billing_timer();
          wasm_instantiation_cache.modify(it, [&](auto& c) {
-            c.module = runtime_interface->instantiate_module(codeobject->code.data(), codeobject->code.size(), code_hash, vm_type, vm_version);
+            bool sync_call_supported = false;
+
+            c.module = runtime_interface->instantiate_module(codeobject->code.data(), codeobject->code.size(), code_hash, vm_type, vm_version, sync_call_supported);  // sets sync_call_supported
+            c.sync_call_supported = sync_call_supported;
+            if (context.get_sync_call_ctx().has_value()) {
+               context.get_mutable_sync_call_ctx()->receiver_supports_sync_call = sync_call_supported;
+            }
          });
          return it->module;
       }

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -181,7 +181,7 @@ struct eosvmoc_tier {
          if (allow_oc_interrupt)
             executing_code_hash.store(code_hash);
          try {
-            get_instantiated_module(code_hash, vm_type, vm_version, context)->apply(context);
+            get_instantiated_module(code_hash, vm_type, vm_version, context.trx_context)->apply(context);
          } catch (const interrupt_exception& e) {
             if (allow_oc_interrupt && eos_vm_oc_compile_interrupt && main_thread_timer.timer_state() == platform_timer::state_t::interrupted) {
                ++eos_vm_oc_compile_interrupt_count;
@@ -197,7 +197,7 @@ struct eosvmoc_tier {
       }
 
       void do_sync_call( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
-         get_instantiated_module(code_hash, vm_type, vm_version, context)->do_sync_call(context);
+         get_instantiated_module(code_hash, vm_type, vm_version, context.trx_context)->do_sync_call(context);
       }
 
       // used for testing
@@ -248,16 +248,16 @@ struct eosvmoc_tier {
          const digest_type&   code_hash,
          const uint8_t&       vm_type,
          const uint8_t&       vm_version,
-         apply_context&       context)
+         transaction_context& trx_context)
       {
-         if (context.trx_context.control.is_write_window()) {
+         if (trx_context.control.is_write_window()) {
             // When in write window (either read only threads are not enabled or
             // they are not schedued to run), only main thread is processing
             // transactions. No need to lock.
-            return get_or_build_instantiated_module(code_hash, vm_type, vm_version, context);
+            return get_or_build_instantiated_module(code_hash, vm_type, vm_version, trx_context);
          } else {
             std::lock_guard g(instantiation_cache_mutex);
-            return get_or_build_instantiated_module(code_hash, vm_type, vm_version, context);
+            return get_or_build_instantiated_module(code_hash, vm_type, vm_version, trx_context);
          }
       }
 
@@ -266,7 +266,7 @@ struct eosvmoc_tier {
          const digest_type&   code_hash,
          const uint8_t&       vm_type,
          const uint8_t&       vm_version,
-         apply_context&       context)
+         transaction_context& trx_context)
       {
          wasm_cache_index::iterator it = wasm_instantiation_cache.find( boost::make_tuple(code_hash, vm_type, vm_version) );
          if (it != wasm_instantiation_cache.end()) {
@@ -281,12 +281,12 @@ struct eosvmoc_tier {
             .last_block_num_used = UINT32_MAX,
             .module = nullptr,
             .vm_type = vm_type,
-            .vm_version = vm_version,
+            .vm_version = vm_version
          } ).first;
          auto timer_pause = fc::make_scoped_exit([&](){
-            context.trx_context.resume_billing_timer();
+            trx_context.resume_billing_timer();
          });
-         context.trx_context.pause_billing_timer();
+         trx_context.pause_billing_timer();
          wasm_instantiation_cache.modify(it, [&](auto& c) {
             c.module = runtime_interface->instantiate_module(codeobject->code.data(), codeobject->code.size(), code_hash, vm_type, vm_version);
          });

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc.hpp
@@ -30,7 +30,7 @@ class eosvmoc_runtime : public eosio::chain::wasm_runtime_interface {
       eosvmoc_runtime(const std::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, const chainbase::database& db);
       ~eosvmoc_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
 
       void init_thread_local_data() override;
 

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc.hpp
@@ -30,7 +30,7 @@ class eosvmoc_runtime : public eosio::chain::wasm_runtime_interface {
       eosvmoc_runtime(const std::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, const chainbase::database& db);
       ~eosvmoc_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) override;
 
       void init_thread_local_data() override;
 

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc.hpp
@@ -30,7 +30,7 @@ class eosvmoc_runtime : public eosio::chain::wasm_runtime_interface {
       eosvmoc_runtime(const std::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, const chainbase::database& db);
       ~eosvmoc_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& ) override;
 
       void init_thread_local_data() override;
 

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
@@ -45,7 +45,7 @@ class eos_vm_runtime : public eosio::chain::wasm_runtime_interface {
    public:
       eos_vm_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) override;
 
    private:
       // todo: managing this will get more complicated with sync calls;
@@ -63,7 +63,7 @@ class eos_vm_profile_runtime : public eosio::chain::wasm_runtime_interface {
    public:
       eos_vm_profile_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) override;
 };
 
 }}}}// eosio::chain::webassembly::eos_vm_runtime

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
@@ -45,7 +45,7 @@ class eos_vm_runtime : public eosio::chain::wasm_runtime_interface {
    public:
       eos_vm_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
 
    private:
       // todo: managing this will get more complicated with sync calls;
@@ -63,7 +63,7 @@ class eos_vm_profile_runtime : public eosio::chain::wasm_runtime_interface {
    public:
       eos_vm_profile_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
 };
 
 }}}}// eosio::chain::webassembly::eos_vm_runtime

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
@@ -31,7 +31,7 @@ using namespace eosio::vm;
 
 void validate(const bytes& code, const whitelisted_intrinsics_type& intrinsics );
 
-void validate(const bytes& code, const wasm_config& cfg, const whitelisted_intrinsics_type& intrinsics );
+void validate(const controller& control, const bytes& code, const wasm_config& cfg, const whitelisted_intrinsics_type& intrinsics );
 
 struct apply_options;
 
@@ -45,7 +45,7 @@ class eos_vm_runtime : public eosio::chain::wasm_runtime_interface {
    public:
       eos_vm_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) override;
 
    private:
       // todo: managing this will get more complicated with sync calls;
@@ -63,7 +63,7 @@ class eos_vm_profile_runtime : public eosio::chain::wasm_runtime_interface {
    public:
       eos_vm_profile_runtime();
       std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) override;
 };
 
 }}}}// eosio::chain::webassembly::eos_vm_runtime

--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -694,10 +694,10 @@ namespace webassembly {
           *                the sync call. LSB bit indicates read-only. All other bits
           *                are reserved to be 0.
           * @param data - the data of the sync call, which may include function name, arguments and other information.
-          * @return the number of bytes of the return value of the call (to be used by next get_call_return_value) .
+          * @return the number of bytes of the return value of the call (to be used by next get_call_return_value) if succeeded, return -1 if sync_call entry point does not exist or has invalid signature .
           *
          */
-         uint32_t call(name receiver, uint64_t flags, span<const char> data);
+         int32_t call(name receiver, uint64_t flags, span<const char> data);
 
          /**
           * Copies the last sync call return value to `memory` up to the length of `memory`.

--- a/libraries/chain/include/eosio/chain/webassembly/interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/interface.hpp
@@ -694,10 +694,11 @@ namespace webassembly {
           *                the sync call. LSB bit indicates read-only. All other bits
           *                are reserved to be 0.
           * @param data - the data of the sync call, which may include function name, arguments and other information.
-          * @return the number of bytes of the return value of the call (to be used by next get_call_return_value) if succeeded, return -1 if sync_call entry point does not exist or has invalid signature .
+          * @return -1 if sync_call entry point does not exist or has invalid signature
+          * @return the number of bytes of the return value of the call (to be used by next get_call_return_value) if succeeded
           *
          */
-         int32_t call(name receiver, uint64_t flags, span<const char> data);
+         int64_t call(name receiver, uint64_t flags, span<const char> data);
 
          /**
           * Copies the last sync call return value to `memory` up to the length of `memory`.

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -13,7 +13,7 @@ class apply_context;
 class wasm_instantiated_module_interface {
    public:
       virtual void apply(apply_context& context) = 0;
-      virtual void do_sync_call(apply_context& context) = 0;
+      virtual sync_call_return_code do_sync_call(apply_context& context) = 0;
 
       virtual ~wasm_instantiated_module_interface();
 };
@@ -21,7 +21,7 @@ class wasm_instantiated_module_interface {
 class wasm_runtime_interface {
    public:
       virtual std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                     const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) = 0;
+                                                                                     const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supporte) = 0;
 
       virtual ~wasm_runtime_interface();
 

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -21,7 +21,7 @@ class wasm_instantiated_module_interface {
 class wasm_runtime_interface {
    public:
       virtual std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                     const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supporte) = 0;
+                                                                                     const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) = 0;
 
       virtual ~wasm_runtime_interface();
 

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -21,7 +21,7 @@ class wasm_instantiated_module_interface {
 class wasm_runtime_interface {
    public:
       virtual std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                     const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supporte) = 0;
+                                                                                     const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) = 0;
 
       virtual ~wasm_runtime_interface();
 

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -21,7 +21,7 @@ class wasm_instantiated_module_interface {
 class wasm_runtime_interface {
    public:
       virtual std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                     const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) = 0;
+                                                                                     const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supporte) = 0;
 
       virtual ~wasm_runtime_interface();
 

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -10,10 +10,6 @@ sync_call_context::sync_call_context(account_name sender, account_name receiver,
 {
 }
 
-void sync_call_context::set_receiver_supports_sync_call(bool supported) {
-   receiver_supports_sync_call = supported;
-}
-
 bool sync_call_context::is_read_only()const {
    return flags & 0b1; // LSB. bit index 0
 }

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -11,11 +11,11 @@ sync_call_context::sync_call_context(account_name sender, account_name receiver,
 }
 
 bool sync_call_context::is_read_only()const {
-   return flags & 0b1; // LSB. bit index 0
+   return flags & static_cast<uint64_t>(sync_call_flags::read_only);
 }
 
 bool sync_call_context::no_op_if_receiver_not_support_sync_call()const {
-   return flags & 0b10;  // second bit from LSB. bit index 1
+   return flags & static_cast<uint64_t>(sync_call_flags::no_op_if_receiver_not_support_sync_call);
 }
 
 } /// eosio::chain

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -14,8 +14,4 @@ bool sync_call_context::is_read_only()const {
    return flags & static_cast<uint64_t>(sync_call_flags::read_only);
 }
 
-bool sync_call_context::no_op_if_receiver_not_support_sync_call()const {
-   return flags & static_cast<uint64_t>(sync_call_flags::no_op_if_receiver_not_support_sync_call);
-}
-
 } /// eosio::chain

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -1,0 +1,25 @@
+#include <eosio/chain/sync_call_context.hpp>
+
+namespace eosio::chain {
+
+sync_call_context::sync_call_context(account_name sender, account_name receiver, uint64_t flags, std::span<const char>data)
+   : sender(sender)
+   , receiver(receiver)
+   , flags(flags)
+   , data(std::move(data))
+{
+}
+
+void sync_call_context::set_receiver_supports_sync_call(bool supported) {
+   receiver_supports_sync_call = supported;
+}
+
+bool sync_call_context::is_read_only()const {
+   return flags & 0b1; // LSB. bit index 0
+}
+
+bool sync_call_context::no_op_if_receiver_not_support_sync_call()const {
+   return flags & 0b10;  // second bit from LSB. bit index 1
+}
+
+} /// eosio::chain

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -6,7 +6,7 @@ sync_call_context::sync_call_context(account_name sender, account_name receiver,
    : sender(sender)
    , receiver(receiver)
    , flags(flags)
-   , data(std::move(data))
+   , data(data)
 {
 }
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -91,8 +91,8 @@ namespace eosio { namespace chain {
       my->apply( code_hash, vm_type, vm_version, context );
    }
 
-   void wasm_interface::do_sync_call( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
-      my->do_sync_call( code_hash, vm_type, vm_version, context );
+   sync_call_return_code wasm_interface::do_sync_call( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
+      return my->do_sync_call( code_hash, vm_type, vm_version, context );
    }
 
    bool wasm_interface::is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const {

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -54,7 +54,7 @@ namespace eosio { namespace chain {
 
       if (control.is_builtin_activated(builtin_protocol_feature_t::configurable_wasm_limits)) {
          const auto& gpo = control.get_global_properties();
-         webassembly::eos_vm_runtime::validate( code, gpo.wasm_configuration, pso.whitelisted_intrinsics );
+         webassembly::eos_vm_runtime::validate( control, code, gpo.wasm_configuration, pso.whitelisted_intrinsics );
          return;
       }
       Module module;

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -40,8 +40,8 @@ class eosvmoc_instantiated_module : public wasm_instantiated_module_interface {
             _eosvmoc_runtime.exec_thread_local->execute(*cd, *_eosvmoc_runtime.mem_thread_local, context);
       }
 
-      void do_sync_call(apply_context& context) override {
-         ;
+      sync_call_return_code do_sync_call(apply_context& context) override {
+         __builtin_unreachable();
       }
 
       const digest_type              _code_hash;
@@ -58,7 +58,7 @@ eosvmoc_runtime::~eosvmoc_runtime() {
 }
 
 std::unique_ptr<wasm_instantiated_module_interface> eosvmoc_runtime::instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                        const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) {
+                                                                                        const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& ) {
    return std::make_unique<eosvmoc_instantiated_module>(code_hash, vm_type, *this);
 }
 

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -58,7 +58,7 @@ eosvmoc_runtime::~eosvmoc_runtime() {
 }
 
 std::unique_ptr<wasm_instantiated_module_interface> eosvmoc_runtime::instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                        const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) {
+                                                                                        const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) {
    return std::make_unique<eosvmoc_instantiated_module>(code_hash, vm_type, *this);
 }
 

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -58,7 +58,7 @@ eosvmoc_runtime::~eosvmoc_runtime() {
 }
 
 std::unique_ptr<wasm_instantiated_module_interface> eosvmoc_runtime::instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                        const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, bool& sync_call_supported) {
+                                                                                        const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) {
    return std::make_unique<eosvmoc_instantiated_module>(code_hash, vm_type, *this);
 }
 

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -148,11 +148,7 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
 
          uint32_t sync_call_idx = _instantiated_module->get_module().get_exported_function("sync_call");
          if (sync_call_idx == std::numeric_limits<uint32_t>::max()) {
-            if (sync_call_ctx->no_op_if_receiver_not_support_sync_call()) {
-               return;
-            } else {
-               EOS_ASSERT(false, sync_call_not_supported_by_receiver_exception, "receiver does not support sync calls");
-            }
+            EOS_ASSERT(false, sync_call_not_supported_by_receiver_exception, "receiver does not support sync calls");
          }
          // If the contract contains sync_call entry point, its signature had already been
          // validated when the contract was deployed.

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -324,7 +324,6 @@ std::unique_ptr<wasm_instantiated_module_interface> eos_vm_runtime<Impl>::instan
       else
 #endif
          bkend = std::make_unique<backend_t>(code, code_size, nullptr, options, false, false); // false, false <--> 2-passes parsing, backend does not own execution context (execution context is reused per thread)
-                                                                                               //
       eos_vm_host_functions_t::resolve(bkend->get_module());
       return std::make_unique<eos_vm_instantiated_module<Impl>>(this, std::move(bkend));
    } catch(eosio::vm::exception& e) {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -84,7 +84,7 @@ void validate(const bytes& code, const whitelisted_intrinsics_type& intrinsics) 
    }
 }
 
-void validate( const bytes& code, const wasm_config& cfg, const whitelisted_intrinsics_type& intrinsics ) {
+void validate( const controller& control, const bytes& code, const wasm_config& cfg, const whitelisted_intrinsics_type& intrinsics ) {
    EOS_ASSERT(code.size() <= cfg.max_module_bytes, wasm_serialization_error, "Code too large");
    wasm_code_ptr code_ptr((uint8_t*)code.data(), code.size());
    try {
@@ -105,6 +105,17 @@ void validate( const bytes& code, const wasm_config& cfg, const whitelisted_intr
       EOS_ASSERT(apply_idx < std::numeric_limits<uint32_t>::max(), wasm_serialization_error, "apply not exported");
       const vm::func_type& apply_type = bkend.get_module().get_function_type(apply_idx);
       EOS_ASSERT((apply_type == vm::host_function{{vm::i64, vm::i64, vm::i64}, {}}), wasm_serialization_error, "apply has wrong type");
+
+      // Check sync-call entry point after the protocol feature is activated.
+      // It is optional for a contract to provide sync calls.
+      // To prevent problems, if sync call entry point is present, its signature must be correct
+      if (control.is_builtin_activated(builtin_protocol_feature_t::sync_call)) {
+         uint32_t sync_call_idx = bkend.get_module().get_exported_function("sync_call");
+         if (sync_call_idx < std::numeric_limits<uint32_t>::max()) {
+            const vm::func_type& sync_call_type = bkend.get_module().get_function_type(sync_call_idx);
+            EOS_ASSERT((sync_call_type == vm::host_function{{vm::i64, vm::i64, vm::i32}, {}}), wasm_serialization_error, "sync call entry point has wrong type");
+         }
+      }
    } catch(vm::exception& e) {
       EOS_THROW(wasm_serialization_error, e.detail());
    }
@@ -131,6 +142,19 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          _instantiated_module(std::move(mod)) {}
 
       void do_sync_call(apply_context& context) override {
+         const std::optional<sync_call_context>& sync_call_ctx  = context.get_sync_call_ctx();
+         assert(sync_call_ctx.has_value());
+         assert(!context.get_action_ptr());
+
+         if (!sync_call_ctx->receiver_supports_sync_call) {
+            if (sync_call_ctx->no_op_if_receiver_not_support_sync_call()) {
+               dlog("receiver does not have sync call entry point or the entry point is invalid, and the no-op flag is set. just returns");
+               return;
+            } else {
+               EOS_ASSERT(false, sync_call_not_supported_by_receiver_exception, "receiver does not support sync calls");
+            }
+         }
+
          backend_t                                bkend;
          typename eos_vm_runtime<Impl>::context_t exec_ctx;
          vm::wasm_allocator&                      wasm_alloc = context.control.get_sync_call_wasm_allocator(); // get the top free wasm allocator from the pool
@@ -138,9 +162,6 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          // always return the wasm_allocator obtainded by get_sync_wasm_allocator back to the pool
          auto ensure = fc::make_scoped_exit([&]() { context.control.return_sync_call_wasm_allocator(); });
 
-         const std::optional<sync_call_context>& sync_call_ctx  = context.get_sync_call_ctx();
-         assert(sync_call_ctx.has_value());
-         assert(!context.get_action_ptr());
 
          apply_options opts = get_apply_options(context);
 
@@ -287,7 +308,7 @@ eos_vm_runtime<Impl>::eos_vm_runtime() {}
 
 template<typename Impl>
 std::unique_ptr<wasm_instantiated_module_interface> eos_vm_runtime<Impl>::instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                             const digest_type&, const uint8_t&, const uint8_t&) {
+                                                                                             const digest_type&, const uint8_t&, const uint8_t&, bool& sync_call_supported) {
 
    using backend_t = eos_vm_backend_t<Impl>;
    try {
@@ -301,7 +322,17 @@ std::unique_ptr<wasm_instantiated_module_interface> eos_vm_runtime<Impl>::instan
       else
 #endif
          bkend = std::make_unique<backend_t>(code, code_size, nullptr, options, false, false); // false, false <--> 2-passes parsing, backend does not own execution context (execution context is reused per thread)
+                                                                                               //
       eos_vm_host_functions_t::resolve(bkend->get_module());
+
+      // check sync_call entry point
+      sync_call_supported = false;
+      uint32_t sync_call_idx = bkend->get_module().get_exported_function("sync_call");
+      if (sync_call_idx < std::numeric_limits<uint32_t>::max()) {
+         // signature has already been checked when the contract was deployed
+         sync_call_supported = true;
+      }
+
       return std::make_unique<eos_vm_instantiated_module<Impl>>(this, std::move(bkend));
    } catch(eosio::vm::exception& e) {
       FC_THROW_EXCEPTION(wasm_execution_error, "Error building eos-vm interp: ${e}", ("e", e.what()));
@@ -315,7 +346,7 @@ template class eos_vm_runtime<eosio::vm::jit>;
 eos_vm_profile_runtime::eos_vm_profile_runtime() {}
 
 std::unique_ptr<wasm_instantiated_module_interface> eos_vm_profile_runtime::instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                               const digest_type&, const uint8_t&, const uint8_t&) {
+                                                                                               const digest_type&, const uint8_t&, const uint8_t&, bool& sync_call_supported) {
 
    using backend_t = eosio::vm::backend<eos_vm_host_functions_t, eosio::vm::jit_profile, webassembly::eos_vm_runtime::apply_options, vm::profile_instr_map>;
    try {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -105,20 +105,30 @@ void validate( const controller& control, const bytes& code, const wasm_config& 
       EOS_ASSERT(apply_idx < std::numeric_limits<uint32_t>::max(), wasm_serialization_error, "apply not exported");
       const vm::func_type& apply_type = bkend.get_module().get_function_type(apply_idx);
       EOS_ASSERT((apply_type == vm::host_function{{vm::i64, vm::i64, vm::i64}, {}}), wasm_serialization_error, "apply has wrong type");
+   } catch(vm::exception& e) {
+      EOS_THROW(wasm_serialization_error, e.detail());
+   }
+}
 
-      // Check sync-call entry point after the protocol feature is activated.
-      // It is optional for a contract to provide sync calls.
-      // To prevent problems, if sync call entry point is present, its signature must be correct
-      if (control.is_builtin_activated(builtin_protocol_feature_t::sync_call)) {
-         uint32_t sync_call_idx = bkend.get_module().get_exported_function("sync_call");
-         if (sync_call_idx < std::numeric_limits<uint32_t>::max()) {
-            const vm::func_type& sync_call_type = bkend.get_module().get_function_type(sync_call_idx);
-            EOS_ASSERT((sync_call_type == vm::host_function{{vm::i64, vm::i64, vm::i32}, {}}), wasm_serialization_error, "sync call entry point has wrong function signature");
+bool has_proper_sync_call_entry_point( const char* code_bytes, size_t code_size ) {
+   bool sync_call_entry_point_is_valid = false;
+   wasm_code_ptr code_ptr((uint8_t*)code_bytes, code_size);
+
+   try {
+      eos_vm_null_backend_t<setcode_options> bkend(code_ptr, code_size, nullptr);
+
+      const uint32_t i = bkend.get_module().get_exported_function("sync_call");
+      if (i < std::numeric_limits<uint32_t>::max()) {
+         const vm::func_type& function_type = bkend.get_module().get_function_type(i);
+         if (function_type == vm::host_function{{vm::i64, vm::i64, vm::i32}, {}}) {
+            sync_call_entry_point_is_valid = true;
          }
       }
    } catch(vm::exception& e) {
       EOS_THROW(wasm_serialization_error, e.detail());
    }
+
+   return sync_call_entry_point_is_valid;
 }
 
 // Be permissive on apply.
@@ -141,17 +151,14 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          _runtime(runtime),
          _instantiated_module(std::move(mod)) {}
 
-      void do_sync_call(apply_context& context) override {
+      sync_call_return_code do_sync_call(apply_context& context) override {
          const std::optional<sync_call_context>& sync_call_ctx  = context.get_sync_call_ctx();
          assert(sync_call_ctx.has_value());
          assert(!context.get_action_ptr());
 
-         uint32_t sync_call_idx = _instantiated_module->get_module().get_exported_function("sync_call");
-         if (sync_call_idx == std::numeric_limits<uint32_t>::max()) {
-            EOS_ASSERT(false, sync_call_not_supported_by_receiver_exception, "receiver does not support sync calls");
+         if (!sync_call_ctx->receiver_supports_sync_call) {
+            return sync_call_return_code::receiver_not_support_sync_call;
          }
-         // If the contract contains sync_call entry point, its signature had already been
-         // validated when the contract was deployed.
 
          backend_t                                bkend;
          typename eos_vm_runtime<Impl>::context_t exec_ctx;
@@ -173,6 +180,8 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          };
 
          execute(context, bkend, exec_ctx, wasm_alloc, fn, true);
+
+         return sync_call_return_code::success;
       }
 
       void apply(apply_context& context) override {
@@ -273,7 +282,7 @@ class eos_vm_profiling_module : public wasm_instantiated_module_interface {
          }
       }
 
-      void do_sync_call(apply_context& context) override {}
+      sync_call_return_code do_sync_call(apply_context& context) override { __builtin_unreachable(); }
 
       profile_data* start(apply_context& context) {
          name account = context.get_receiver();
@@ -305,7 +314,7 @@ eos_vm_runtime<Impl>::eos_vm_runtime() {}
 
 template<typename Impl>
 std::unique_ptr<wasm_instantiated_module_interface> eos_vm_runtime<Impl>::instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                             const digest_type&, const uint8_t&, const uint8_t&) {
+                                                                                             const digest_type&, const uint8_t&, const uint8_t&, bool& sync_call_supported) {
 
    using backend_t = eos_vm_backend_t<Impl>;
    try {
@@ -319,7 +328,10 @@ std::unique_ptr<wasm_instantiated_module_interface> eos_vm_runtime<Impl>::instan
       else
 #endif
          bkend = std::make_unique<backend_t>(code, code_size, nullptr, options, false, false); // false, false <--> 2-passes parsing, backend does not own execution context (execution context is reused per thread)
+
       eos_vm_host_functions_t::resolve(bkend->get_module());
+      sync_call_supported = has_proper_sync_call_entry_point(code_bytes, code_size);
+
       return std::make_unique<eos_vm_instantiated_module<Impl>>(this, std::move(bkend));
    } catch(eosio::vm::exception& e) {
       FC_THROW_EXCEPTION(wasm_execution_error, "Error building eos-vm interp: ${e}", ("e", e.what()));
@@ -333,7 +345,7 @@ template class eos_vm_runtime<eosio::vm::jit>;
 eos_vm_profile_runtime::eos_vm_profile_runtime() {}
 
 std::unique_ptr<wasm_instantiated_module_interface> eos_vm_profile_runtime::instantiate_module(const char* code_bytes, size_t code_size,
-                                                                                               const digest_type&, const uint8_t&, const uint8_t&) {
+                                                                                               const digest_type&, const uint8_t&, const uint8_t&, bool&) {
 
    using backend_t = eosio::vm::backend<eos_vm_host_functions_t, eosio::vm::jit_profile, webassembly::eos_vm_runtime::apply_options, vm::profile_instr_map>;
    try {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -113,7 +113,7 @@ void validate( const controller& control, const bytes& code, const wasm_config& 
          uint32_t sync_call_idx = bkend.get_module().get_exported_function("sync_call");
          if (sync_call_idx < std::numeric_limits<uint32_t>::max()) {
             const vm::func_type& sync_call_type = bkend.get_module().get_function_type(sync_call_idx);
-            EOS_ASSERT((sync_call_type == vm::host_function{{vm::i64, vm::i64, vm::i32}, {}}), wasm_serialization_error, "sync call entry point has wrong type");
+            EOS_ASSERT((sync_call_type == vm::host_function{{vm::i64, vm::i64, vm::i32}, {}}), wasm_serialization_error, "sync call entry point has wrong function signature");
          }
       }
    } catch(vm::exception& e) {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -149,7 +149,6 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          uint32_t sync_call_idx = _instantiated_module->get_module().get_exported_function("sync_call");
          if (sync_call_idx == std::numeric_limits<uint32_t>::max()) {
             if (sync_call_ctx->no_op_if_receiver_not_support_sync_call()) {
-               dlog("receiver does not have sync call entry point or the entry point is invalid, and the no-op flag is set. just returns");
                return;
             } else {
                EOS_ASSERT(false, sync_call_not_supported_by_receiver_exception, "receiver does not support sync calls");

--- a/libraries/chain/webassembly/sync_call.cpp
+++ b/libraries/chain/webassembly/sync_call.cpp
@@ -2,7 +2,7 @@
 #include <eosio/chain/apply_context.hpp>
 
 namespace eosio { namespace chain { namespace webassembly {
-   int32_t interface::call(name receiver, uint64_t flags, std::span<const char> data) {
+   int64_t interface::call(name receiver, uint64_t flags, std::span<const char> data) {
       return context.execute_sync_call(receiver, flags, data);
    }
 

--- a/libraries/chain/webassembly/sync_call.cpp
+++ b/libraries/chain/webassembly/sync_call.cpp
@@ -2,7 +2,7 @@
 #include <eosio/chain/apply_context.hpp>
 
 namespace eosio { namespace chain { namespace webassembly {
-   uint32_t interface::call(name receiver, uint64_t flags, std::span<const char> data) {
+   int32_t interface::call(name receiver, uint64_t flags, std::span<const char> data) {
       return context.execute_sync_call(receiver, flags, data);
    }
 

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -2319,7 +2319,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(set_finalizers_test, T, testers) { try {
 // A basic contract to show new host functions can be called.
 static const char basic_sync_call_host_funcs_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32)(result i32)))
+   (import "env" "call" (func $call (param i64 i64 i32 i32)(result i64)))
    (import "env" "get_call_data" (func $get_call_data (param i32 i32)(result i32)))
    (import "env" "set_call_return_value" (func $set_call_return_value (param i32 i32)))
    (memory $0 1)

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -2338,6 +2338,11 @@ BOOST_AUTO_TEST_CASE(sync_call_activation_test) try {
    tester c(setup_policy::preactivate_feature_and_new_bios);
    const auto& pfm = c.control->get_protocol_feature_manager();
 
+   if( c.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
    // Ensure SYNC_CALL not yet activated
    BOOST_CHECK(!c.control->is_builtin_activated(builtin_protocol_feature_t::sync_call));
 

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -31,7 +31,7 @@ static const char* doit_abi = R"=====(
 static const char sync_call_in_same_account_wast[] = R"=====(
 (module
    (import "env" "eosio_assert" (func $assert (param i32 i32)))
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
 
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(same_account) { try {
 // Make a sync call to a function in "callee"_n account
 static const char caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(different_account) { try {
 // Calls "callee1"_n
 static const char call_depth_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee1 i64 (i64.const 4729647295748898816)) ;; "calllee1"_n uint64 value
@@ -152,7 +152,7 @@ static const char call_depth_wast[] = R"=====(
 // Calls "callee2"_n
 static const char callee1_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee2 i64 (i64.const 4729647296285769728)) ;; "calllee2"_n uint64 value
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(multi_level_call_depth) { try {
 // Call "callee1"_n and "callee2"_n in sequence
 static const char seq_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee1 i64 (i64.const 4729647295748898816))
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(seq_sync_calls) { try {
 // Make a large number of sync calls in a loop
 static const char loop_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(large_number_of_sequential_test) { try {
 // Make sync calls from different actions
 static const char different_actions_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $doit_value i64 (i64.const 5556755844919459840))
@@ -478,7 +478,7 @@ BOOST_AUTO_TEST_CASE(calls_from_different_actions) { try {
 // Make recursive sync calls
 static const char recursive_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (import "env" "eosio_assert" (func $assert (param i32 i32)))
    (memory $0 1)
    (export "memory" (memory $0))
@@ -513,7 +513,7 @@ static const char recursive_caller_wast[] = R"=====(
 
 static const char recursive_callee_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory $0 1)
    (export "memory" (memory $0))
    (global $caller i64 (i64.const 4729647518550327296))
@@ -582,7 +582,7 @@ BOOST_AUTO_TEST_CASE(receiver_account_not_existent) { try {
 // 3. saves the result in action trace for verification by test
 static const char basic_params_return_value_caller_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (import "env" "get_call_return_value" (func $get_call_return_value (param i32 i32) (result i32))) ;; memory
    (import "env" "set_action_return_value" (func $set_action_return_value (param i32 i32)))
    (import "env" "read_action_data" (func $read_action_data (param i32 i32) (result i32)))
@@ -597,6 +597,7 @@ static const char basic_params_return_value_caller_wast[] = R"=====(
       (call $read_action_data(i32.const 0)(i32.const 4))       ;; read action input into address 0
       set_local $input_size
       (call $call (get_global $callee) (i64.const 0)(i32.const 0)(get_local $input_size)) ;; make a sync call with data starting at address 0
+      i32.wrap/i64  ;; cast result of $call from i64 to i32
       set_local $return_value_size
       (drop (call $get_call_return_value (i32.const 8)(get_local $return_value_size))) ;; save return value at address 8
       (call $set_action_return_value (i32.const 8) (get_local $return_value_size))     ;; set the return value to action_return_value so test can check in action trace
@@ -835,7 +836,7 @@ BOOST_AUTO_TEST_CASE(set_call_return_value_not_in_sync_call_test) { try {
 static const char get_call_return_value_less_memory_wast[] = R"=====(
 (module
    (import "env" "eosio_assert" (func $assert (param i32 i32)))
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (import "env" "get_call_return_value" (func $get_call_return_value (param i32 i32) (result i32))) ;; memory
    (memory $0 1)
    (export "memory" (memory $0))
@@ -945,7 +946,7 @@ void create_one_account_and_set_code(const char* wat, account_name& acct, valida
 static const char entry_point_validation_caller_wast[] = R"=====(
 (module
    (import "env" "eosio_assert" (func $assert (param i32 i32)))
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory (export "memory") 1)
    (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
 
@@ -953,8 +954,8 @@ static const char entry_point_validation_caller_wast[] = R"=====(
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
       (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 8))
 
-      (i32.const -1)  ;; callee does not export `sync_call`, $call should return -1
-      i32.ne
+      (i64.const -1)  ;; callee does not export `sync_call`, $call should return -1
+      i64.ne
       if             ;; assert if $call did not return -1
          (call $assert (i32.const 0) (i32.const 16))
       end
@@ -1014,7 +1015,7 @@ BOOST_AUTO_TEST_CASE(invalid_sync_call_entry_point_test)  { try {
 // The last LSB is set
 static const char valid_flags_wast[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
@@ -1043,7 +1044,7 @@ BOOST_AUTO_TEST_CASE(valid_flags_test) { try {
 // The second LSB is set
 static const char invalid_flags_wast1[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
@@ -1074,7 +1075,7 @@ BOOST_AUTO_TEST_CASE(invalid_flags_test1) { try {
 // The last 2 LSBs are set
 static const char invalid_flags_wast2[] = R"=====(
 (module
-   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -924,4 +924,95 @@ BOOST_AUTO_TEST_CASE(get_call_return_value_not_called_sync_call_test) { try {
    BOOST_REQUIRE_NO_THROW(t.push_action(caller, "doit"_n, caller, {}));
 } FC_LOG_AND_RETHROW() }
 
+void create_accounts_and_set_code(const char* caller_wat, const char* callee_wat, validating_tester& t) {
+   const auto& caller = account_name("caller");
+   t.create_account(caller);
+   t.set_code(caller, caller_wat);
+   t.set_abi(caller, doit_abi);
+
+   const auto& callee = account_name("callee");
+   t.create_account(callee);
+   t.set_code(callee, callee_wat);
+}
+
+static const char no_sync_call_entry_point_wast[] = R"=====(
+(module
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+)
+)=====";
+
+// Verify sync call is abort if sync call entry point does not exist and the no-op-if-not-exist
+// is not set
+BOOST_AUTO_TEST_CASE(no_sync_call_entry_point_no_op_flag_not_set_test)  { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   create_accounts_and_set_code(caller_wast, no_sync_call_entry_point_wast, t);
+
+   BOOST_CHECK_EXCEPTION(t.push_action("caller"_n, "doit"_n, "caller"_n, {}),
+                         sync_call_not_supported_by_receiver_exception,
+                         fc_exception_message_contains("receiver does not support sync calls"));
+} FC_LOG_AND_RETHROW() }
+
+static const char no_op_if_receiver_not_support_sync_call_caller_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i32))) ;; receiver, flags, data span
+   (memory $0 1)
+   (export "memory" (memory $0))
+   (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (drop (call $call (get_global $callee) (i64.const 0x02)(i32.const 0)(i32.const 8)))  ;; flags' bit 1 is set to 1, for no_op_if_receiver_not_support_sync_call
+   )
+)
+)=====";
+
+// Verify sync call is no-op if sync call entry point does not exist and the no-op-if-not-exist
+// is set
+BOOST_AUTO_TEST_CASE(no_sync_call_entry_point_no_op_flag_set_test)  { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   create_accounts_and_set_code(no_op_if_receiver_not_support_sync_call_caller_wast, no_sync_call_entry_point_wast, t);
+
+   BOOST_REQUIRE_NO_THROW(t.push_action("caller"_n, "doit"_n, "caller"_n, {}));
+} FC_LOG_AND_RETHROW() }
+
+// Wrong sync call signature (the type of data_size is wrong)
+static const char bad_entry_point_wast[] = R"=====(
+(module
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i64)) ;; data_size type should be i32
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+)
+)=====";
+
+// Verify a contract with wrong sync call entry point cannot be deployed
+BOOST_AUTO_TEST_CASE(bad_entry_point_test)  { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   const auto& callee = account_name("callee");
+   t.create_account(callee);
+   BOOST_CHECK_EXCEPTION(t.set_code(callee, bad_entry_point_wast),
+                         wasm_serialization_error,
+                         fc_exception_message_contains("sync call entry point has wrong type"));
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -1012,7 +1012,7 @@ BOOST_AUTO_TEST_CASE(bad_entry_point_test)  { try {
    t.create_account(callee);
    BOOST_CHECK_EXCEPTION(t.set_code(callee, bad_entry_point_wast),
                          wasm_serialization_error,
-                         fc_exception_message_contains("sync call entry point has wrong type"));
+                         fc_exception_message_contains("sync call entry point has wrong function signature"));
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Implement this feature earlier to help prevent errors in WASM test contracts.

* Before a contract is inserted into `wasm_instantiation_cache`, check if `sync_call` entry point is  present in the contract; if present, validate the signature. Set `receiver_supports_sync_call` flag of the cache entry accordingly.
* When a sync call is made, check `receiver_supports_sync_call` of the receiver. If `false`, return `-1` and let the caller decide what to do about the failure.
* Tests are added for those validation.

Resolves  https://github.com/AntelopeIO/spring/issues/1219