### PR TITLE
[1.1.4] Test fix: Make sure node2 and node3 have trx reference block

### DIFF
--- a/tests/p2p_no_blocks_test.py
+++ b/tests/p2p_no_blocks_test.py
@@ -94,6 +94,9 @@ try:
     transferAmount="50.0000 {0}".format(CORE_SYMBOL)
     trx=nonProdNode01.transferFunds(cluster.eosioAccount, cluster.defproduceraAccount, transferAmount, dontSend=True)
 
+    Print("Sync past transfer reference block")
+    # Make sure node2 and node3 have trx reference block before killing bios node otherwise the trx will fail
+    # because the reference block is not available.
     head = nonProdNode01.getHeadBlockNum()
     assert noBlocks02.waitForBlock(headBlockNum), "node02 did not get block before bios shutdown"
     assert noBlocks03.waitForBlock(headBlockNum), "node03 did not get block before bios shutdown"

--- a/tests/p2p_no_blocks_test.py
+++ b/tests/p2p_no_blocks_test.py
@@ -94,6 +94,10 @@ try:
     transferAmount="50.0000 {0}".format(CORE_SYMBOL)
     trx=nonProdNode01.transferFunds(cluster.eosioAccount, cluster.defproduceraAccount, transferAmount, dontSend=True)
 
+    head = nonProdNode01.getHeadBlockNum()
+    assert noBlocks02.waitForBlock(headBlockNum), "node02 did not get block before bios shutdown"
+    assert noBlocks03.waitForBlock(headBlockNum), "node03 did not get block before bios shutdown"
+
     Print("Killing bios node")
     cluster.biosNode.kill(signal.SIGTERM)
 


### PR DESCRIPTION
Make sure node2 and node3 have trx reference block before killing bios node otherwise the trx will fail because the reference block is not available.

```
debug 2025-04-11T15:14:41.435 net-1     net_plugin.cpp:4204           operator()           ] signaled NACK, trx-id = f3b8e5c456fd9e94263640bf7453efaf9edc2c102e0174160b03c5f32a9e4936 : 3040007 invalid_ref_block_exception: Invalid Reference Block
Transaction's reference block 162 did not match 0000000000000000000000000000000000000000000000000000000000000000. Is this transaction from a different fork?
    {"rb":162,"bs":"0000000000000000000000000000000000000000000000000000000000000000"}
    nodeos  controller.cpp:5942 validate_tapos

    {}
    nodeos  controller.cpp:5943 validate_tapos
```

Resolves #1209 