### PR TITLE
[RFC] hide `max_action_return_value_size` in `get_consensus_parameters` when feature not activated

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2678,7 +2678,11 @@ read_only::get_consensus_parameters_results
 read_only::get_consensus_parameters(const get_consensus_parameters_params&, const fc::time_point& ) const {
    get_consensus_parameters_results results;
 
-   results.chain_config = db.get_global_properties().configuration;
+   if (db.is_builtin_activated(builtin_protocol_feature_t::action_return_value))
+      to_variant(db.get_global_properties().configuration,        results.chain_config); //chain_config_v1
+   else
+      to_variant(db.get_global_properties().configuration.base(), results.chain_config); //chain_config_v0
+
    if (db.is_builtin_activated(builtin_protocol_feature_t::configurable_wasm_limits)) {
       results.wasm_config = db.get_global_properties().wasm_configuration;
    }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -830,7 +830,7 @@ public:
 
    using get_consensus_parameters_params = empty;
    struct get_consensus_parameters_results {
-     chain::chain_config               chain_config;
+     fc::variant                       chain_config; //filled as chain_config_v0, v1, etc depending on activated features
      std::optional<chain::wasm_config> wasm_config;
    };
    get_consensus_parameters_results get_consensus_parameters(const get_consensus_parameters_params&, const fc::time_point& deadline) const;


### PR DESCRIPTION
For a little background see AntelopeIO/leap#1660 and AntelopeIO/leap#1770. We decided to hide the `wasm_configuration` in `get_consensus_parameters` when `CONFIGURABLE_WASM_LIMITS2` is not activated. This helps resolve some confusion.

But I realized in https://github.com/AntelopeIO/spring/pull/1257#issuecomment-2730533968 that this introduces an inconsistency: we still show `max_action_return_value_size` even if `ACTION_RETURN_VALUE` is not activated.

So this change will effectively hide `max_action_return_value_size` until `ACTION_RETURN_VALUE` is activated. This turned out really quite simple to do so makes it tempting to resolve the inconsistency this way.

If OK, will explore what a test would look like