### PR TITLE
remove C++20 ifdefs in merkle.hpp

### DIFF
--- a/libraries/chain/include/eosio/chain/incremental_merkle.hpp
+++ b/libraries/chain/include/eosio/chain/incremental_merkle.hpp
@@ -31,9 +31,9 @@ namespace eosio::chain {
 class incremental_merkle_tree {
 public:
    void append(const digest_type& digest) {
-      assert(trees.size() == static_cast<size_t>(detail::popcount(mask)));
+      assert(trees.size() == static_cast<size_t>(std::popcount(mask)));
       _append(digest, trees.end(), 0);
-      assert(trees.size() == static_cast<size_t>(detail::popcount(mask)));
+      assert(trees.size() == static_cast<size_t>(std::popcount(mask)));
    }
 
    digest_type get_root() const {


### PR DESCRIPTION
Cleanup in file I was touching anyways for future experiment; seems non-contentious enough to take regardless of future experiment's uncertainty.