### PR TITLE
Test: Make sure finalizercNode is synced up before killing node0

### DIFF
--- a/tests/production_pause_vote_timeout.py
+++ b/tests/production_pause_vote_timeout.py
@@ -203,10 +203,13 @@ try:
     ####################### test 4 ######################
     # shutdown node0 and make sure node1 does not pause
 
+    currentBlockNum = node0.getBlockNum()
+
     Print("Restart finalizercNode")
     finalizercNode.relaunch()
 
     Print("Wait for LIB after finalizercNode back up")
+    assert finalizercNode.waitForIrreversibleBlock(currentBlockNum), "finalizercNode did not sync and advance LIB"
     assert finalizercNode.waitForLibToAdvance(), "finalizercNode did not advance LIB after relaunch"
 
     Print("Shutdown Node0")


### PR DESCRIPTION
The test failed because the `finacliercNode` was not synced up and voting on current blocks before the `node0` was killed. Modify the test to verify that `finalizercNode` is synced up and current before killing `node0`.

Resolves #1260