### PR TITLE
[1.1.4 -> main] Correctly identify snapshot as forked out

### DIFF
--- a/libraries/chain/include/eosio/chain/pending_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/pending_snapshot.hpp
@@ -14,8 +14,8 @@ class pending_snapshot {
 public:
    using next_t = eosio::chain::next_function<T>;
 
-   pending_snapshot(const chain::block_id_type& block_id, const next_t& next, std::string pending_path, std::string final_path)
-       : block_id(block_id), next(next), pending_path(std::move(pending_path)), final_path(std::move(final_path)) {}
+   pending_snapshot(const chain::block_id_type& block_id, block_timestamp_type timestamp, const next_t& next, std::string pending_path, std::string final_path)
+       : block_id(block_id), timestamp(timestamp), next(next), pending_path(std::move(pending_path)), final_path(std::move(final_path)) {}
 
    uint32_t get_height() const {
       return chain::block_header::num_from_id(block_id);
@@ -33,30 +33,44 @@ public:
       return snapshots_dir / fc::format_string(".incomplete-snapshot-${id}.bin", fc::mutable_variant_object()("id", block_id));
    }
 
-   T finalize(const chain::controller& chain) const {
-      auto block_ptr = chain.fetch_block_by_id(block_id);
-      auto in_chain = (bool) block_ptr;
-      std::error_code ec;
+   // call only with lib_id that is irreversible
+   T finalize(const block_id_type& lib_id, const chain::controller& chain) const {
+      auto lib_num = chain::block_header::num_from_id(lib_id);
+      auto block_num = get_height();
 
-      if(!in_chain) {
+      assert(lib_num >= block_num);
+
+      bool valid = lib_id == block_id;
+      if (!valid) {
+         // Could attempt to look up the block_id, but not finding it doesn't necessarily mean it is not
+         // irreversible. Might be running without a block log or might have been loaded via a snapshot.
+         // Also, finalize called before forkdb is pruned of non-irreversible blocks, finding it doesn't necessarily
+         // mean it is irreversible.
+         if (lib_num > block_num) { // assume it is irreversible since unable to 100% determine
+            valid = true;
+         }
+      }
+
+      std::error_code ec;
+      if(!valid) {
          fs::remove(fs::path(pending_path), ec);
          ilog("Snapshot created at block id ${id} invalidated because block was forked out", ("id", block_id));
          EOS_THROW(chain::snapshot_finalization_exception,
-                   "Snapshotted block was forked out of the chain.  ID: ${block_id}",
-                   ("block_id", block_id));
+                   "Snapshotted block was forked out of the chain.  ID: ${id}", ("id", block_id));
       }
 
       fs::rename(fs::path(pending_path), fs::path(final_path), ec);
       EOS_ASSERT(!ec, chain::snapshot_finalization_exception,
                  "Unable to finalize valid snapshot of block number ${bn}: [code: ${ec}] ${message}",
-                 ("bn", get_height())("ec", ec.value())("message", ec.message()));
+                 ("bn", block_num)("ec", ec.value())("message", ec.message()));
 
-      ilog("Snapshot created at block ${bn} available at ${fn}", ("bn", block_ptr->block_num())("fn", final_path));
+      ilog("Snapshot created at block ${bn} available at ${fn}", ("bn", block_num)("fn", final_path));
 
-      return {block_id, block_ptr->block_num(), block_ptr->timestamp, chain::chain_snapshot_header::current_version, final_path};
+      return {block_id, block_num, timestamp, chain::chain_snapshot_header::current_version, final_path};
    }
 
    chain::block_id_type block_id;
+   block_timestamp_type timestamp;
    next_t next;
    std::string pending_path;
    std::string final_path;

--- a/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
@@ -188,7 +188,7 @@ public:
    void on_start_block(uint32_t height, chain::controller& chain);
 
    // to promote pending snapshots
-   void on_irreversible_block(const signed_block_ptr& lib, const chain::controller& chain);
+   void on_irreversible_block(const signed_block_ptr& lib, const block_id_type& block_id, const chain::controller& chain);
 
    // snapshot scheduler handlers
    snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri);

--- a/tests/test_snapshot_information.cpp
+++ b/tests/test_snapshot_information.cpp
@@ -62,8 +62,8 @@ void test_snapshot_information() {
 
    write_snapshot( pending_path );
    next_t next;
-   pending_snapshot pending{ block2->previous, next, pending_path.generic_string(), final_path.generic_string() };
-   test_snap_info = pending.finalize(*chain.control);
+   pending_snapshot pending{ block2->previous, block2->timestamp, next, pending_path.generic_string(), final_path.generic_string() };
+   test_snap_info = pending.finalize(block2->previous, *chain.control);
    BOOST_REQUIRE_EQUAL(test_snap_info.head_block_num, base_block_num);
    BOOST_REQUIRE_EQUAL(test_snap_info.version, chain_snapshot_header::current_version);
 }


### PR DESCRIPTION
Snapshot was verifying that a block was irreversible by `chain.fetch_block_by_id(block_id)`. However this was checked on the `irreversible_block` signal which is signaled before forks are pruned from the fork database. Therefore, it was possible to find a non-irreversible block for a block_id that was non-irreversible but that had a block_num <= LIB.

Not sure it is worth the complexity to support lib_num < block_num, but kept the existing functionality. Looks like this really only handles the rare cases of starting from a snapshot and creating a snapshot on HEAD. Or switching from IRREVERSIBLE to HEAD mode with a snapshot scheduled on an irreversible block that becomes irreversible. Even in those cases this could still potentially fail if running without a block log.

The snapshot scheduler previously would not generate a snapshot for a forked out block. For example, if a snapshot was scheduled for block 7, but 7 was forked out, then it would not generate a snapshot on the canonical 7 block. With this PR, the scheduler will generate two snapshots for block 7 and throw the first one away.

Merges `release/1.1` into `main` including #1361 

Resolves #1355