### PR TITLE
[1.1.3] Test fix: Better handle case where block not available

### DIFF
--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -708,15 +708,21 @@ class NodeosQueries:
         if waitForBlock:
             self.waitForBlock(blockNum, timeout=timeout, blockType=BlockType.head)
         block=self.getBlock(blockNum, exitOnError=exitOnError)
-        if block is None and not exitOnError:
-            return None
+        if block is None:
+            if exitOnError:
+                Utils.errorExit(f"getBlock returned None for {blockNum}")
+            else:
+                return None
         return NodeosQueries.getBlockAttribute(block, "producer", blockNum, exitOnError=exitOnError)
 
     def getBlockProducer(self, timeout=None, waitForBlock=True, exitOnError=True, blockType=BlockType.head):
         blockNum=self.getBlockNum(blockType=blockType)
         block=self.getBlock(blockNum, exitOnError=exitOnError, blockType=blockType)
-        if block is None and not exitOnError:
-            return None
+        if block is None:
+            if exitOnError:
+                Utils.errorExit(f"getBlock returned None for {blockNum}")
+            else:
+                return None
         return NodeosQueries.getBlockAttribute(block, "producer", blockNum, exitOnError=exitOnError)
 
     def getNextCleanProductionCycle(self, trans):

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -708,11 +708,15 @@ class NodeosQueries:
         if waitForBlock:
             self.waitForBlock(blockNum, timeout=timeout, blockType=BlockType.head)
         block=self.getBlock(blockNum, exitOnError=exitOnError)
+        if block is None and not exitOnError:
+            return None
         return NodeosQueries.getBlockAttribute(block, "producer", blockNum, exitOnError=exitOnError)
 
     def getBlockProducer(self, timeout=None, waitForBlock=True, exitOnError=True, blockType=BlockType.head):
         blockNum=self.getBlockNum(blockType=blockType)
         block=self.getBlock(blockNum, exitOnError=exitOnError, blockType=blockType)
+        if block is None and not exitOnError:
+            return None
         return NodeosQueries.getBlockAttribute(block, "producer", blockNum, exitOnError=exitOnError)
 
     def getNextCleanProductionCycle(self, trans):

--- a/tests/nodeos_short_fork_take_over_test.py
+++ b/tests/nodeos_short_fork_take_over_test.py
@@ -360,7 +360,7 @@ try:
         blockProducer0=prodNodes[0].getBlockProducerByNum(checkMatchBlock, exitOnError=False)
         blockProducer1=prodNodes[1].getBlockProducerByNum(checkMatchBlock, exitOnError=False)
         match=blockProducer0==blockProducer1
-        if match:
+        if match and blockProducer0 is not None:
             if checkHead:
                 forkResolved=True
                 break


### PR DESCRIPTION
Improve handling of `exitOnError=False` when block not available.

Resolves #1304