### PR TITLE
[1.1.4] Correctly identify snapshot as forked out

### DIFF
--- a/libraries/chain/include/eosio/chain/pending_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/pending_snapshot.hpp
@@ -14,8 +14,8 @@ class pending_snapshot {
 public:
    using next_t = eosio::chain::next_function<T>;
 
-   pending_snapshot(const chain::block_id_type& block_id, const next_t& next, std::string pending_path, std::string final_path)
-       : block_id(block_id), next(next), pending_path(std::move(pending_path)), final_path(std::move(final_path)) {}
+   pending_snapshot(const chain::block_id_type& block_id, block_timestamp_type timestamp, const next_t& next, std::string pending_path, std::string final_path)
+       : block_id(block_id), timestamp(timestamp), next(next), pending_path(std::move(pending_path)), final_path(std::move(final_path)) {}
 
    uint32_t get_height() const {
       return chain::block_header::num_from_id(block_id);
@@ -33,36 +33,44 @@ public:
       return snapshots_dir / fc::format_string(".incomplete-snapshot-${id}.bin", fc::mutable_variant_object()("id", block_id));
    }
 
+   // call only with lib_id that is irreversible
    T finalize(const block_id_type& lib_id, const chain::controller& chain) const {
       auto lib_num = chain::block_header::num_from_id(lib_id);
-      auto block_num = chain::block_header::num_from_id(block_id);
+      auto block_num = get_height();
 
       assert(lib_num >= block_num);
 
-      // finalize called before forkdb is pruned of non-irreversible blocks, so this can find a non-irreversible block
-      auto block_ptr = chain.fetch_block_by_id(block_id);
-      auto in_chain = !!block_ptr && (lib_num > block_num || lib_id == block_id);
-      std::error_code ec;
+      bool valid = lib_id == block_id;
+      if (!valid) {
+         // Could attempt to look up the block_id, but not finding it doesn't necessarily mean it is not
+         // irreversible. Might be running without a block log or might have been loaded via a snapshot.
+         // Also, finalize called before forkdb is pruned of non-irreversible blocks, finding it doesn't necessarily
+         // mean it is irreversible.
+         if (lib_num > block_num) { // assume it is irreversible since unable to 100% determine
+            valid = true;
+         }
+      }
 
-      if(!in_chain) {
+      std::error_code ec;
+      if(!valid) {
          fs::remove(fs::path(pending_path), ec);
          ilog("Snapshot created at block id ${id} invalidated because block was forked out", ("id", block_id));
          EOS_THROW(chain::snapshot_finalization_exception,
-                   "Snapshotted block was forked out of the chain.  ID: ${block_id}",
-                   ("block_id", block_id));
+                   "Snapshotted block was forked out of the chain.  ID: ${id}", ("id", block_id));
       }
 
       fs::rename(fs::path(pending_path), fs::path(final_path), ec);
       EOS_ASSERT(!ec, chain::snapshot_finalization_exception,
                  "Unable to finalize valid snapshot of block number ${bn}: [code: ${ec}] ${message}",
-                 ("bn", get_height())("ec", ec.value())("message", ec.message()));
+                 ("bn", block_num)("ec", ec.value())("message", ec.message()));
 
-      ilog("Snapshot created at block ${bn} available at ${fn}", ("bn", block_ptr->block_num())("fn", final_path));
+      ilog("Snapshot created at block ${bn} available at ${fn}", ("bn", block_num)("fn", final_path));
 
-      return {block_id, block_ptr->block_num(), block_ptr->timestamp, chain::chain_snapshot_header::current_version, final_path};
+      return {block_id, block_num, timestamp, chain::chain_snapshot_header::current_version, final_path};
    }
 
    chain::block_id_type block_id;
+   block_timestamp_type timestamp;
    next_t next;
    std::string pending_path;
    std::string final_path;

--- a/libraries/chain/include/eosio/chain/pending_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/pending_snapshot.hpp
@@ -37,8 +37,7 @@ public:
       auto lib_num = chain::block_header::num_from_id(lib_id);
       auto block_num = chain::block_header::num_from_id(block_id);
 
-      EOS_ASSERT(lib_num >= block_num, chain::snapshot_finalization_exception,
-                 "finalize called for non-irreversible block ${bn}:${bid}", ("bn", block_num)("bid", block_id));
+      assert(lib_num >= block_num);
 
       // finalize called before forkdb is pruned of non-irreversible blocks, so this can find a non-irreversible block
       auto block_ptr = chain.fetch_block_by_id(block_id);

--- a/libraries/chain/include/eosio/chain/pending_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/pending_snapshot.hpp
@@ -42,7 +42,7 @@ public:
 
       // finalize called before forkdb is pruned of non-irreversible blocks, so this can find a non-irreversible block
       auto block_ptr = chain.fetch_block_by_id(block_id);
-      auto in_chain = static_cast<bool>(block_ptr) && (lib_num > block_num || lib_id == block_id);
+      auto in_chain = !!block_ptr && (lib_num > block_num || lib_id == block_id);
       std::error_code ec;
 
       if(!in_chain) {

--- a/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
@@ -188,7 +188,7 @@ public:
    void on_start_block(uint32_t height, chain::controller& chain);
 
    // to promote pending snapshots
-   void on_irreversible_block(const signed_block_ptr& lib, const chain::controller& chain);
+   void on_irreversible_block(const signed_block_ptr& lib, const block_id_type& block_id, const chain::controller& chain);
 
    // snapshot scheduler handlers
    snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri);

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -224,7 +224,7 @@ void snapshot_scheduler::create_snapshot(next_function<snapshot_information> nex
                     ("t", temp_path.generic_string())("p", pending_path.generic_string())
                     ("bn", head_block_num)("ec", ec.value())("message", ec.message()));
          ilog("Snapshot creation at block ${bn} complete; snapshot will be available once block becomes irreversible", ("bn", head_block_num));
-         _pending_snapshot_index.emplace(head_id, next, pending_path.generic_string(), snapshot_path.generic_string());
+         _pending_snapshot_index.emplace(head_id, head_block_time, next, pending_path.generic_string(), snapshot_path.generic_string());
          add_pending_snapshot_info(snapshot_information{head_id, head_block_num, head_block_time, chain_snapshot_header::current_version, pending_path.generic_string()});
       }
       CATCH_AND_CALL(next);

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -132,17 +132,7 @@ void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chai
    _inflight_sid = srid;
    auto next = [srid, this](const chain::next_function_variant<snapshot_information>& result) {
       if(std::holds_alternative<fc::exception_ptr>(result)) {
-         try {
-            throw *std::get<fc::exception_ptr>(result);
-         } catch(const fc::exception& e) {
-            EOS_THROW(snapshot_execution_exception,
-                     "Snapshot creation error: ${details}",
-                     ("details", e.to_detail_string()));
-         } catch(const std::exception& e) {
-            EOS_THROW(snapshot_execution_exception,
-                     "Snapshot creation error: ${details}",
-                     ("details", e.what()));
-         }
+         wlog("Snapshot creation error: ${d}", ("d", std::get<fc::exception_ptr>(result)->to_detail_string()));
       } else {
          // success, snapshot finalized
          auto snapshot_info = std::get<snapshot_information>(result);

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -45,7 +45,7 @@ void snapshot_scheduler::on_start_block(uint32_t height, chain::controller& chai
    }
 }
 
-void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, const chain::controller& chain) {
+void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, const block_id_type& block_id, const chain::controller& chain) {
    auto& snapshots_by_height = _pending_snapshot_index.get<by_height>();
    uint32_t lib_height = lib->block_num();
 
@@ -54,7 +54,7 @@ void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, cons
       auto next = pending->next;
 
       try {
-         next(pending->finalize(chain));
+         next(pending->finalize(block_id, chain));
       }
       CATCH_AND_CALL(next);
 

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -863,11 +863,11 @@ public:
       }
    }
 
-   void on_irreversible_block(const signed_block_ptr& lib) {
+   void on_irreversible_block(const signed_block_ptr& lib, const block_id_type& block_id) {
       const chain::controller& chain = chain_plug->chain();
       EOS_ASSERT(chain.is_write_window(), producer_exception, "write window is expected for on_irreversible_block signal");
       _irreversible_block_time = lib->timestamp.to_time_point();
-      _snapshot_scheduler.on_irreversible_block(lib, chain);
+      _snapshot_scheduler.on_irreversible_block(lib, block_id, chain);
       if (!_is_savanna_active) {
          _is_savanna_active = lib->is_proper_svnn_block();
       }
@@ -1588,8 +1588,8 @@ void producer_plugin_impl::plugin_startup() {
          on_accepted_block_header(block);
       }));
       _irreversible_block_connection.emplace(chain.irreversible_block().connect([this](const block_signal_params& t) {
-         const auto& [ block, _ ] = t;
-         on_irreversible_block(block);
+         const auto& [ block, block_id ] = t;
+         on_irreversible_block(block, block_id);
       }));
 
       _block_start_connection.emplace(chain.block_start().connect([this, &chain](uint32_t bs) {
@@ -1612,10 +1612,9 @@ void producer_plugin_impl::plugin_startup() {
          _vote_block_connection.emplace(chain.voted_block().connect(on_vote_signal));
       }
 
-      const auto fork_db_root_num = chain.fork_db_root().block_num();
-      const auto fork_db_root     = chain.fetch_block_by_number(fork_db_root_num);
-      if (fork_db_root) {
-         on_irreversible_block(fork_db_root);
+      const auto fork_db_root = chain.fork_db_root();
+      if (fork_db_root.block()) { // not available if starting from a snapshot
+         on_irreversible_block(fork_db_root.block(), fork_db_root.id());
 
          if (!_is_savanna_active && irreversible_mode() && chain_plug->accept_transactions()) {
             wlog("Legacy consensus active. Accepting speculative transaction execution not recommended in read-mode=irreversible");

--- a/tests/test_snapshot_information.cpp
+++ b/tests/test_snapshot_information.cpp
@@ -63,7 +63,7 @@ void test_snapshot_information() {
    write_snapshot( pending_path );
    next_t next;
    pending_snapshot pending{ block2->previous, next, pending_path.generic_string(), final_path.generic_string() };
-   test_snap_info = pending.finalize(*chain.control);
+   test_snap_info = pending.finalize(block2->previous, *chain.control);
    BOOST_REQUIRE_EQUAL(test_snap_info.head_block_num, base_block_num);
    BOOST_REQUIRE_EQUAL(test_snap_info.version, chain_snapshot_header::current_version);
 }

--- a/tests/test_snapshot_information.cpp
+++ b/tests/test_snapshot_information.cpp
@@ -62,7 +62,7 @@ void test_snapshot_information() {
 
    write_snapshot( pending_path );
    next_t next;
-   pending_snapshot pending{ block2->previous, next, pending_path.generic_string(), final_path.generic_string() };
+   pending_snapshot pending{ block2->previous, block2->timestamp, next, pending_path.generic_string(), final_path.generic_string() };
    test_snap_info = pending.finalize(block2->previous, *chain.control);
    BOOST_REQUIRE_EQUAL(test_snap_info.head_block_num, base_block_num);
    BOOST_REQUIRE_EQUAL(test_snap_info.version, chain_snapshot_header::current_version);


### PR DESCRIPTION
Snapshot was verifying that a block was irreversible by `chain.fetch_block_by_id(block_id)`. However this was checked on the `irreversible_block` signal which is signaled before forks are pruned from the fork database. Therefore, it was possible to find a non-irreversible block for a block_id that was non-irreversible but that had a block_num <= LIB.

Not sure it is worth the complexity to support lib_num < block_num, but kept the existing functionality. Looks like this really only handles the rare cases of starting from a snapshot and creating a snapshot on HEAD. Or switching from IRREVERSIBLE to HEAD mode with a snapshot scheduled on an irreversible block that becomes irreversible. Even in those cases this could still potentially fail if running without a block log.

The snapshot scheduler previously would not generate a snapshot for a forked out block. For example, if a snapshot was scheduled for block 7, but 7 was forked out, then it would not generate a snapshot on the canonical 7 block. With this PR, the scheduler will generate two snapshots for block 7 and throw the first one away.

Resolves #1355