### PR TITLE
[1.1.3] Add vaulta to default eos vm oc whitelist

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -363,7 +363,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "'auto' - EOS VM OC tier-up is enabled for eosio.* accounts, read-only trxs, and except on producers applying blocks.\n"
           "'all'  - EOS VM OC tier-up is enabled for all contract execution.\n"
           "'none' - EOS VM OC tier-up is completely disabled.\n")
-         ("eos-vm-oc-whitelist", bpo::value<vector<string>>()->composing()->multitoken()->default_value(std::vector<string>{{"xsat"}}),
+         ("eos-vm-oc-whitelist", bpo::value<vector<string>>()->composing()->multitoken()->default_value(std::vector<string>{"xsat", "vaulta"}),
           "EOS VM OC tier-up whitelist account suffixes for tier-up runtime 'auto'.")
 #endif
          ("enable-account-queries", bpo::value<bool>()->default_value(false), "enable queries to find accounts by various metadata.")

--- a/plugins/chain_plugin/test/plugin_config_test.cpp
+++ b/plugins/chain_plugin/test/plugin_config_test.cpp
@@ -23,6 +23,13 @@ BOOST_AUTO_TEST_CASE(chain_plugin_default_tests) {
    // test default eos-vm-oc-whitelist
    BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"xsat"}));
    BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"vaulta"}));
+   BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"core.vaulta"}));
+   BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"xs.vaulta"}));
+   BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"xsat.vaulta"}));
+   BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"vaulta.xsat"}));
+   BOOST_CHECK(!plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"vault"}));
+   BOOST_CHECK(!plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"xs"}));
+   BOOST_CHECK(!plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{""}));
 }
 
 BOOST_AUTO_TEST_CASE(chain_plugin_eos_vm_oc_whitelist) {

--- a/plugins/chain_plugin/test/plugin_config_test.cpp
+++ b/plugins/chain_plugin/test/plugin_config_test.cpp
@@ -22,6 +22,7 @@ BOOST_AUTO_TEST_CASE(chain_plugin_default_tests) {
 
    // test default eos-vm-oc-whitelist
    BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"xsat"}));
+   BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"vaulta"}));
 }
 
 BOOST_AUTO_TEST_CASE(chain_plugin_eos_vm_oc_whitelist) {
@@ -38,4 +39,5 @@ BOOST_AUTO_TEST_CASE(chain_plugin_eos_vm_oc_whitelist) {
    BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"hello"}));
    BOOST_CHECK(plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"xs.hello"}));
    BOOST_CHECK(!plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"xsat"}));
+   BOOST_CHECK(!plugin.chain().is_eos_vm_oc_whitelisted(eosio::chain::name{"vaulta"}));
 }


### PR DESCRIPTION
Add `vaulta` to default list of `eos-vm-oc-whitelist` in anticipation of `core.vaulta` and others.

Resolves #1329 