### PR TITLE
SC: A new approach to managing Wasm allocators in controller

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library( eosio_chain
               wasm_eosio_validation.cpp
               wasm_eosio_injection.cpp
               wasm_config.cpp
+              wasm_alloc_pool.cpp
               host_context.cpp
               apply_context.cpp
               abi_serializer.cpp

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1014,10 +1014,8 @@ struct controller_impl {
    peer_keys_db_t                  peer_keys_db;
 
    thread_local static platform_timer timer; // a copy for main thread and each read-only thread
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
    thread_local static vm::wasm_allocator wasm_alloc; // a copy for main thread and each read-only thread
    wasm_alloc_pool wasm_allocator_pool;
-#endif
    wasm_interface  wasmif;
    app_window_type app_window = app_window_type::write;
 
@@ -5087,9 +5085,7 @@ struct controller_impl {
 }; /// controller_impl
 
 thread_local platform_timer controller_impl::timer;
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
 thread_local eosio::vm::wasm_allocator controller_impl::wasm_alloc;
-#endif
 
 const resource_limits_manager&   controller::get_resource_limits_manager()const
 {
@@ -6001,7 +5997,6 @@ uint32_t controller::earliest_available_block_num() const{
    return my->earliest_available_block_num();
 }
 
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
 vm::wasm_allocator& controller::get_wasm_allocator() {
    return my->wasm_alloc;
 }
@@ -6021,7 +6016,6 @@ void controller::set_wasm_alloc_pool_num_threads(uint32_t num_threads) {
 void controller::set_wasm_alloc_pool_max_call_depth(uint32_t depth) {
    my->wasm_allocator_pool.set_max_call_depth(depth);
 }
-#endif
 
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
 bool controller::is_eos_vm_oc_enabled() const {
@@ -6358,10 +6352,8 @@ void controller_impl::on_activation<builtin_protocol_feature_t::sync_call>() {
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "set_call_return_value" );
    } );
 
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
    auto max_call_depth = db.get<global_property_object>().configuration.max_sync_call_depth;
    wasm_allocator_pool.set_max_call_depth(max_call_depth);
-#endif
 }
 
 /// End of protocol feature activation handlers

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -6001,11 +6001,11 @@ vm::wasm_allocator& controller::get_wasm_allocator() {
    return my->wasm_alloc;
 }
 
-vm::wasm_allocator* controller::acquire_sync_call_wasm_allocator() {
+std::shared_ptr<vm::wasm_allocator> controller::acquire_sync_call_wasm_allocator() {
    return my->wasm_allocator_pool.acquire();
 }
 
-void controller::release_sync_call_wasm_allocator(vm::wasm_allocator* alloc) {
+void controller::release_sync_call_wasm_allocator(std::shared_ptr<vm::wasm_allocator> alloc) {
    my->wasm_allocator_pool.release(alloc);
 }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -26,6 +26,7 @@
 #include <eosio/chain/snapshot_detail.hpp>
 #include <eosio/chain/thread_utils.hpp>
 #include <eosio/chain/platform_timer.hpp>
+#include <eosio/chain/wasm_alloc_pool.hpp>
 #include <eosio/chain/block_header_state_utils.hpp>
 #include <eosio/chain/deep_mind.hpp>
 #include <eosio/chain/finalizer.hpp>
@@ -1015,10 +1016,9 @@ struct controller_impl {
    thread_local static platform_timer timer; // a copy for main thread and each read-only thread
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
    thread_local static vm::wasm_allocator wasm_alloc; // a copy for main thread and each read-only thread
-   thread_local static std::vector<vm::wasm_allocator> sync_call_wasm_alloc; // used for sync call. expensive to create one for each call
-   thread_local static uint32_t sync_call_wasm_alloc_index;
+   wasm_alloc_pool wasm_allocator_pool;
 #endif
-   wasm_interface wasmif;
+   wasm_interface  wasmif;
    app_window_type app_window = app_window_type::write;
 
    typedef pair<scope_name,action_name>                   handler_key;
@@ -1304,11 +1304,6 @@ struct controller_impl {
          elog( "Exception in vote thread pool, exiting: ${e}", ("e", e.to_detail_string()) );
          if( shutdown ) shutdown();
       } );
-
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
-      sync_call_wasm_alloc.resize(16); // Will change to use max_sync_call_depth of global property object in future version
-      sync_call_wasm_alloc_index = 0;
-#endif
 
       set_activation_handler<builtin_protocol_feature_t::preactivate_feature>();
       set_activation_handler<builtin_protocol_feature_t::replace_deferred>();
@@ -4939,10 +4934,6 @@ struct controller_impl {
    // Only called from read-only trx execution threads when producer_plugin
    // starts them.
    void init_thread_local_data() {
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
-      sync_call_wasm_alloc.resize(16);
-      sync_call_wasm_alloc_index = 0;
-#endif
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
       if ( is_eos_vm_oc_enabled() ) {
          wasmif.init_thread_local_data();
@@ -5098,8 +5089,6 @@ struct controller_impl {
 thread_local platform_timer controller_impl::timer;
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
 thread_local eosio::vm::wasm_allocator controller_impl::wasm_alloc;
-thread_local std::vector<eosio::vm::wasm_allocator> controller_impl::sync_call_wasm_alloc;
-thread_local uint32_t controller_impl::sync_call_wasm_alloc_index = 0;
 #endif
 
 const resource_limits_manager&   controller::get_resource_limits_manager()const
@@ -6011,20 +6000,29 @@ void controller::enable_deep_mind(deep_mind_handler* logger) {
 uint32_t controller::earliest_available_block_num() const{
    return my->earliest_available_block_num();
 }
+
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
 vm::wasm_allocator& controller::get_wasm_allocator() {
    return my->wasm_alloc;
 }
 
-vm::wasm_allocator& controller::get_sync_call_wasm_allocator() {
-   EOS_ASSERT( my->sync_call_wasm_alloc_index < 16, misc_exception, "sync_call_wasm_alloc_index ${i} must be less than ${m}", ("i", my->sync_call_wasm_alloc_index) ("m", 16) ); // will change to use max_sync_call_depth
-   return my->sync_call_wasm_alloc[my->sync_call_wasm_alloc_index++];
+vm::wasm_allocator* controller::acquire_sync_call_wasm_allocator() {
+   return my->wasm_allocator_pool.acquire();
 }
 
-void controller::return_sync_call_wasm_allocator() {
-   --my->sync_call_wasm_alloc_index;
+void controller::release_sync_call_wasm_allocator(vm::wasm_allocator* alloc) {
+   my->wasm_allocator_pool.release(alloc);
+}
+
+void controller::set_wasm_alloc_pool_num_threads(uint32_t num_threads) {
+   my->wasm_allocator_pool.set_threads(num_threads);
+}
+
+void controller::set_wasm_alloc_pool_max_call_depth(uint32_t depth) {
+   my->wasm_allocator_pool.set_max_call_depth(depth);
 }
 #endif
+
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
 bool controller::is_eos_vm_oc_enabled() const {
    return my->is_eos_vm_oc_enabled();
@@ -6359,6 +6357,11 @@ void controller_impl::on_activation<builtin_protocol_feature_t::sync_call>() {
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "get_call_data" );
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "set_call_return_value" );
    } );
+
+#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
+   auto max_call_depth = db.get<global_property_object>().configuration.max_sync_call_depth;
+   wasm_allocator_pool.set_max_call_depth(max_call_depth);
+#endif
 }
 
 /// End of protocol feature activation handlers

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -6010,7 +6010,7 @@ void controller::release_sync_call_wasm_allocator(vm::wasm_allocator* alloc) {
 }
 
 void controller::set_wasm_alloc_pool_num_threads(uint32_t num_threads) {
-   my->wasm_allocator_pool.set_threads(num_threads);
+   my->wasm_allocator_pool.set_num_threads(num_threads);
 }
 
 void controller::set_wasm_alloc_pool_max_call_depth(uint32_t depth) {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -450,11 +450,11 @@ namespace eosio::chain {
          void enable_deep_mind( deep_mind_handler* logger );
          uint32_t earliest_available_block_num() const;
 
-         vm::wasm_allocator&  get_wasm_allocator();
-         vm::wasm_allocator*  acquire_sync_call_wasm_allocator();
-         void                 release_sync_call_wasm_allocator(vm::wasm_allocator* alloc);
-         void                 set_wasm_alloc_pool_num_threads(uint32_t num_threads);
-         void                 set_wasm_alloc_pool_max_call_depth(uint32_t depth);
+         vm::wasm_allocator&                 get_wasm_allocator();
+         std::shared_ptr<vm::wasm_allocator> acquire_sync_call_wasm_allocator();
+         void                                release_sync_call_wasm_allocator(std::shared_ptr<vm::wasm_allocator> alloc);
+         void                                set_wasm_alloc_pool_num_threads(uint32_t num_threads);
+         void                                set_wasm_alloc_pool_max_call_depth(uint32_t depth);
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
          bool is_eos_vm_oc_enabled() const;
 #endif

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -450,13 +450,11 @@ namespace eosio::chain {
          void enable_deep_mind( deep_mind_handler* logger );
          uint32_t earliest_available_block_num() const;
 
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
          vm::wasm_allocator&  get_wasm_allocator();
          vm::wasm_allocator*  acquire_sync_call_wasm_allocator();
          void                 release_sync_call_wasm_allocator(vm::wasm_allocator* alloc);
          void                 set_wasm_alloc_pool_num_threads(uint32_t num_threads);
          void                 set_wasm_alloc_pool_max_call_depth(uint32_t depth);
-#endif
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
          bool is_eos_vm_oc_enabled() const;
 #endif

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -452,8 +452,10 @@ namespace eosio::chain {
 
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
          vm::wasm_allocator&  get_wasm_allocator();
-         vm::wasm_allocator&  get_sync_call_wasm_allocator();
-         void                 return_sync_call_wasm_allocator();
+         vm::wasm_allocator*  acquire_sync_call_wasm_allocator();
+         void                 release_sync_call_wasm_allocator(vm::wasm_allocator* alloc);
+         void                 set_wasm_alloc_pool_num_threads(uint32_t num_threads);
+         void                 set_wasm_alloc_pool_max_call_depth(uint32_t depth);
 #endif
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
          bool is_eos_vm_oc_enabled() const;

--- a/libraries/chain/include/eosio/chain/wasm_alloc_pool.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_alloc_pool.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <eosio/chain/config.hpp>
 #include <eosio/vm/allocator.hpp>
 #include <boost/lockfree/stack.hpp>
 
@@ -46,7 +47,7 @@ private:
    uint32_t num_threads    = 1; // `1` for the main thread
    uint32_t max_call_depth = 1; // prior to sync call protocol feature activated
 
-   std::unique_ptr<boost::lockfree::stack<vm::wasm_allocator*>> stack;
+   boost::lockfree::stack<vm::wasm_allocator*> stack {config::default_max_sync_call_depth};
 };
 
 }  /// namespace eosio::chain

--- a/libraries/chain/include/eosio/chain/wasm_alloc_pool.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_alloc_pool.hpp
@@ -27,13 +27,12 @@ class wasm_alloc_pool {
 
 public:
    wasm_alloc_pool();
-   ~wasm_alloc_pool();
 
    // request a wasm allocator from the pool, called on any threads
-   vm::wasm_allocator* acquire();
+   std::shared_ptr<vm::wasm_allocator> acquire();
 
    // release a wasm allocator back to the pool, called on any threads
-   void release(vm::wasm_allocator* alloc);
+   void release(std::shared_ptr<vm::wasm_allocator> alloc);
 
    // called on main thread from producer_plugin startup after number of read-only threads is determined
    void set_num_threads(uint32_t num_threads);
@@ -47,7 +46,7 @@ private:
    uint32_t num_threads    = 1; // `1` for the main thread
    uint32_t max_call_depth = 1; // prior to sync call protocol feature activated
 
-   boost::lockfree::stack<vm::wasm_allocator*> stack {config::default_max_sync_call_depth};
+   boost::lockfree::stack<std::shared_ptr<vm::wasm_allocator>> stack {config::default_max_sync_call_depth};
 };
 
 }  /// namespace eosio::chain

--- a/libraries/chain/include/eosio/chain/wasm_alloc_pool.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_alloc_pool.hpp
@@ -35,7 +35,7 @@ public:
    void release(vm::wasm_allocator* alloc);
 
    // called on main thread from producer_plugin startup after number of read-only threads is determined
-   void set_threads(uint32_t num_threads);
+   void set_num_threads(uint32_t num_threads);
 
    // called on main thread from sync_call protocol feature activation or set_packed_parameters
    void set_max_call_depth(uint32_t depth);

--- a/libraries/chain/include/eosio/chain/wasm_alloc_pool.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_alloc_pool.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <eosio/vm/allocator.hpp>
+#include <boost/lockfree/stack.hpp>
+
+/*
+ *
+ * Problem: Dynamically creating wasm allocators is expensive. To support sync
+ *          calls, each of the main and read only threads requires a set of
+ *          pre-constructed `max_sync_call_depth` of wasm allocators.
+ *          But `max_sync_call_depth` can be changed by BPs, which causes resizing
+ *          of the allocator sets.
+ * Solution: Use a wasm allocator pool with a Boost lockfree stack.
+ * Advantages:
+ *    1. Lockfree for acquiring and releasing wasm allocators.
+ *    2. When `max_sync_call_depth` changes, the pool changes right away. No need
+ *       to check if `max_sync_call_depth` has changed every time.
+ *    3. Avoid the use of thread_locals.
+ *    4. Simpler to reason.
+ *
+ */
+
+namespace eosio::chain {
+
+class wasm_alloc_pool {
+
+public:
+   wasm_alloc_pool();
+   ~wasm_alloc_pool();
+
+   // request a wasm allocator from the pool, called on any threads
+   vm::wasm_allocator* acquire();
+
+   // release a wasm allocator back to the pool, called on any threads
+   void release(vm::wasm_allocator* alloc);
+
+   // called on main thread from producer_plugin startup after number of read-only threads is determined
+   void set_threads(uint32_t num_threads);
+
+   // called on main thread from sync_call protocol feature activation or set_packed_parameters
+   void set_max_call_depth(uint32_t depth);
+
+private:
+   void resize(uint32_t new_num_thread, uint32_t new_depth);
+
+   uint32_t num_threads    = 1; // `1` for the main thread
+   uint32_t max_call_depth = 1; // prior to sync call protocol feature activated
+
+   std::unique_ptr<boost::lockfree::stack<vm::wasm_allocator*>> stack;
+};
+
+}  /// namespace eosio::chain

--- a/libraries/chain/wasm_alloc_pool.cpp
+++ b/libraries/chain/wasm_alloc_pool.cpp
@@ -39,7 +39,7 @@ void wasm_alloc_pool::release(vm::wasm_allocator* alloc) {
 }
 
 // called on main thread from producer_plugin startup number of read-only threads is determined
-void wasm_alloc_pool::set_threads(uint32_t new_num_thread) {
+void wasm_alloc_pool::set_num_threads(uint32_t new_num_thread) {
    if (new_num_thread <= num_threads) {
       // For simplicity, we don't shrink the pool
       return;
@@ -58,7 +58,7 @@ void wasm_alloc_pool::set_max_call_depth(uint32_t new_depth) {
    resize(num_threads, new_depth);
 }
 
-// called on main thread (it is called by set_threads or set_max_call_depth).
+// called on main thread (it is called by set_num_threads or set_max_call_depth).
 void wasm_alloc_pool::resize(uint32_t new_num_thread, uint32_t new_depth) {
    auto old_pool_size  = num_threads * max_call_depth;
    auto new_pool_size  = new_num_thread * new_depth;

--- a/libraries/chain/wasm_alloc_pool.cpp
+++ b/libraries/chain/wasm_alloc_pool.cpp
@@ -1,5 +1,5 @@
+#include <eosio/chain/config.hpp>
 #include <eosio/chain/wasm_alloc_pool.hpp>
-#include <fc/log/logger.hpp>
 
 namespace eosio::chain {
 
@@ -9,7 +9,7 @@ wasm_alloc_pool::wasm_alloc_pool()
    , max_call_depth(1)
 {
    // create 1 wasm allocator for the main thread
-   stack = std::make_unique<boost::lockfree::stack<vm::wasm_allocator*>>(1);
+   stack = std::make_unique<boost::lockfree::stack<vm::wasm_allocator*>>(config::default_max_sync_call_depth);
    stack->push(new vm::wasm_allocator);
 }
 

--- a/libraries/chain/wasm_alloc_pool.cpp
+++ b/libraries/chain/wasm_alloc_pool.cpp
@@ -1,0 +1,92 @@
+#include <eosio/chain/wasm_alloc_pool.hpp>
+#include <fc/log/logger.hpp>
+
+namespace eosio::chain {
+
+// only called on main thread
+wasm_alloc_pool::wasm_alloc_pool()
+   : num_threads(1)
+   , max_call_depth(1)
+{
+   // create 1 wasm allocator for the main thread
+   stack = std::make_unique<boost::lockfree::stack<vm::wasm_allocator*>>(1);
+   stack->push(new vm::wasm_allocator);
+}
+
+wasm_alloc_pool::~wasm_alloc_pool() {
+   vm::wasm_allocator* alloc;
+   while (stack->pop(alloc)) {
+      delete alloc;
+   }
+}
+
+// called on any threads
+vm::wasm_allocator* wasm_alloc_pool::acquire() {
+   // Each thread can use at most `max_sync_call_depth` wasm allocators
+   // The stack would never be empty for a new acquire request
+   assert(!stack->empty());
+
+   vm::wasm_allocator* alloc;
+   stack->pop(alloc);
+
+   assert(alloc);
+   return alloc;
+}
+
+// called on any threads
+void wasm_alloc_pool::release(vm::wasm_allocator* alloc) {
+   stack->push(alloc);
+}
+
+// called on main thread from producer_plugin startup number of read-only threads is determined
+void wasm_alloc_pool::set_threads(uint32_t new_num_thread) {
+   if (new_num_thread <= num_threads) {
+      // For simplicity, we don't shrink the pool
+      return;
+   }
+
+   resize(new_num_thread, max_call_depth);
+}
+
+// called on main thread from sync_call protocol feature activation or set_packed_parameters
+void wasm_alloc_pool::set_max_call_depth(uint32_t new_depth) {
+   if (new_depth <= max_call_depth) {
+      // For simplicity, we don't shrink the pool
+      return;
+   }
+
+   resize(num_threads, new_depth);
+}
+
+void wasm_alloc_pool::resize(uint32_t new_num_thread, uint32_t new_depth) {
+   auto old_pool_size  = num_threads * max_call_depth; // take a note of old size
+
+   // save allocators not being in use into a temporary place
+   std::vector<vm::wasm_allocator*> temp;
+   vm::wasm_allocator* alloc;
+   while (stack->pop(alloc)) {
+      temp.push_back(alloc);
+   }
+
+   // update with new values
+   num_threads         = new_num_thread;
+   max_call_depth      = new_depth;
+   auto new_pool_size  = num_threads * max_call_depth;
+
+   // recreate the internal stack with the new capacity
+   stack = std::make_unique<boost::lockfree::stack<vm::wasm_allocator*>>(new_pool_size);
+
+   // put back existing allocators not in use to the pool.
+   // allocators in use by the main thread will be released back to the pool eventually
+   for (const auto& alloc: temp) {
+      stack->push(alloc);
+   }
+
+   // add new ones
+   auto num_new_allocs = new_pool_size - old_pool_size;
+   for (uint32_t i = 0u; i < num_new_allocs ; ++i) {
+      stack->push(new vm::wasm_allocator);
+   }
+} 
+
+} /// eosio::chain

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -259,7 +259,6 @@ namespace eosio { namespace chain { namespace webassembly {
       fc::datastream<const char*> ds( packed_parameters.data(), packed_parameters.size() );
 
       chain::chain_config cfg = context.control.get_global_properties().configuration;
-      auto old_max_sync_call_depth = cfg.max_sync_call_depth;
       config_range config_range(cfg, {context.control});
 
       fc::raw::unpack(ds, config_range);
@@ -270,11 +269,7 @@ namespace eosio { namespace chain { namespace webassembly {
               gprops.configuration = config_range.config;
       });
 
-      // only update wasm_allocator pool size when new max_sync_call_depth
-      // is greater than existing one
-      if (config_range.config.max_sync_call_depth > old_max_sync_call_depth) {
-         context.control.set_wasm_alloc_pool_max_call_depth(config_range.config.max_sync_call_depth);
-      }
+      context.control.set_wasm_alloc_pool_max_call_depth(config_range.config.max_sync_call_depth);
    }
 
    bool interface::is_privileged( account_name n ) const {

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -259,9 +259,7 @@ namespace eosio { namespace chain { namespace webassembly {
       fc::datastream<const char*> ds( packed_parameters.data(), packed_parameters.size() );
 
       chain::chain_config cfg = context.control.get_global_properties().configuration;
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
       auto old_max_sync_call_depth = cfg.max_sync_call_depth;
-#endif
       config_range config_range(cfg, {context.control});
 
       fc::raw::unpack(ds, config_range);
@@ -272,13 +270,11 @@ namespace eosio { namespace chain { namespace webassembly {
               gprops.configuration = config_range.config;
       });
 
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
       // only update wasm_allocator pool size when new max_sync_call_depth
       // is greater than existing one
       if (config_range.config.max_sync_call_depth > old_max_sync_call_depth) {
          context.control.set_wasm_alloc_pool_max_call_depth(config_range.config.max_sync_call_depth);
       }
-#endif
    }
 
    bool interface::is_privileged( account_name n ) const {

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -159,11 +159,11 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
 
          backend_t                                bkend;
          typename eos_vm_runtime<Impl>::context_t exec_ctx;
-         vm::wasm_allocator*                      wasm_alloc = context.control.acquire_sync_call_wasm_allocator();
+         std::shared_ptr<vm::wasm_allocator>      wasm_alloc = std::move(context.control.acquire_sync_call_wasm_allocator());
 
          // always return the wasm_allocator obtainded back to the pool when exiting
          auto ensure = fc::make_scoped_exit([&]() {
-            context.control.release_sync_call_wasm_allocator(wasm_alloc);
+            context.control.release_sync_call_wasm_allocator(std::move(wasm_alloc));
          });
 
          apply_options opts = get_apply_options(context);

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1631,11 +1631,9 @@ void producer_plugin_impl::plugin_startup() {
       }
 
       if (_ro_thread_pool_size > 0) {
-#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
          // inform controller's wasm_alloc_pool of number of updated total threads
          // (number of main plus read only threads)
          chain.set_wasm_alloc_pool_num_threads(1 + _ro_thread_pool_size);
-#endif
 
          _ro_thread_pool.start(
             _ro_thread_pool_size,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1631,6 +1631,12 @@ void producer_plugin_impl::plugin_startup() {
       }
 
       if (_ro_thread_pool_size > 0) {
+#if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
+         // inform controller's wasm_alloc_pool of number of updated total threads
+         // (number of main plus read only threads)
+         chain.set_wasm_alloc_pool_num_threads(1 + _ro_thread_pool_size);
+#endif
+
          _ro_thread_pool.start(
             _ro_thread_pool_size,
             [](const fc::exception& e) {

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -1669,4 +1669,99 @@ BOOST_AUTO_TEST_CASE(privilege_call_test)  { try {
    BOOST_CHECK_NO_THROW(t.push_action("caller"_n, "doit"_n, "caller"_n, {}));
 } FC_LOG_AND_RETHROW() }
 
+// If the action input is 0, set max_sync_call_depth to 20,
+// If the action input is 1, set max_sync_call_depth to 10,
+// Otherwise, make the sync call with call depth of the input
+static const char max_call_depth_update_caller_wast[] = R"=====(
+(module
+   (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64))) ;; receiver, flags, data span
+   (import "env" "read_action_data" (func $read_action_data (param i32 i32) (result i32)))
+   (import "env" "set_parameters_packed" (func $set_parameters_packed (param i32 i32)))
+   (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
+
+   (export "apply" (func $apply))
+   (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
+      (local $input i32)
+
+      (drop (call $read_action_data(i32.const 0)(i32.const 4)))  ;; read action input into memory[0]
+
+     (set_local $input (i32.load (i32.const 0)))  ;; load input
+
+     (if (i32.eq (get_local $input) (i32.const 0))
+        (then
+           (call $set_parameters_packed (i32.const 4) (i32.const 6))  ;; set max_sync_call_depth to 20
+        )
+        (else
+           (if (i32.eq (get_local $input) (i32.const 1))
+              (then
+                 (call $set_parameters_packed (i32.const 10) (i32.const 6))  ;; set max_sync_call_depth to 10
+              )
+              (else
+                 (drop (call $call (get_global $callee) (i64.const 0)(i32.const 0)(i32.const 4))) ;; make a sync call with data starting at address 0, size 4
+              )
+           )
+        )
+     )
+   )
+
+   (memory (export "memory") 1)
+   (data (i32.const 4) ;; memory[4]
+      "\01"           ;; 1:  sequence_length
+      "\12"           ;; 18: max_sync_call_depth id
+      "\14\00\00\00"  ;; 20: new max_sync_call_depth value
+      "\01"           ;; 1:  sequence_length, memory[10]
+      "\12"           ;; 18: max_sync_call_depth id
+      "\0A\00\00\00"  ;; 10: another max_sync_call_depth value
+   )
+)
+)=====";
+
+BOOST_AUTO_TEST_CASE(max_call_depth_update_test)  { try {
+   validating_tester t;
+
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // skip eos_vm_oc for now.
+      return;
+   }
+
+   create_accounts_and_set_code(max_call_depth_update_caller_wast, direct_recursive_wast, t);
+
+   // Add privilege to caller account so it can call set_parameters_packed
+   t.push_action(config::system_account_name, "setpriv"_n, config::system_account_name,
+                 mvo()("account", "caller"_n)("is_priv", 1));
+   t.produce_block();
+
+   // Verify `config::default_max_sync_call_depth + 1` (17) recursive calls will fail
+   BOOST_CHECK_EXCEPTION(t.push_action("caller"_n, "callwithinpt"_n, "caller"_n, mvo() ("input", std::to_string(config::default_max_sync_call_depth + 1))),
+                         sync_call_depth_exception,
+                         fc_exception_message_contains("reached sync call max call depth"));
+
+   // Increase max_sync_call_depth to 20
+   t.push_action("caller"_n, "callwithinpt"_n, "caller"_n, mvo() ("input", "0"));
+   t.produce_block();
+
+   // Now `config::default_max_sync_call_depth + 1` (17) recursive calls should pass
+   BOOST_REQUIRE_NO_THROW(t.push_action("caller"_n, "callwithinpt"_n, "caller"_n, mvo() ("input", std::to_string(config::default_max_sync_call_depth + 1))));
+
+   // 20 recursive calls should also pass
+   BOOST_REQUIRE_NO_THROW(t.push_action("caller"_n, "callwithinpt"_n, "caller"_n, mvo() ("input", "20")));
+
+   // But `21` recursive calls should fail
+   BOOST_CHECK_EXCEPTION(t.push_action("caller"_n, "callwithinpt"_n, "caller"_n, mvo() ("input", "21")),
+                         sync_call_depth_exception,
+                         fc_exception_message_contains("reached sync call max call depth"));
+
+   // Reduce max_sync_call_depth to 10
+   t.push_action("caller"_n, "callwithinpt"_n, "caller"_n, mvo() ("input", "1"));
+   t.produce_block();
+
+   // Now `10` recursive calls should pass
+   BOOST_REQUIRE_NO_THROW(t.push_action("caller"_n, "callwithinpt"_n, "caller"_n, mvo() ("input", "10")));
+
+   // But `11` recursive calls should fail
+   BOOST_CHECK_EXCEPTION(t.push_action("caller"_n, "callwithinpt"_n, "caller"_n, mvo() ("input", "11")),
+                         sync_call_depth_exception,
+                         fc_exception_message_contains("reached sync call max call depth"));
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Dynamically creating wasm allocators is expensive; we don't want to create an allocator for each level of a call. Currently a thread_local queue with a fixed size (`max_sync_call_depth`) is pre-created on each thread.  But `max_sync_call_depth` can be changed by BPs, which requires dynamically resizing the queue on each thread. Solutions seem to be complicated if keeping using the thread locals.

This PR implements a new approach to managing Wasm allocators,  using a pool with an internal Boost lockfree stack.

The advantages are
 1.  Lockfree for acquiring and releasing allocators.
 2. When `max_sync_call_depth` changes, the pool changes right away. No need to check if `max_sync_call_depth` has changed every time.
3. Avoid the use of thread_locals.
4. Simpler to reason.

Thanks to @spoonincode for suggesting looking into Boost lockfree data structures.
 
Note: It seems the wasm allocator implementation prior to sync call can be removed. But that's better to be done in https://github.com/AntelopeIO/spring/issues/1254

Resolves https://github.com/AntelopeIO/spring/issues/1269