### PR TITLE
[1.1.4] Avoid possible process block interruption on fork switch

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4048,6 +4048,7 @@ namespace eosio {
             ++c->unique_blocks_rcvd_count;
 
             // ready to process immediately, so signal producer to interrupt start_block
+            // call before process_blocks to avoid interrupting process_blocks
             my_impl->producer_plug->received_block(block_num, fork_db_add_result);
 
             fc_dlog(logger, "post process_incoming_block to app thread, block ${n}", ("n", ptr->block_num()));

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4046,11 +4046,12 @@ namespace eosio {
 
          if (fork_db_add_result == fork_db_add_t::appended_to_head || fork_db_add_result == fork_db_add_t::fork_switch) {
             ++c->unique_blocks_rcvd_count;
-            fc_dlog(logger, "post process_incoming_block to app thread, block ${n}", ("n", ptr->block_num()));
-            my_impl->producer_plug->process_blocks();
 
             // ready to process immediately, so signal producer to interrupt start_block
             my_impl->producer_plug->received_block(block_num, fork_db_add_result);
+
+            fc_dlog(logger, "post process_incoming_block to app thread, block ${n}", ("n", ptr->block_num()));
+            my_impl->producer_plug->process_blocks();
          }
       });
    }


### PR DESCRIPTION
Call `process_blocks` after `received_blocks` to prevent `received_blocks` from interrupting `process_blocks` on fork switch.

Resolves #1343 