### PR TITLE
[1.1.4 -> main] Test fix: Wait an extra block for protocol activation

### DIFF
--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -396,6 +396,8 @@ class Transactions(NodeosQueries):
                     Utils.Print("ERROR: Failed to preactive digest {}".format(digest))
                     return None
             self.waitForTransactionInBlock(trans['transaction_id'])
+            # protocol features are activated in the next start_block, wait one more block
+            self.waitForHeadToAdvance()
 
     # Require PREACTIVATE_FEATURE to be activated and require eosio.bios with preactivate_feature
     def activateAllBuiltinProtocolFeature(self):


### PR DESCRIPTION
Protocol activation happens in the next block start_block, wait an extra block so that activation can happen. The test was failing because even though the transaction with the activate was found, the protocol feature had not actually been activated yet. Activation happens in the next start_block. Wait another block so that the protocol feature is activated.

Merges `release/1.1` into `main` including #1341 

Resolves #1247 