### PR TITLE
[1.1.3] Retry setfinalizer on failure

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -1053,7 +1053,15 @@ class Cluster(object):
         if Utils.Debug: Utils.Print("setfinalizers: %s" % (setFinStr))
         Utils.Print("Setting finalizers")
         opts = "--permission eosio@active"
-        trans = node.pushMessage("eosio", "setfinalizer", setFinStr, opts)
+        # setfinalizer can fail on ci/cd because it required too much CPU, try a few times
+        retries = 3
+        while retries > 0:
+            trans = node.pushMessage("eosio", "setfinalizer", setFinStr, opts, force=True)
+            if trans is None or not trans[0]:
+                retries = retries - 1
+                continue
+            else:
+                break
         if trans is None or not trans[0]:
             Utils.Print("ERROR: Failed to set finalizers")
             return None


### PR DESCRIPTION
`setfinalizer` can fail because it took longer than the allowed max transaction time. This is made worse by #1287. Add a retry on failure similar to what we do for set contract: https://github.com/AntelopeIO/spring/blob/8ec275d8b4fc5b047d012e1412a77c143c1042c7/tests/TestHarness/transactions.py#L164-L164

Resolves #1314