### PR TITLE
Test: Do not exit on error when evaluating fork

### DIFF
--- a/tests/nodeos_short_fork_take_over_test.py
+++ b/tests/nodeos_short_fork_take_over_test.py
@@ -356,8 +356,9 @@ try:
     while remainingChecks>0:
         if checkMatchBlock == killBlockNum and checkHead:
             checkMatchBlock = prodNodes[0].getBlockNum()
-        blockProducer0=prodNodes[0].getBlockProducerByNum(checkMatchBlock)
-        blockProducer1=prodNodes[1].getBlockProducerByNum(checkMatchBlock)
+        # do not exit on error as fork switching can make block not available temporarily
+        blockProducer0=prodNodes[0].getBlockProducerByNum(checkMatchBlock, exitOnError=False)
+        blockProducer1=prodNodes[1].getBlockProducerByNum(checkMatchBlock, exitOnError=False)
         match=blockProducer0==blockProducer1
         if match:
             if checkHead:


### PR DESCRIPTION
During a fork-switch a block can be temporarily not available. Do not exit the test, but allow time for fork switch.

Resolves #1248 