### PR TITLE
allow any executor for `post_async_task()`

### DIFF
--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -319,10 +319,14 @@ namespace eosio { namespace chain {
       boost::asio::io_context ctx;
    };
 
-   // async on io_context and return future
-   template<typename F>
-   auto post_async_task( boost::asio::io_context& ioc, F&& f ) {
-      return boost::asio::post( ioc, boost::asio::use_future(std::forward<F>(f)) );
+   template<typename T>
+   concept SupportsASIOPost = boost::asio::execution::is_executor<std::decay_t<T>>::value ||
+                              std::is_same_v<std::decay_t<T>, boost::asio::io_context>;
+
+   // async on executor and return future
+   template<SupportsASIOPost E, typename F>
+   auto post_async_task( E&& ioc, F&& f ) {
+      return boost::asio::post( std::forward<E>(ioc), boost::asio::use_future(std::forward<F>(f)) );
    }
 
 } } // eosio::chain


### PR DESCRIPTION
Needed for some future experiment; seems non-contentious and generic enough to PR ahead of time regardless of future experiment's uncertainty.

Allows using any executor for `post_async_task()`. Well, `io_context` is _not_ an executor, so really allows any executor or `io_context`. The alternative -- strictly accept executors -- would require adding calls to `ctx.get_executor()` any place that makes use of `post_async_task()` and passed an `io_context`. Oftentimes this is `post_async_task(thread_pool.get_executor())` but `get_executor()` on named_thread_pool is a misnomer since it returns an `io_context`.