### PR TITLE
[1.1.3] Ignore block cpu limit for read-only trxs

### DIFF
--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -120,7 +120,12 @@ namespace eosio::chain {
 
       net_limit = rl.get_block_net_limit();
 
-      objective_duration_limit = fc::microseconds( rl.get_block_cpu_limit() );
+      if (is_read_only() && !control.is_write_window()) { // if in write window then honor objective block limit
+         // this is not objective, but plays the same role for read-only trxs
+         objective_duration_limit = block_deadline - start; // read-only window size
+      } else {
+         objective_duration_limit = fc::microseconds( rl.get_block_cpu_limit() );
+      }
       _deadline = start + objective_duration_limit;
 
       // Possibly lower net_limit to the maximum net usage a transaction is allowed to be billed


### PR DESCRIPTION
With this PR, `read-only-read-window-time-us` can be set to larger than `max_block_cpu_usage` without causing any issues with read-only trxs being retried repeatedly. Now the read-window time is used to determine if the read-only trx should be retried instead of the block cpu limit. 

The fix does allow for read-only trxs run on the main thread to be limited by the block cpu limit. We currently do not allow read-only trxs to be run on the main thread, but we plan on adding support for that in the near future.

Note: really good docs for read-only trxs can be found at: https://github.com/eosnetworkfoundation/product/blob/read_only_trx_memory/transactions/read-only/parallel.md
The docs include a nice diagram of interaction of read and write windows.

With this PR, setting a large `read-only-read-window-time-us` will cause a node to pause until a long running read-only trx completes before processing a block. For example, `read-only-read-window-time-us = 50000000` can cause a node to pause up to 50 seconds while processing a large 50 second read-only trx. After the 50 seconds the node will process queued up blocks and sync up to the head of the chain.

Resolves #1286 