### PR TITLE
Update to `peer_keys_db_t` to match changes in `eos-system-contracts` pr 185.

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1324,7 +1324,7 @@ struct controller_impl {
          vote_processor.notify_lib(block->block_num());
 
          // update peer public keys from chainbase db 
-         peer_keys_db.update_peer_keys(self, block->block_num());
+         peer_keys_db.update_peer_keys(self, block->timestamp);
       });
 
 #define SET_APP_HANDLER( receiver, contract, action) \

--- a/libraries/chain/include/eosio/chain/peer_keys_db.hpp
+++ b/libraries/chain/include/eosio/chain/peer_keys_db.hpp
@@ -24,7 +24,7 @@ public:
    void set_active(bool b) { _active = b; }
 
    // must be called from main thread
-   size_t update_peer_keys(const controller& chain, uint32_t lib_number);
+   size_t update_peer_keys(const controller& chain, block_timestamp_type lib_timestamp);
 
    // safe to be called from any thread
    std::optional<public_key_type> get_peer_key(name n) const;
@@ -35,10 +35,10 @@ public:
 private:
    std::optional<uint64_t> _get_version(const chainbase::database& db);
 
-   bool               _active = false;       // if not active (the default), no update occurs
-   uint32_t           _block_num = 0;        // below map includes keys registered up to _block_num (inclusive)
-   mutable fc::mutex  _m;
-   peer_key_map_t     _peer_key_map GUARDED_BY(_m);
+   bool                 _active{false};   // if not active (the default), no update occurs
+   block_timestamp_type _block_timestamp; // below map includes keys registered up to _block_timestamp (inclusive)
+   mutable fc::mutex    _m;
+   peer_key_map_t       _peer_key_map GUARDED_BY(_m);
 };
 
 } // namespace eosio::chain

--- a/libraries/chain/peer_keys_db.cpp
+++ b/libraries/chain/peer_keys_db.cpp
@@ -50,7 +50,6 @@ size_t peer_keys_db_t::update_peer_keys(const controller& chain, uint32_t lib_nu
 
             name                  row_name;
             uint32_t              row_block_num;
-            uint8_t               row_version;
             std::variant<v0_data> row_variant;
 
             const auto&                 obj = *itr2;
@@ -64,12 +63,10 @@ size_t peer_keys_db_t::update_peer_keys(const controller& chain, uint32_t lib_nu
             EOS_ASSERT(row_block_num > static_cast<uint64_t>(_block_num), misc_exception,
                        "deserialized invalid version from `peerkeys`");
 
-            fc::raw::unpack(ds, row_version);
-            if (row_version != 0)
-               continue;
-
             fc::raw::unpack(ds, row_variant);
-            EOS_ASSERT(std::holds_alternative<v0_data>(row_variant), misc_exception, "deserialized invalid data from `peerkeys`");
+            EOS_ASSERT(std::holds_alternative<v0_data>(row_variant), misc_exception,
+                       "deserialized invalid data from `peerkeys`");
+
             auto& data = std::get<v0_data>(row_variant);
             if (data.pubkey) {
                EOS_ASSERT(data.pubkey->valid(), misc_exception, "deserialized invalid public key from `peerkeys`");


### PR DESCRIPTION
Updates for changes in https://github.com/eosnetworkfoundation/eos-system-contracts/pull/185.