### PR TITLE
Interrupt speculative transaction when block received

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4558,8 +4558,8 @@ struct controller_impl {
       // Only interrupt transaction if applying a block. Speculative trxs already have a deadline set so they
       // have limited run time already. This is to allow killing a long-running transaction in a block being
       // validated.
-      if (!replaying && applying_block) {
-         ilog("Interrupting apply block");
+      if (!replaying) {
+         ilog("Interrupting trx...");
          main_thread_timer.interrupt_timer();
       }
    }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4560,7 +4560,7 @@ struct controller_impl {
       // This is to allow killing a long-running transaction in a block being validated during apply block.
       // This also allows killing a trx when a block is received to prioritize block validation.
       if (!replaying) {
-         ilog("Interrupting trx...");
+         dlog("Interrupting trx...");
          main_thread_timer.interrupt_timer();
       }
    }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -209,7 +209,7 @@ namespace eosio::chain {
          deque<transaction_metadata_ptr> abort_block();
 
          /// Expected to be called from signal handler, or producer_plugin
-         void interrupt_apply_block_transaction();
+         void interrupt_transaction();
 
        /**
         *

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4026,11 +4026,12 @@ namespace eosio {
 
          if (fork_db_add_result == fork_db_add_t::appended_to_head || fork_db_add_result == fork_db_add_t::fork_switch) {
             ++c->unique_blocks_rcvd_count;
-            fc_dlog(logger, "post process_incoming_block to app thread, block ${n}", ("n", ptr->block_num()));
-            my_impl->producer_plug->process_blocks();
 
             // ready to process immediately, so signal producer to interrupt start_block
             my_impl->producer_plug->received_block(block_num, fork_db_add_result);
+
+            fc_dlog(logger, "post process_incoming_block to app thread, block ${n}", ("n", ptr->block_num()));
+            my_impl->producer_plug->process_blocks();
          }
       });
    }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -3050,7 +3050,10 @@ void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fo
    my->_received_block = block_num;
    // fork_db_add_t::fork_switch means head block of best fork (different from the current branch) is received.
    // Since a better fork is available, interrupt current block validation and allow a fork switch to the better branch.
-   if (fork_db_add_result == fork_db_add_t::fork_switch) {
+   if (fork_db_add_result == fork_db_add_t::appended_to_head) {
+      fc_tlog(_log, "new head block received");
+      my->chain_plug->chain().interrupt_transaction();
+   } else if (fork_db_add_result == fork_db_add_t::fork_switch) {
       fc_ilog(_log, "new best fork received");
       my->chain_plug->chain().interrupt_transaction();
    }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1217,6 +1217,11 @@ public:
 
    bool in_producing_mode()   const { return _pending_block_mode == pending_block_mode::producing; }
    bool in_speculating_mode() const { return _pending_block_mode == pending_block_mode::speculating; }
+
+   void interrupt_transaction() {
+      if (_is_savanna_active) // interrupt during transition causes issues, so only allow after transition
+         chain_plug->chain().interrupt_transaction();
+   }
 };
 
 void new_chain_banner(const eosio::chain::controller& db)
@@ -2844,8 +2849,7 @@ void producer_plugin_impl::schedule_production_loop() {
       // we failed to start a block, so try again later?
       _timer.async_wait([this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
          if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
-            if (_is_savanna_active) // interrupt during transition causes issues, so only allow after transition
-               chain_plug->chain().interrupt_transaction();
+            interrupt_transaction();
             app().executor().post(priority::high, exec_queue::read_write, [this]() {
                schedule_production_loop();
             });
@@ -2931,8 +2935,7 @@ void producer_plugin_impl::schedule_delayed_production_loop(const std::weak_ptr<
       _timer.expires_at(epoch + boost::posix_time::microseconds(wake_up_time->time_since_epoch().count()));
       _timer.async_wait([this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
          if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
-            if (_is_savanna_active) // interrupt during transition causes issues, so only allow after transition
-               chain_plug->chain().interrupt_transaction();
+            interrupt_transaction();
             app().executor().post(priority::high, exec_queue::read_write, [this]() {
                schedule_production_loop();
             });
@@ -3055,10 +3058,10 @@ void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fo
    if (my->_is_savanna_active) { // interrupt during transition causes issues, so only allow after transition
       if (fork_db_add_result == fork_db_add_t::appended_to_head) {
          fc_tlog(_log, "new head block received, interrupting trx");
-         my->chain_plug->chain().interrupt_transaction();
+         my->interrupt_transaction();
       } else if (fork_db_add_result == fork_db_add_t::fork_switch) {
          fc_ilog(_log, "new best fork received, interrupting trx");
-         my->chain_plug->chain().interrupt_transaction();
+         my->interrupt_transaction();
       }
    }
 }
@@ -3068,8 +3071,7 @@ void producer_plugin::interrupt() {
    fc_ilog(_log, "interrupt");
    app().executor().stop(); // shutdown any blocking read_only_execution_task
    my->interrupt_read_only();
-   if (my->_is_savanna_active) // interrupt during transition causes issues, so only allow after transition
-      my->chain_plug->chain().interrupt_transaction();
+   my->interrupt_transaction();
 }
 
 void producer_plugin_impl::interrupt_read_only() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -712,7 +712,7 @@ public:
    bool                                              _disable_subjective_p2p_billing              = true;
    bool                                              _disable_subjective_api_billing              = true;
    fc::time_point                                    _irreversible_block_time;
-   bool                                              _is_savanna_active                           = false;
+   std::atomic<bool>                                 _is_savanna_active                           = false;
 
    std::vector<chain::digest_type> _protocol_features_to_activate;
    bool                            _protocol_features_signaled = false; // to mark whether it has been signaled in start_block
@@ -2844,7 +2844,8 @@ void producer_plugin_impl::schedule_production_loop() {
       // we failed to start a block, so try again later?
       _timer.async_wait([this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
          if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
-            chain_plug->chain().interrupt_transaction();
+            if (_is_savanna_active) // interrupt during transition causes issues, so only allow after transition
+               chain_plug->chain().interrupt_transaction();
             app().executor().post(priority::high, exec_queue::read_write, [this]() {
                schedule_production_loop();
             });
@@ -2930,7 +2931,8 @@ void producer_plugin_impl::schedule_delayed_production_loop(const std::weak_ptr<
       _timer.expires_at(epoch + boost::posix_time::microseconds(wake_up_time->time_since_epoch().count()));
       _timer.async_wait([this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
          if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
-            chain_plug->chain().interrupt_transaction();
+            if (_is_savanna_active) // interrupt during transition causes issues, so only allow after transition
+               chain_plug->chain().interrupt_transaction();
             app().executor().post(priority::high, exec_queue::read_write, [this]() {
                schedule_production_loop();
             });
@@ -3050,12 +3052,14 @@ void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fo
    my->_received_block = block_num;
    // fork_db_add_t::fork_switch means head block of best fork (different from the current branch) is received.
    // Since a better fork is available, interrupt current block validation and allow a fork switch to the better branch.
-   if (fork_db_add_result == fork_db_add_t::appended_to_head) {
-      fc_tlog(_log, "new head block received");
-      my->chain_plug->chain().interrupt_transaction();
-   } else if (fork_db_add_result == fork_db_add_t::fork_switch) {
-      fc_ilog(_log, "new best fork received");
-      my->chain_plug->chain().interrupt_transaction();
+   if (my->_is_savanna_active) { // interrupt during transition causes issues, so only allow after transition
+      if (fork_db_add_result == fork_db_add_t::appended_to_head) {
+         fc_tlog(_log, "new head block received");
+         my->chain_plug->chain().interrupt_transaction();
+      } else if (fork_db_add_result == fork_db_add_t::fork_switch) {
+         fc_ilog(_log, "new best fork received");
+         my->chain_plug->chain().interrupt_transaction();
+      }
    }
 }
 
@@ -3063,7 +3067,8 @@ void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fo
 void producer_plugin::interrupt() {
    fc_ilog(_log, "interrupt");
    my->interrupt_read_only();
-   my->chain_plug->chain().interrupt_transaction();
+   if (my->_is_savanna_active) // interrupt during transition causes issues, so only allow after transition
+      my->chain_plug->chain().interrupt_transaction();
 }
 
 void producer_plugin_impl::interrupt_read_only() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2844,7 +2844,7 @@ void producer_plugin_impl::schedule_production_loop() {
       // we failed to start a block, so try again later?
       _timer.async_wait([this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
          if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
-            chain_plug->chain().interrupt_apply_block_transaction();
+            chain_plug->chain().interrupt_transaction();
             app().executor().post(priority::high, exec_queue::read_write, [this]() {
                schedule_production_loop();
             });
@@ -2930,7 +2930,7 @@ void producer_plugin_impl::schedule_delayed_production_loop(const std::weak_ptr<
       _timer.expires_at(epoch + boost::posix_time::microseconds(wake_up_time->time_since_epoch().count()));
       _timer.async_wait([this, cid = ++_timer_corelation_id](const boost::system::error_code& ec) {
          if (ec != boost::asio::error::operation_aborted && cid == _timer_corelation_id) {
-            chain_plug->chain().interrupt_apply_block_transaction();
+            chain_plug->chain().interrupt_transaction();
             app().executor().post(priority::high, exec_queue::read_write, [this]() {
                schedule_production_loop();
             });
@@ -3052,7 +3052,7 @@ void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fo
    // Since a better fork is available, interrupt current block validation and allow a fork switch to the better branch.
    if (fork_db_add_result == fork_db_add_t::fork_switch) {
       fc_ilog(_log, "new best fork received");
-      my->chain_plug->chain().interrupt_apply_block_transaction();
+      my->chain_plug->chain().interrupt_transaction();
    }
 }
 
@@ -3060,7 +3060,7 @@ void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fo
 void producer_plugin::interrupt() {
    fc_ilog(_log, "interrupt");
    my->interrupt_read_only();
-   my->chain_plug->chain().interrupt_apply_block_transaction();
+   my->chain_plug->chain().interrupt_transaction();
 }
 
 void producer_plugin_impl::interrupt_read_only() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -3054,10 +3054,10 @@ void producer_plugin::received_block(uint32_t block_num, chain::fork_db_add_t fo
    // Since a better fork is available, interrupt current block validation and allow a fork switch to the better branch.
    if (my->_is_savanna_active) { // interrupt during transition causes issues, so only allow after transition
       if (fork_db_add_result == fork_db_add_t::appended_to_head) {
-         fc_tlog(_log, "new head block received");
+         fc_tlog(_log, "new head block received, interrupting trx");
          my->chain_plug->chain().interrupt_transaction();
       } else if (fork_db_add_result == fork_db_add_t::fork_switch) {
-         fc_ilog(_log, "new best fork received");
+         fc_ilog(_log, "new best fork received, interrupting trx");
          my->chain_plug->chain().interrupt_transaction();
       }
    }

--- a/unittests/checktime_tests.cpp
+++ b/unittests/checktime_tests.cpp
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE( checktime_interrupt_test) { try {
 
    std::thread th( [&c=*other.control]() {
       std::this_thread::sleep_for( std::chrono::milliseconds(50) );
-      c.interrupt_apply_block_transaction();
+      c.interrupt_transaction();
    } );
 
    // apply block, caught in an "infinite" loop


### PR DESCRIPTION
Interrupt speculative transaction execution when a block is received or on ctrl-c.

Along with the existing interrupt of transactions in a block being validated, also interrupt speculative trxs so that processing of incoming block can start immediately.

Example:
```
debug 2025-04-08T14:39:46.595 net-3     net_plugin.cpp:4029           operator()           ] post process_incoming_block to app thread, block 441
debug 2025-04-08T14:39:46.595 net-3     controller.cpp:4563           interrupt_transactio ] Interrupting trx...
debug 2025-04-08T14:39:46.595 net-2     net_plugin.cpp:2855           operator()           ] ["localhost:9883 - f7f9514" - 4 127.0.0.1:60824] bcast block 441
debug 2025-04-08T14:39:46.596 nodeos    producer_plugin.cpp:2593      handle_push_result   ] [TRX_TRACE] Speculative execution COULD NOT FIT, elapsed 568us, tx: 08b18c0b53cab805495586bba2c53b6ed1dd390c7caad2b4a840c2036410ed4b RETRYING
debug 2025-04-08T14:39:46.596 net-2     net_plugin.cpp:1999           operator()           ] Connection - 4 - done sending block 441
debug 2025-04-08T14:39:46.596 nodeos    producer_plugin.cpp:971       restart_speculative_ ] Restarting exhausted speculative block #441
debug 2025-04-08T14:39:46.596 nodeos    producer_plugin.cpp:312       report               ] Block #441 defproducerb trx idle: 439611us out of 455626us, success: 12, 14269us, fail: 0, 0us, transient: 0, 0us, other: 1745us
debug 2025-04-08T14:39:46.596 nodeos    producer_plugin.cpp:2928      schedule_delayed_pro ] Scheduling Speculative/Production Change at 2025-04-08T14:39:47.096
debug 2025-04-08T14:39:46.596 nodeos    controller.cpp:4448           operator()           ] applying 1 fork db blocks from 441:000001b96c9ef0518f0c1493d79d8ff0c1e093185d886e2a39d6e3a69653e4c6 to 441:000001b96c9ef0518f0c1493d79d8ff0c1e093185d886e2a39d6e3a69653e4c6
...
info  2025-04-08T14:39:46.603 nodeos    controller.cpp:3558           log_applied          ] Received block 6c9ef0518f0c1493... #441 @ 2025-04-08T14:39:47.000 signed by defproducerb [trxs: 12, lib: 439, net: 1728, cpu: 5818 us, elapsed: 3348 us, applying time: 6518 us, latency: -396 ms]
debug 2025-04-08T14:39:46.603 nodeos    producer_plugin.cpp:2236      start_block          ] Starting block #442 2025-04-08T14:39:47.500 producer defproducerb, deadline 2025-04-08T14:39:47.103
```

Resolves #1170 