### PR TITLE
[1.1.3] Test fix: Decrease max_block_cpu_usage and max_transaction_cpu_usage values

### DIFF
--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -120,7 +120,12 @@ namespace eosio::chain {
 
       net_limit = rl.get_block_net_limit();
 
-      objective_duration_limit = fc::microseconds( rl.get_block_cpu_limit() );
+      if (is_read_only() && !control.is_write_window()) { // if in write window then honor objective block limit
+         // this is not objective, but plays the same role for read-only trxs
+         objective_duration_limit = block_deadline - start; // read-only window size
+      } else {
+         objective_duration_limit = fc::microseconds( rl.get_block_cpu_limit() );
+      }
       _deadline = start + objective_duration_limit;
 
       // Possibly lower net_limit to the maximum net usage a transaction is allowed to be billed

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -319,9 +319,9 @@ class Cluster(object):
 
         if genesisPath is None:
             argsArr.append("--max-block-cpu-usage")
-            argsArr.append(str(200000))
+            argsArr.append(str(400000))
             argsArr.append("--max-transaction-cpu-usage")
-            argsArr.append(str(150000))
+            argsArr.append(str(250000))
         else:
             argsArr.append("--genesis")
             argsArr.append(str(genesisPath))

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -319,9 +319,9 @@ class Cluster(object):
 
         if genesisPath is None:
             argsArr.append("--max-block-cpu-usage")
-            argsArr.append(str(500000))
+            argsArr.append(str(200000))
             argsArr.append("--max-transaction-cpu-usage")
-            argsArr.append(str(475000))
+            argsArr.append(str(150000))
         else:
             argsArr.append("--genesis")
             argsArr.append(str(genesisPath))

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -108,7 +108,7 @@ def startCluster():
     specificExtraNodeosArgs[pnodes]+=" --read-only-write-window-time-us "
     specificExtraNodeosArgs[pnodes]+=" 10000 "
     specificExtraNodeosArgs[pnodes]+=" --read-only-read-window-time-us "
-    specificExtraNodeosArgs[pnodes]+=" 490000 "
+    specificExtraNodeosArgs[pnodes]+=" 510000 " # larger than block time to test Spring Issue #1286
     specificExtraNodeosArgs[pnodes]+=" --eos-vm-oc-cache-size-mb "
     specificExtraNodeosArgs[pnodes]+=" 1 " # set small so there is churn
     specificExtraNodeosArgs[pnodes]+=" --read-only-threads "


### PR DESCRIPTION
See https://github.com/AntelopeIO/spring/issues/1151#issuecomment-2660193692 for a detailed discussion of the test failure scenario.
Looks like https://github.com/AntelopeIO/spring/pull/1172 didn't change all tests to use mainnet values. Some still run with 475ms trx time.

Ideally it would be nice to run ci/cd with EOS Mainnet values for `max_block_cpu_usage` and `max_transaction_cpu_usage`. However, this puts us in a situation where tests will be flakey because transactions hit the time limit. See for example: 
https://github.com/AntelopeIO/spring/actions/runs/14131407538/job/39593258845
https://github.com/AntelopeIO/spring/actions/runs/14131407538/job/39593259641
https://github.com/AntelopeIO/spring/actions/runs/14131694179/job/39594280368

This PR reduces the value to something hopefully large enough for ci/cd without getting into the pathological case of https://github.com/AntelopeIO/spring/issues/1151#issuecomment-2660193692

Note: read-only trx tests were failing on this PR because of an issue with read-only trxs, see #1286. Fixed by #1288 which has been merged into this PR.

Resolves #1278 