### PR TITLE
[1.1.4] Increase max-transaction-cpu-usage for slow/overwhelmed ci/cd

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -321,7 +321,7 @@ class Cluster(object):
             argsArr.append("--max-block-cpu-usage")
             argsArr.append(str(400000))
             argsArr.append("--max-transaction-cpu-usage")
-            argsArr.append(str(250000))
+            argsArr.append(str(375000))
         else:
             argsArr.append("--genesis")
             argsArr.append(str(genesisPath))


### PR DESCRIPTION
We have been seeing a number of tests fail because a trx could not execute in 250ms on ci/cd. Increase to 375ms to give more time on ci/cd.

Resolves #1321 
Resolves #1345 