### PR TITLE
SC: Enforce host function constraints in sync calls

### DIFF
--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -53,15 +53,17 @@ action_name sync_call_context::get_sender() const {
    return receiver;
 }
 
-// EOS_ASSERTs and tests will be added for the following methods in next PR
 void sync_call_context::require_authorization(const account_name& account) {
+   EOS_ASSERT(false, sync_call_validate_exception, "require_auth is only allowed in actions");
 }
 bool sync_call_context::has_authorization(const account_name& account) const {
    return false;
 }
 void sync_call_context::require_authorization(const account_name& account, const permission_name& permission) {
+   EOS_ASSERT(false, sync_call_validate_exception, "require_auth2 is only allowed in actions");
 }
 void sync_call_context::require_recipient(account_name account) {
+   EOS_ASSERT(false, sync_call_validate_exception, "require_recipient is only allowed in actions");
 }
 bool sync_call_context::has_recipient(account_name account)const {
    return false;
@@ -69,10 +71,10 @@ bool sync_call_context::has_recipient(account_name account)const {
 void sync_call_context::update_db_usage( const account_name& payer, int64_t delta ) {
 }
 int sync_call_context::get_action( uint32_t type, uint32_t index, char* buffer, size_t buffer_size)const {
-   return 0;
+   EOS_ASSERT(false, sync_call_validate_exception, "get_action is only allowed in actions");
 }
 int sync_call_context::get_context_free_data( uint32_t index, char* buffer, size_t buffer_size )const {
-   return 0;
+   EOS_ASSERT(false, sync_call_validate_exception, "get_context_free_data is only allowed in actions");
 }
 bool sync_call_context::is_context_free()const {
    return false;
@@ -94,15 +96,19 @@ const action* sync_call_context::get_action_ptr()const {
 void sync_call_context::exec() {
 }
 void sync_call_context::execute_inline( action&& a ) {
+   EOS_ASSERT(false, sync_call_validate_exception, "send_inline is only allowed in actions");
 }
 void sync_call_context::execute_context_free_inline( action&& a ) {
+   EOS_ASSERT(false, sync_call_validate_exception, "send_context_free_inline is only allowed in actions");
 }
 void sync_call_context::schedule_deferred_transaction( const uint128_t& sender_id, account_name payer, transaction&& trx, bool replace_existing ) {
+   EOS_ASSERT(false, sync_call_validate_exception, "send_deferred is only allowed in actions");
 }
 bool sync_call_context::cancel_deferred_transaction( const uint128_t& sender_id, account_name sender ) {
    return false;
 }
 bool sync_call_context::cancel_deferred_transaction( const uint128_t& sender_id) {
+   EOS_ASSERT(false, sync_call_validate_exception, "cancel_deferred is only allowed in actions");
    return false;
 }
 

--- a/libraries/chain/webassembly/action.cpp
+++ b/libraries/chain/webassembly/action.cpp
@@ -4,6 +4,8 @@
 
 namespace eosio { namespace chain { namespace webassembly {
    int32_t interface::read_action_data(legacy_span<char> memory) const {
+      EOS_ASSERT(dynamic_cast<apply_context*>(&context), sync_call_validate_exception, "read_action_data is only allowed in actions");
+
       auto s = context.get_action().data.size();
       auto copy_size = std::min( static_cast<size_t>(memory.size()), s );
       if( copy_size == 0 ) return s;
@@ -13,6 +15,7 @@ namespace eosio { namespace chain { namespace webassembly {
    }
 
    int32_t interface::action_data_size() const {
+      EOS_ASSERT(dynamic_cast<apply_context*>(&context), sync_call_validate_exception, "action_data_size is only allowed in actions");
       return context.get_action().data.size();
    }
 
@@ -21,6 +24,7 @@ namespace eosio { namespace chain { namespace webassembly {
    }
 
    void interface::set_action_return_value( span<const char> packed_blob ) {
+      EOS_ASSERT(dynamic_cast<apply_context*>(&context), sync_call_validate_exception, "set_action_return_value is only allowed in actions");
       auto max_action_return_value_size = 
          context.control.get_global_properties().configuration.max_action_return_value_size;
       if( !context.trx_context.is_read_only() )

--- a/libraries/chain/webassembly/transaction.cpp
+++ b/libraries/chain/webassembly/transaction.cpp
@@ -4,6 +4,8 @@
 
 namespace eosio { namespace chain { namespace webassembly {
    void interface::send_inline( legacy_span<const char> data ) {
+      EOS_ASSERT(dynamic_cast<apply_context*>(&context), sync_call_validate_exception, "send_inline is only allowed in actions");
+
       //TODO: Why is this limit even needed? And why is it not consistently checked on actions in input or deferred transactions
       EOS_ASSERT( data.size() < context.control.get_global_properties().configuration.max_inline_action_size, inline_action_too_big,
                  "inline action too big" );
@@ -14,6 +16,8 @@ namespace eosio { namespace chain { namespace webassembly {
    }
 
    void interface::send_context_free_inline( legacy_span<const char> data ) {
+      EOS_ASSERT(dynamic_cast<apply_context*>(&context), sync_call_validate_exception, "send_context_free_inline is only allowed in actions");
+
       //TODO: Why is this limit even needed? And why is it not consistently checked on actions in input or deferred transactions
       EOS_ASSERT( data.size() < context.control.get_global_properties().configuration.max_inline_action_size, inline_action_too_big,
                 "inline action too big" );
@@ -24,12 +28,16 @@ namespace eosio { namespace chain { namespace webassembly {
    }
 
    void interface::send_deferred( legacy_ptr<const uint128_t> sender_id, account_name payer, legacy_span<const char> data, uint32_t replace_existing) {
+      EOS_ASSERT(dynamic_cast<apply_context*>(&context), sync_call_validate_exception, "send_deferred is only allowed in actions");
+
       transaction trx;
       fc::raw::unpack<transaction>(data.data(), data.size(), trx);
       context.schedule_deferred_transaction(*sender_id, payer, std::move(trx), replace_existing);
    }
 
    bool interface::cancel_deferred( legacy_ptr<const uint128_t> val ) {
+      EOS_ASSERT(dynamic_cast<apply_context*>(&context), sync_call_validate_exception, "cancel_deferred is only allowed in actions");
+
       return context.cancel_deferred_transaction( *val );
    }
 }}} // ns eosio::chain::webassembly


### PR DESCRIPTION
The following host functions
1. `require_auth`,
2.  `require_auth2`,
3.  `require_recipient`,
4.  `read_action_data`,
5.  `action_data_size`,
6.  `set_action_return_value`,
7.  `get_context_free_data`,
8.  `send_inline`,
9.  `send_context_free_inline`,
10.  `send_deferred`,
11.  `cancel_deferred`
 
are not applicable for sync calls. Abort  the sync calls if they are used.

For each of the host functions, a test is added to verify the sync call is aborted.

Resolves https://github.com/AntelopeIO/spring/issues/1218