### PR TITLE
Fix incorrect names (`preActivate` instead of `activate`) and add debugging info

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -1111,7 +1111,7 @@ class Cluster(object):
             return None
 
         if pfSetupPolicy == PFSetupPolicy.FULL:
-            biosNode.preactivateAllBuiltinProtocolFeature()
+            biosNode.activateAllBuiltinProtocolFeature()
         Node.validateTransaction(trans)
 
         contract="eosio.bios"

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -368,8 +368,9 @@ class Transactions(NodeosQueries):
         assert self.waitForHeadToAdvance(blocksToAdvance=2), "ERROR: TIMEOUT WAITING FOR PREACTIVATE"
 
     # Return an array of feature digests to be preactivated in a correct order respecting dependencies
+    # but skip "PREACTIVATE_FEATURE"
     # Require producer_api_plugin
-    def getAllBuiltinFeatureDigestsToPreactivate(self):
+    def getAllBuiltinFeatureDigestsToActivate(self):
         protocolFeatures = {}
         supportedProtocolFeatures = self.getSupportedProtocolFeatures()
         for protocolFeature in supportedProtocolFeatures["payload"]:
@@ -384,7 +385,7 @@ class Transactions(NodeosQueries):
 
 
     # Require PREACTIVATE_FEATURE to be activated and require eosio.bios with preactivate_feature
-    def preactivateProtocolFeatures(self, featureDigests:list):
+    def activateProtocolFeatures(self, featureDigests:list):
         for group in featureDigests:
             for digest in group:
                 Utils.Print("push activate action with digest {}".format(digest))
@@ -397,7 +398,6 @@ class Transactions(NodeosQueries):
             self.waitForTransactionInBlock(trans['transaction_id'])
 
     # Require PREACTIVATE_FEATURE to be activated and require eosio.bios with preactivate_feature
-    def preactivateAllBuiltinProtocolFeature(self):
-        allBuiltinProtocolFeatureDigests = self.getAllBuiltinFeatureDigestsToPreactivate()
-        self.preactivateProtocolFeatures(allBuiltinProtocolFeatureDigests)
-
+    def activateAllBuiltinProtocolFeature(self):
+        sorted_groups_of_digests = self.getAllBuiltinFeatureDigestsToActivate()
+        self.activateProtocolFeatures(sorted_groups_of_digests)

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -172,6 +172,17 @@ class PluginHttpTest(unittest.TestCase):
         command = "get_activated_protocol_features"
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
         self.assertEqual(type(ret_json["payload"]["activated_protocol_features"]), list)
+
+        # some extra debugging info
+        activated_features = ret_json["payload"]["activated_protocol_features"]
+        activated_names = [feature['specification'][0]['value'] for feature in activated_features]
+        expected_names = allFeatureCodenames
+        Utils.Print("activated_features={}".format(activated_features))
+        Utils.Print("expected_names={}".format(expected_names))
+        for n in expected_names:
+            if n not in activated_names:
+                Utils.Print("Missing feature: {}".format(n))
+
         self.assertEqual(len(ret_json["payload"]["activated_protocol_features"]), ACT_FEATURE_CURRENT_EXPECTED_TOTAL)
         for dict_feature in ret_json["payload"]["activated_protocol_features"]:
             self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -120,7 +120,7 @@ class PluginHttpTest(unittest.TestCase):
 
         retMap = self.nodeos.publishContract(eosioAccount, contractDir, wasmFile, abiFile, waitForTransBlock=True)
 
-        self.nodeos.preactivateAllBuiltinProtocolFeature()
+        self.nodeos.activateAllBuiltinProtocolFeature()
 
     # test all chain api
     def test_ChainApi(self) :


### PR DESCRIPTION
This is work on issue #1247.
I was not able to figure out why it seems that sometimes, we are missing one activated protocol feature.
This PR adds some debugging code to print out the missing feature when the issue occurs.

> note: Issue may have been present for a long time, but was hidden as a failure of the test to return an exit value caused it to always succeed (fixed in https://github.com/AntelopeIO/spring/pull/1195).