### PR TITLE
[1.1.3 -> main] Test fix: Kill node before end of defproducerb to allow more tolerance

### DIFF
--- a/tests/nodeos_short_fork_take_over_test.py
+++ b/tests/nodeos_short_fork_take_over_test.py
@@ -210,9 +210,9 @@ try:
     # block number to start expecting node killed after
     preKillBlockNum=nonProdNode.getBlockNum()
     preKillBlockProducer=nonProdNode.getBlockProducerByNum(preKillBlockNum)
-    # kill at last block before defproducerl, since the block it is killed on will get propagated
+    # kill before defproducerc
     killAtProducer="defproducerb"
-    inRowCountPerProducer=12
+    inRowCountPerProducer=10 # kill before c can produce
     nonProdNode.killNodeOnProducer(producer=killAtProducer, whereInSequence=(inRowCountPerProducer-1))
 
 
@@ -303,7 +303,7 @@ try:
     killBlockNum=blockNum
     lastBlockNum=killBlockNum+(maxActiveProducers - 1)*inRowCountPerProducer+1  # allow 1st testnet group to produce just 1 more block than the 2nd
 
-    Print("Tracking the blocks from the divergence till there are 10*12 blocks on one chain and 10*12+1 on the other, from block %d to %d" % (killBlockNum, lastBlockNum))
+    Print("Tracking the blocks from the divergence till there are 2*12 blocks on one chain and 2*12+1 on the other, from block %d to %d" % (killBlockNum, lastBlockNum))
 
     for blockNum in range(killBlockNum,lastBlockNum):
         blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum)


### PR DESCRIPTION
The test tried to time killing the bridge node at the last block of the round. There is no need to be that exact. Kill near the end of `defproducerb` without trying to hit the last block of the round.

Merges `release/1.1` into `main` including #1302 

Resolves #1301 