### PR TITLE
[1.1.4 -> main] Test: Disable pause production in test

### DIFF
--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -43,6 +43,8 @@ try:
     maxRAMFlag="--chain-state-db-size-mb"
     maxRAMValue=1010
     extraNodeosArgs=" %s %d %s %d  --http-max-response-time-ms 990000 " % (minRAMFlag, minRAMValue, maxRAMFlag, maxRAMValue)
+    # test relies on production continuing on restart
+    extraNodeosArgs+=" --production-pause-vote-timeout-ms 0 "
     if cluster.launch(onlyBios=False, pnodes=pNodes, totalNodes=totalNodes, totalProducers=totalNodes, activateIF=activateIF, extraNodeosArgs=extraNodeosArgs) is False:
         Utils.cmdError("launcher")
         errorExit("Failed to stand up eos cluster.")


### PR DESCRIPTION
Disable pause production since the test relies on production continuing after restart and the pause can kick in if the nodes take too long to stop/start.

Merges `release/1.1` into `main` including #1369 

Resolves #1344 