### PR TITLE
SC: Hide max_sync_call_depth and max_sync_call_data_size in the return value of get_consensus_parameters if sync_call protocol feature is not activated

### DIFF
--- a/libraries/chain/include/eosio/chain/chain_config.hpp
+++ b/libraries/chain/include/eosio/chain/chain_config.hpp
@@ -207,10 +207,6 @@ struct chain_config_v2 : chain_config_v1 {
       return static_cast<const Base&>(*this);
    }
 
-   inline const chain_config_v0& v0() const {
-      return static_cast<const chain_config_v0&>(*this);
-   }
-
    void validate() const;
 
    template<typename Stream>

--- a/libraries/chain/include/eosio/chain/chain_config.hpp
+++ b/libraries/chain/include/eosio/chain/chain_config.hpp
@@ -207,6 +207,10 @@ struct chain_config_v2 : chain_config_v1 {
       return static_cast<const Base&>(*this);
    }
 
+   inline const chain_config_v0& v0() const {
+      return static_cast<const chain_config_v0&>(*this);
+   }
+
    void validate() const;
 
    template<typename Stream>

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2683,7 +2683,7 @@ read_only::get_consensus_parameters(const get_consensus_parameters_params&, cons
    else if (db.is_builtin_activated(builtin_protocol_feature_t::action_return_value))
       to_variant(db.get_global_properties().configuration.base(), results.chain_config); //chain_config_v1
    else
-      to_variant(db.get_global_properties().configuration.v0(), results.chain_config); //chain_config_v0
+      to_variant(db.get_global_properties().configuration.base().base(), results.chain_config); //chain_config_v0
 
    if (db.is_builtin_activated(builtin_protocol_feature_t::configurable_wasm_limits)) {
       results.wasm_config = db.get_global_properties().wasm_configuration;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2678,10 +2678,12 @@ read_only::get_consensus_parameters_results
 read_only::get_consensus_parameters(const get_consensus_parameters_params&, const fc::time_point& ) const {
    get_consensus_parameters_results results;
 
-   if (db.is_builtin_activated(builtin_protocol_feature_t::action_return_value))
-      to_variant(db.get_global_properties().configuration,        results.chain_config); //chain_config_v1
+   if (db.is_builtin_activated(builtin_protocol_feature_t::sync_call))
+      to_variant(db.get_global_properties().configuration, results.chain_config); //chain_config_v2
+   else if (db.is_builtin_activated(builtin_protocol_feature_t::action_return_value))
+      to_variant(db.get_global_properties().configuration.base(), results.chain_config); //chain_config_v1
    else
-      to_variant(db.get_global_properties().configuration.base(), results.chain_config); //chain_config_v0
+      to_variant(db.get_global_properties().configuration.v0(), results.chain_config); //chain_config_v0
 
    if (db.is_builtin_activated(builtin_protocol_feature_t::configurable_wasm_limits)) {
       results.wasm_config = db.get_global_properties().wasm_configuration;

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -174,8 +174,8 @@ BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
    chain_config_v1 v1config;
    from_variant(parms.chain_config, v1config);
 
-   BOOST_TEST(v1config.max_action_return_value_size == t.control->get_global_properties().configuration.max_action_return_value_size);
    BOOST_TEST(parms.chain_config.get_object().contains("max_action_return_value_size"));
+   BOOST_TEST(v1config.max_action_return_value_size == t.control->get_global_properties().configuration.max_action_return_value_size);
    BOOST_TEST(!parms.wasm_config);
    BOOST_TEST(!parms.chain_config.get_object().contains("max_sync_call_depth"));
    BOOST_TEST(!parms.chain_config.get_object().contains("max_sync_call_data_size"));
@@ -209,9 +209,10 @@ BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
    chain_config_v2 v2config;
    from_variant(parms.chain_config, v2config);
 
-   BOOST_TEST(v2config.max_action_return_value_size == t.control->get_global_properties().configuration.max_action_return_value_size);
    BOOST_TEST(parms.chain_config.get_object().contains("max_sync_call_depth"));
    BOOST_TEST(parms.chain_config.get_object().contains("max_sync_call_data_size"));
+   BOOST_TEST(v2config.max_sync_call_depth == t.control->get_global_properties().configuration.max_sync_call_depth);
+   BOOST_TEST(v2config.max_sync_call_data_size == t.control->get_global_properties().configuration.max_sync_call_data_size);
 } FC_LOG_AND_RETHROW() //get_consensus_parameters
 
 BOOST_FIXTURE_TEST_CASE( get_account, validating_tester ) try {


### PR DESCRIPTION
Do not include `max_sync_call_depth` and `max_sync_call_data_size` in the return value of `get_consensus_parameters` if sync_call protocol feature is not activated. This is consistent with the behavior of https://github.com/AntelopeIO/spring/pull/1284.

Resolves https://github.com/AntelopeIO/spring/issues/1289