### PR TITLE
SC: privilege support

### DIFF
--- a/libraries/chain/host_context.cpp
+++ b/libraries/chain/host_context.cpp
@@ -75,6 +75,11 @@ uint32_t host_context::execute_sync_call(name call_receiver, uint64_t flags, std
          try {
             // use a new sync_call_context for next sync call
             sync_call_context call_ctx(control, trx_context, get_sync_call_sender(), call_receiver, depth, flags, data);
+
+            if (!control.skip_trx_checks()) {
+               call_ctx.privileged = receiver_account->is_privileged();
+            }
+
             control.get_wasm_interface().do_sync_call(receiver_account->code_hash, receiver_account->vm_type, receiver_account->vm_version, call_ctx);
 
             // store return value

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -80,7 +80,6 @@ class apply_context : public host_context {
       void finalize_trace( action_trace& trace, const fc::time_point& start );
 
       bool is_context_free()const override { return context_free; }
-      bool is_privileged()const override { return privileged; }
       const action& get_action()const override { return *act; }
       const action* get_action_ptr()const { return act; }
 
@@ -96,7 +95,6 @@ class apply_context : public host_context {
       uint32_t                      recurse_depth; ///< how deep inline actions can recurse
       uint32_t                      first_receiver_action_ordinal = 0;
       uint32_t                      action_ordinal = 0;
-      bool                          privileged   = false;
       bool                          context_free = false;
 
    private:

--- a/libraries/chain/include/eosio/chain/host_context.hpp
+++ b/libraries/chain/include/eosio/chain/host_context.hpp
@@ -557,7 +557,7 @@ public:
    virtual int get_action( uint32_t type, uint32_t index, char* buffer, size_t buffer_size ) const { assert(false); __builtin_unreachable(); }
    virtual int get_context_free_data( uint32_t index, char* buffer, size_t buffer_size )const { assert(false); __builtin_unreachable(); }
    virtual bool is_context_free()const = 0;
-   virtual bool is_privileged()const = 0;
+   bool is_privileged()const { return privileged; }
    action_name get_receiver()const { return receiver; };
    virtual const action& get_action()const { assert(false); __builtin_unreachable(); }
    virtual action_name get_sender() const = 0;
@@ -587,6 +587,7 @@ public:
    transaction_context&             trx_context; ///< transaction context in which the action is running
    account_name                     receiver; ///< the code that is currently running
    std::vector<char>                action_return_value;
+   bool                             privileged = false;
 
    std::optional<std::vector<char>> last_sync_call_return_value{}; // return value of last sync call initiated by the current code (host context)
    uint32_t                         sync_call_depth = 0; // depth for sync call

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -31,7 +31,6 @@ public:
    bool has_recipient(account_name account)const override;
    void update_db_usage( const account_name& payer, int64_t delta ) override;
    bool is_context_free()const override;
-   bool is_privileged()const override;
 };
 
 } } /// namespace eosio::chain

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -58,9 +58,6 @@ bool sync_call_context::has_recipient(account_name account)const {
 bool sync_call_context::is_context_free()const {
    return false;
 }
-bool sync_call_context::is_privileged()const { // to be revisited when privileged is being worked
-   return false;
-}
 
 // This needs to be investigated further
 void sync_call_context::update_db_usage( const account_name& payer, int64_t delta ) {}

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -420,7 +420,7 @@ REGISTER_LEGACY_HOST_FUNCTION(preactivate_feature, privileged_check);
 REGISTER_HOST_FUNCTION(set_resource_limits, privileged_check);
 REGISTER_LEGACY_HOST_FUNCTION(get_resource_limits, privileged_check);
 REGISTER_HOST_FUNCTION(get_parameters_packed, privileged_check);
-REGISTER_HOST_FUNCTION(set_parameters_packed, privileged_check);
+REGISTER_HOST_FUNCTION(set_parameters_packed, privileged_check, action_check); // Not allowed in sync calls. Change of max_sync_call_depth will interfere with active sync calls.
 REGISTER_HOST_FUNCTION(get_wasm_parameters_packed, privileged_check);
 REGISTER_HOST_FUNCTION(set_wasm_parameters_packed, privileged_check);
 REGISTER_LEGACY_HOST_FUNCTION(set_proposed_producers, privileged_check);

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -1360,12 +1360,13 @@ static const char constrains_enforcement_callee_wast[] = R"=====(
    (import "env" "send_context_free_inline" (func $send_context_free_inline (param i32 i32)))   ;; index 10
    (import "env" "send_deferred" (func $send_deferred (param i32 i64 i32 i32 i32)))  ;; index 11
    (import "env" "cancel_deferred" (func $cancel_deferred (param i32) (result i32))) ;; index 12
+   (import "env" "set_parameters_packed" (func $set_parameters_packed (param i32 i32))) ;; index 13
 
    (import "env" "get_call_data" (func $get_call_data (param i32 i32) (result i32))) ;; memory
    (memory $0 1)
    (export "memory" (memory $0))
 
-   (table 13 anyfunc)          ;; function table definition. update the number of entries below when a new function is added
+   (table 14 anyfunc)          ;; function table definition. update the number of entries below when a new function is added
    (elem (i32.const 0) $case_require_auth)               ;; index 0
    (elem (i32.const 1) $case_require_auth2)              ;; index 1
    (elem (i32.const 2) $case_has_auth)                   ;; index 2
@@ -1376,9 +1377,10 @@ static const char constrains_enforcement_callee_wast[] = R"=====(
    (elem (i32.const 7) $case_set_action_return_value)    ;; index 7
    (elem (i32.const 8) $case_get_context_free_data)      ;; index 8
    (elem (i32.const 9) $case_send_inline)                ;; index 9
-   (elem (i32.const 10) $case_send_context_free_inline)   ;; index 10
+   (elem (i32.const 10) $case_send_context_free_inline)  ;; index 10
    (elem (i32.const 11) $case_send_deferred)             ;; index 11
    (elem (i32.const 12) $case_cancel_deferred)           ;; index 12
+   (elem (i32.const 13) $case_set_parameters_packed)     ;; index 13
 
    (type $ftable (func))      ;; function table instantiation
    (func $case_require_auth
@@ -1445,6 +1447,11 @@ static const char constrains_enforcement_callee_wast[] = R"=====(
    (func $case_cancel_deferred
       i32.const 4  ;; create a pointer
       (drop (call $cancel_deferred))
+   )
+   (func $case_set_parameters_packed
+      i32.const 0
+      i32.const 0
+      call $set_parameters_packed
    )
 
    (func $callee (param $index i32)
@@ -1539,6 +1546,53 @@ BOOST_AUTO_TEST_CASE(constrains_enforcement_test)  { try {
    BOOST_CHECK_EXCEPTION(t.push_action("caller"_n, "callhostfunc"_n, "caller"_n, mvo() ("index", "12")),
                          unaccessible_api,
                          fc_exception_message_contains("this API may only be called from action"));
+
+   // set_parameters_packed
+   t.push_action(config::system_account_name, "setpriv"_n, config::system_account_name,
+                 mvo()("account", "callee"_n)("is_priv", 1)); // make receiver account privileged such that set_parameters_packed can meet the privilege precondition
+   BOOST_CHECK_EXCEPTION(t.push_action("caller"_n, "callhostfunc"_n, "caller"_n, mvo() ("index", "13")),
+                         unaccessible_api,
+                         fc_exception_message_contains("this API may only be called from action"));
+} FC_LOG_AND_RETHROW() }
+
+// Provide the called function via "sync_call" entry point calling the function
+static const char privilege_call_wast[] = R"=====(
+(module
+   (import "env" "eosio_assert" (func $assert (param i32 i32)))
+   (import "env" "get_wasm_parameters_packed" (func $get_wasm_parameters_packed (param i32 i32 i32) (result i32)))
+   (memory (export "memory") 1)
+
+   (export "sync_call" (func $sync_call))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+      (drop (call $get_wasm_parameters_packed (i32.const 0) (i32.const 0) (i32.const 0))) ;; get_wasm_parameters_packed requires privilege
+   )
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
+)
+)=====";
+
+BOOST_AUTO_TEST_CASE(privilege_call_test)  { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   create_accounts_and_set_code(caller_wast, privilege_call_wast, t);
+
+   // No privilege, sync call should fail
+   BOOST_CHECK_EXCEPTION(t.push_action("caller"_n, "doit"_n, "caller"_n, {}),
+                         unaccessible_api,
+                         fc_exception_message_contains("callee does not have permission to call this API"));
+
+   // Add privilege to receiver account ("callee"_n)
+   t.push_action(config::system_account_name, "setpriv"_n, config::system_account_name,
+                 mvo()("account", "callee"_n)("is_priv", 1));
+
+   // With privilege, sync call should succeed
+   BOOST_CHECK_NO_THROW(t.push_action("caller"_n, "doit"_n, "caller"_n, {}));
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Allow privileged host functions to be called if the receiver has the privileged permission.

Note `set_parameters_packed` is not allowed in sync calls as change of `max_sync_call_depth` will interfere with active sync calls. Updating wasm allocator queues upon changed  `max_sync_call_depth` will be done by https://github.com/AntelopeIO/spring/issues/1269

Resolve https://github.com/AntelopeIO/spring/issues/1279