### PR TITLE
Add option specifying what to print in `print_log`.

### DIFF
--- a/programs/spring-util/actions/blocklog.hpp
+++ b/programs/spring-util/actions/blocklog.hpp
@@ -4,13 +4,16 @@
 
 using namespace eosio::chain;
 
+enum class print_from_t { both, block_log, fork_db };
+
 struct blocklog_options {
-   std::string blocks_dir = "blocks";
-   std::string output_file = "";
-   uint32_t first_block = 0;
-   uint32_t last_block = std::numeric_limits<uint32_t>::max();
-   std::string output_dir = "";
-   uint32_t stride = 100000;
+   std::string  blocks_dir  = "blocks";
+   std::string  output_file = "";
+   uint32_t     first_block = 0;
+   uint32_t     last_block  = std::numeric_limits<uint32_t>::max();
+   std::string  output_dir  = "";
+   uint32_t     stride      = 100000;
+   print_from_t print_from  = print_from_t::both;
 
    // flags
    bool no_pretty_print = false;


### PR DESCRIPTION
Resolves #1320.

Add an option to `spring-util block-log print-log` allowing to specify whether we want to print blocks from the `block_log`, the `fork_db`, or `both` (default remains `both` so the default behavior is not changing).

example of output (during replay, so fork db was empty):

```
~/github/enf/spring/build_clang18_debug gh_1320:main *2 !2 ?1 ❯ ./bin/spring-util block-log print-log --as-json-array --print-from=fork_db --blocks-dir /media/greg/Samsung_T5/eos/cfg0/main/blocks
info  2025-04-15T19:32:36.283 spring-ut block_log.cpp:742             open                 ] Log has 6024 blocks
info  2025-04-15T19:32:36.283 spring-ut blocklog.cpp:274              read_log             ] existing block log contains block num 328123855 through block num 328129878
info  2025-04-15T19:32:36.283 spring-ut blocklog.cpp:38               report               ] spring-util - reading log took 0 msec
[]%                                                                                                                                                                                                                          ~/github/enf/spring/build_clang18_debug gh_1320:main *2 !2 ?1 ❯ ./bin/spring-util block-log print-log --as-json-array --print-from=block_log --blocks-dir /media/greg/Samsung_T5/eos/cfg0/main/blocks > xx
info  2025-04-15T19:32:53.991 spring-ut block_log.cpp:742             open                 ] Log has 10620 blocks
info  2025-04-15T19:32:53.992 spring-ut blocklog.cpp:274              read_log             ] existing block log contains block num 328123855 through block num 328134474
info  2025-04-15T19:33:03.742 spring-ut blocklog.cpp:38               report               ] spring-util - reading log took 9750 msec
~/github/enf/spring/build_clang18_debug gh_1320:main *2 !2 ?1 ❯ head -10 xx                                                                                                                                              10s
[{
  "block_num": 328123855,
  "id": "138ec5cfd59f834e70bb66d6ddc0b6a628744de44265c65d0a2219a578bfd4e3",
  "ref_block_prefix": 3597056880,
  "timestamp": "2023-08-28T19:15:06.000",
  "producer": "eosflytomars",
  "confirmed": 240,
  "previous": "138ec5ceec14bcba2ae5703931142dfae68b6e6738479af1f300013e37684654",
  "transaction_mroot": "d31937f05755977ee590771054efc8d109edb8b509c0c870245ba6469bdafcae",
  "action_mroot": "010a8e0343c5c8b27d48c2a9691612ea7a70dc330be4d60ad58c5becebabb38d",
```
