### PR TITLE
Change log message when computing integrity hash

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2232,7 +2232,7 @@ struct controller_impl {
       // clear in case the previous call to clear did not finish in time of deadline
       clear_expired_input_transactions( fc::time_point::maximum() );
 
-      snapshot_written_row_counter row_counter(expected_snapshot_row_count());
+      snapshot_written_row_counter row_counter(expected_snapshot_row_count(), snapshot->name());
 
       snapshot->write_section<chain_snapshot_header>([this]( auto &section ){
          section.add_row(chain_snapshot_header(), db);

--- a/libraries/chain/include/eosio/chain/snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot.hpp
@@ -146,7 +146,9 @@ namespace eosio { namespace chain {
             write_section(detail::snapshot_section_traits<T>::section_name(), f);
          }
 
-      virtual ~snapshot_writer(){};
+         virtual ~snapshot_writer(){};
+
+         virtual const char* name() const = 0;
 
       protected:
          virtual void write_start_section( const std::string& section_name ) = 0;
@@ -304,6 +306,7 @@ namespace eosio { namespace chain {
       public:
          variant_snapshot_writer(fc::mutable_variant_object& snapshot);
 
+         const char* name() const override { return "variant snapshot"; }
          void write_start_section( const std::string& section_name ) override;
          void write_row( const detail::abstract_snapshot_row_writer& row_writer ) override;
          void write_end_section( ) override;
@@ -337,6 +340,7 @@ namespace eosio { namespace chain {
       public:
          explicit ostream_snapshot_writer(std::ostream& snapshot);
 
+         const char* name() const override { return "snapshot"; }
          void write_start_section( const std::string& section_name ) override;
          void write_row( const detail::abstract_snapshot_row_writer& row_writer ) override;
          void write_end_section( ) override;
@@ -355,6 +359,7 @@ namespace eosio { namespace chain {
       public:
          explicit ostream_json_snapshot_writer(std::ostream& snapshot);
 
+         const char* name() const override { return "JSON snapshot"; }
          void write_start_section( const std::string& section_name ) override;
          void write_row( const detail::abstract_snapshot_row_writer& row_writer ) override;
          void write_end_section() override;
@@ -434,6 +439,7 @@ namespace eosio { namespace chain {
       public:
          explicit integrity_hash_snapshot_writer(fc::sha256::encoder&  enc);
 
+         const char* name() const override { return "integrity hash"; }
          void write_start_section( const std::string& section_name ) override;
          void write_row( const detail::abstract_snapshot_row_writer& row_writer ) override;
          void write_end_section( ) override;
@@ -445,15 +451,16 @@ namespace eosio { namespace chain {
    };
    
    struct snapshot_written_row_counter {
-      snapshot_written_row_counter(const size_t total) : total(total) {}
+      snapshot_written_row_counter(const size_t total, const char* name) : total(total), name(name) {}
       void progress() {
          if(++count % 50000 == 0 && time(NULL) - last_print >= 5) {
-            ilog("Snapshot creation ${pct}% complete", ("pct",std::min((unsigned)(((double)count/total)*100),100u)));
+            ilog("${n} creation ${pct}% complete", ("n", name)("pct",std::min((unsigned)(((double)count/total)*100),100u)));
             last_print = time(NULL);
          }
       }
       size_t count = 0;
       const size_t total = 0;
+      const char* name;
       time_t last_print = time(NULL);
    };
 

--- a/libraries/chain/include/eosio/chain/snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot.hpp
@@ -460,7 +460,7 @@ namespace eosio { namespace chain {
       }
       size_t count = 0;
       const size_t total = 0;
-      const char* name;
+      const char* name = nullptr;
       time_t last_print = time(NULL);
    };
 


### PR DESCRIPTION
Update the percentage log output of snapshot creation to report type of snapshot being created. Uses `integrity hash` for the integrity hash creation on startup and shutdown.

```
info  2025-03-24T18:04:19.004 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 0% complete
info  2025-03-24T18:05:04.005 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 7% complete
info  2025-03-24T18:05:20.612 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 12% complete
info  2025-03-24T18:06:58.004 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 26% complete
info  2025-03-24T18:07:15.242 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 42% complete
info  2025-03-24T18:09:07.009 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 68% complete
info  2025-03-24T18:10:07.050 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 95% complete
info  2025-03-24T18:10:32.049 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 97% complete
info  2025-03-24T18:10:34.735 nodeos    controller.cpp:2039           init                 ] chain database started with hash: db466873134910fa7a3184746efbdd2eb3fa62f7c0fd01db341f6dd4e5ee029f
...
info  2025-03-24T18:10:39.008 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 5% complete
info  2025-03-24T18:11:55.219 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 13% complete
info  2025-03-24T18:12:21.048 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 41% complete
info  2025-03-24T18:13:28.651 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 68% complete
info  2025-03-24T18:13:39.080 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 95% complete
info  2025-03-24T18:13:59.186 nodeos    snapshot.hpp:457              progress             ] integrity hash creation 96% complete
info  2025-03-24T18:14:15.829 nodeos    controller.cpp:2092           ~controller_impl     ] chain database stopped with hash: db466873134910fa7a3184746efbdd2eb3fa62f7c0fd01db341f6dd4e5ee029f
```

Resolves #1147 