### PR TITLE
Log if not producing because of stale production

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2059,8 +2059,10 @@ producer_plugin_impl::determine_pending_block_mode(const fc::time_point& now,
    // If the next block production opportunity is in the present or future, we're synced.
    if (!_production_enabled) {
       _pending_block_mode = pending_block_mode::speculating;
-      if (_producers.find(scheduled_producer.producer_name) != _producers.end())
+      if (_producers.find(scheduled_producer.producer_name) != _producers.end()) {
          fc_elog(_log, "Not producing block because stale production not enabled, block ${t}", ("t", block_time));
+         not_producing_when_time = true;
+      }
    } else if (_producers.find(scheduled_producer.producer_name) == _producers.end()) {
       _pending_block_mode = pending_block_mode::speculating;
    } else if (num_relevant_signatures == 0) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2059,6 +2059,8 @@ producer_plugin_impl::determine_pending_block_mode(const fc::time_point& now,
    // If the next block production opportunity is in the present or future, we're synced.
    if (!_production_enabled) {
       _pending_block_mode = pending_block_mode::speculating;
+      if (_producers.find(scheduled_producer.producer_name) != _producers.end())
+         fc_elog(_log, "Not producing block because stale production not enabled, block ${t}", ("t", block_time));
    } else if (_producers.find(scheduled_producer.producer_name) == _producers.end()) {
       _pending_block_mode = pending_block_mode::speculating;
    } else if (num_relevant_signatures == 0) {


### PR DESCRIPTION
Add a log of `Not producing block because stale production not enabled` which was the only cases that didn't already log when a node would produce but doesn't for some reason. Noticed this on a recent test failure when looking at the logs.

Also sets the flag that prevents the `producer_plugin` from going into an infinite wait for a block. Since you are a configured producer you should keep trying to produce.