### PR TITLE
SC: enforce `max_sync_call_depth` for nested and recursive sync calls

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -39,7 +39,8 @@ static inline void print_debug(account_name receiver, const action_trace& ar) {
 }
 
 apply_context::apply_context(controller& con, transaction_context& trx_ctx, uint32_t action_ordinal, uint32_t depth)
-:host_context(con, trx_ctx, depth)
+:host_context(con, trx_ctx)
+,recurse_depth(depth)
 ,first_receiver_action_ordinal(action_ordinal)
 ,action_ordinal(action_ordinal)
 {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -39,8 +39,7 @@ static inline void print_debug(account_name receiver, const action_trace& ar) {
 }
 
 apply_context::apply_context(controller& con, transaction_context& trx_ctx, uint32_t action_ordinal, uint32_t depth)
-:host_context(con, trx_ctx)
-,recurse_depth(depth)
+:host_context(con, trx_ctx, depth)
 ,first_receiver_action_ordinal(action_ordinal)
 ,action_ordinal(action_ordinal)
 {

--- a/libraries/chain/host_context.cpp
+++ b/libraries/chain/host_context.cpp
@@ -38,10 +38,7 @@ host_context::~host_context() = default;
 
 // called from apply_context or sync_call_context
 uint32_t host_context::execute_sync_call(name call_receiver, uint64_t flags, std::span<const char> data) {
-   // If the call is initiated from an apply_context (an action), it is the first
-   // level of a sync call by the action, set the depth to 1.
-   // Otherwise the call is from another sync call, increment the depth by 1.
-   const uint32_t depth = dynamic_cast<apply_context*>(this) ? 1 : sync_call_depth + 1;
+   const uint32_t depth = sync_call_depth + 1;
    const auto max_depth = control.get_global_properties().configuration.max_sync_call_depth;
    EOS_ASSERT(depth <= max_depth, sync_call_depth_exception,
               "reached sync call max call depth ${max_depth}", ("max_depth", max_depth));

--- a/libraries/chain/host_context.cpp
+++ b/libraries/chain/host_context.cpp
@@ -6,11 +6,11 @@
 
 namespace eosio::chain {
 
-host_context::host_context(controller& con, transaction_context& trx_ctx, uint32_t depth)
+// used to create an apply context
+host_context::host_context(controller& con, transaction_context& trx_ctx)
    : control(con)
    , db(con.mutable_db())
    , trx_context(trx_ctx)
-   , recurse_depth(depth)
    , idx64(*this)
    , idx128(*this)
    , idx256(*this)
@@ -19,12 +19,13 @@ host_context::host_context(controller& con, transaction_context& trx_ctx, uint32
 {
 }
 
-host_context::host_context(controller& con, transaction_context& trx_ctx, uint32_t depth, account_name receiver)
+// used to create a sync call context
+host_context::host_context(controller& con, transaction_context& trx_ctx, account_name receiver, uint32_t sync_call_depth)
    : control(con)
    , db(con.mutable_db())
    , trx_context(trx_ctx)
-   , recurse_depth(depth)
    , receiver(receiver)
+   , sync_call_depth(sync_call_depth)
    , idx64(*this)
    , idx128(*this)
    , idx256(*this)
@@ -37,8 +38,12 @@ host_context::~host_context() = default;
 
 // called from apply_context or sync_call_context
 uint32_t host_context::execute_sync_call(name call_receiver, uint64_t flags, std::span<const char> data) {
+   // If the call is initiated from an apply_context (an action), it is the first
+   // level of a sync call by the action, set the depth to 1.
+   // Otherwise the call is from another sync call, increment the depth by 1.
+   const uint32_t depth = dynamic_cast<apply_context*>(this) ? 1 : sync_call_depth + 1;
    const auto max_depth = control.get_global_properties().configuration.max_sync_call_depth;
-   EOS_ASSERT(recurse_depth < max_depth, sync_call_depth_exception,
+   EOS_ASSERT(depth <= max_depth, sync_call_depth_exception,
               "reached sync call max call depth ${max_depth}", ("max_depth", max_depth));
 
    const auto max_data_size = control.get_global_properties().configuration.max_sync_call_data_size;
@@ -71,13 +76,8 @@ uint32_t host_context::execute_sync_call(name call_receiver, uint64_t flags, std
          }
 
          try {
-            // If the call is initiated from an apply_context (an action), it is the first
-            // level of a sync call by the action, set septh to 1.
-            // Otherwise the call is from another sync call, increment the call depth by 1.
-            const uint32_t depth = dynamic_cast<apply_context*>(this) ? 1 : recurse_depth + 1;
-
             // use a new sync_call_context for next sync call
-            sync_call_context call_ctx(control, trx_context, depth, get_sync_call_sender(), call_receiver, flags, data);
+            sync_call_context call_ctx(control, trx_context, get_sync_call_sender(), call_receiver, depth, flags, data);
             control.get_wasm_interface().do_sync_call(receiver_account->code_hash, receiver_account->vm_type, receiver_account->vm_version, call_ctx);
 
             // store return value

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -99,6 +99,7 @@ class apply_context : public host_context {
    private:
       const action*                 act = nullptr; ///< action being applied
       // act pointer may be invalidated on call to trx_context.schedule_action
+      uint32_t                      recurse_depth; ///< how deep inline actions can recurse
       uint32_t                      first_receiver_action_ordinal = 0;
       uint32_t                      action_ordinal = 0;
       bool                          privileged   = false;

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -99,7 +99,6 @@ class apply_context : public host_context {
    private:
       const action*                 act = nullptr; ///< action being applied
       // act pointer may be invalidated on call to trx_context.schedule_action
-      uint32_t                      recurse_depth; ///< how deep inline actions can recurse
       uint32_t                      first_receiver_action_ordinal = 0;
       uint32_t                      action_ordinal = 0;
       bool                          privileged   = false;

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -690,4 +690,6 @@ namespace eosio { namespace chain {
                                     3270003, "Sync call data size is too large" )
       FC_DECLARE_DERIVED_EXCEPTION( sync_call_not_supported_by_receiver_exception, sync_call_exception,
                                     3270004, "Sync call is not supported by the receiver" )
+      FC_DECLARE_DERIVED_EXCEPTION( sync_call_depth_exception, sync_call_exception,
+                                    3270005, "max allowed sync call depth reached" )
 } } // eosio::chain

--- a/libraries/chain/include/eosio/chain/host_context.hpp
+++ b/libraries/chain/include/eosio/chain/host_context.hpp
@@ -484,8 +484,8 @@ public:
 
 public:
    /// Constructor and destructor:
-   host_context(controller& con, transaction_context& trx_ctx, uint32_t depth);
-   host_context(controller& con, transaction_context& trx_ctx, uint32_t depth,  account_name receiver);
+   host_context(controller& con, transaction_context& trx_ctx);
+   host_context(controller& con, transaction_context& trx_ctx, account_name receiver, uint32_t sync_call_depth );
    virtual ~host_context();
 
    /// Authorization methods:
@@ -583,10 +583,11 @@ public:
    controller&                      control;
    chainbase::database&             db;  ///< database where state is stored
    transaction_context&             trx_context; ///< transaction context in which the action is running
-   uint32_t                         recurse_depth; ///< how deep inline actions can recurse
    account_name                     receiver; ///< the code that is currently running
    std::vector<char>                action_return_value;
-   std::optional<std::vector<char>> last_sync_call_return_value{}; /// return value of last sync call initiated by the current code (host context)
+
+   std::optional<std::vector<char>> last_sync_call_return_value{}; // return value of last sync call initiated by the current code (host context)
+   uint32_t                         sync_call_depth = 0; // depth for sync call
 
    generic_index<index64_object>                                  idx64;
    generic_index<index128_object>                                 idx128;

--- a/libraries/chain/include/eosio/chain/host_context.hpp
+++ b/libraries/chain/include/eosio/chain/host_context.hpp
@@ -587,7 +587,7 @@ public:
    std::vector<char>                action_return_value;
 
    std::optional<std::vector<char>> last_sync_call_return_value{}; // return value of last sync call initiated by the current code (host context)
-   uint32_t                         sync_call_depth = 0; // depth for sync call
+   const uint32_t                   sync_call_depth = 0; // depth for sync call
 
    generic_index<index64_object>                                  idx64;
    generic_index<index128_object>                                 idx128;

--- a/libraries/chain/include/eosio/chain/host_context.hpp
+++ b/libraries/chain/include/eosio/chain/host_context.hpp
@@ -484,8 +484,8 @@ public:
 
 public:
    /// Constructor and destructor:
-   host_context(controller& con, transaction_context& trx_ctx);
-   host_context(controller& con, transaction_context& trx_ctx, account_name receiver);
+   host_context(controller& con, transaction_context& trx_ctx, uint32_t depth);
+   host_context(controller& con, transaction_context& trx_ctx, uint32_t depth,  account_name receiver);
    virtual ~host_context();
 
    /// Authorization methods:
@@ -561,6 +561,7 @@ public:
    action_name get_receiver()const { return receiver; };
    virtual const action& get_action()const = 0;
    virtual action_name get_sender() const = 0;
+   account_name get_sync_call_sender() const { return receiver; } // current action or sync call's receiver is next call's sender
 
    /// Execution methods:
 
@@ -582,6 +583,7 @@ public:
    controller&                      control;
    chainbase::database&             db;  ///< database where state is stored
    transaction_context&             trx_context; ///< transaction context in which the action is running
+   uint32_t                         recurse_depth; ///< how deep inline actions can recurse
    account_name                     receiver; ///< the code that is currently running
    std::vector<char>                action_return_value;
    std::optional<std::vector<char>> last_sync_call_return_value{}; /// return value of last sync call initiated by the current code (host context)

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -12,7 +12,7 @@ enum class sync_call_flags {
 
 class sync_call_context : public host_context {
 public:
-   sync_call_context(controller& con, transaction_context& trx_ctx, uint32_t depth, account_name sender, account_name receiver, uint64_t flags, std::span<const char> data);
+   sync_call_context(controller& con, transaction_context& trx_ctx, account_name sender, account_name receiver, uint32_t sync_call_depth, uint64_t flags, std::span<const char> data);
 
    uint32_t get_call_data(std::span<char> memory) const override;
    void set_call_return_value(std::span<const char> return_value) override;

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -12,7 +12,7 @@ enum class sync_call_flags {
 
 class sync_call_context : public host_context {
 public:
-   sync_call_context(controller& con, transaction_context& trx_ctx, account_name sender, account_name receiver, uint64_t flags, std::span<const char> data);
+   sync_call_context(controller& con, transaction_context& trx_ctx, uint32_t depth, account_name sender, account_name receiver, uint64_t flags, std::span<const char> data);
 
    uint32_t get_call_data(std::span<char> memory) const override;
    void set_call_return_value(std::span<const char> return_value) override;

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -5,14 +5,13 @@
 
 namespace eosio::chain {
 
-sync_call_context::sync_call_context(controller& con, transaction_context& trx_ctx, account_name sender, account_name receiver, uint64_t flags, std::span<const char>data)
-   : host_context(con, trx_ctx, receiver)
+sync_call_context::sync_call_context(controller& con, transaction_context& trx_ctx, uint32_t depth, account_name sender, account_name receiver, uint64_t flags, std::span<const char>data)
+   : host_context(con, trx_ctx, depth, receiver)
    , sender(sender)
    , flags(flags)
    , data(data)
 {
 }
-
 
 uint32_t sync_call_context::get_call_data(std::span<char> memory) const {
    auto        data_size = data.size();

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -5,8 +5,8 @@
 
 namespace eosio::chain {
 
-sync_call_context::sync_call_context(controller& con, transaction_context& trx_ctx, uint32_t depth, account_name sender, account_name receiver, uint64_t flags, std::span<const char>data)
-   : host_context(con, trx_ctx, depth, receiver)
+sync_call_context::sync_call_context(controller& con, transaction_context& trx_ctx, account_name sender, account_name receiver, uint32_t sync_call_depth, uint64_t flags, std::span<const char>data)
+   : host_context(con, trx_ctx, receiver, sync_call_depth)
    , sender(sender)
    , flags(flags)
    , data(data)


### PR DESCRIPTION
Enforce on chain configuration parameter `max_sync_call_depth` for nested and recursive sync calls. Once the depth is reached, the call is aborted.

Notable things about the two new two tests for the PR:

1. One test has one function making sync calls to itself recursively, another has two functions on different accounts calling each other recursively. Both tests show sync calls work correctly when max depth is not reached, and calls are aborted when max depth is reached.

2. The test WASM contracts utilize `sender` and `receiver` arguments from `sync_call` entry point, which demonstrates those two arguments are set correctly.

Resolves https://github.com/AntelopeIO/spring/issues/1268