### PR TITLE
[half-baked] use chain thread pool for merkles to avoid creation and destruction of threads every block

### DIFF
--- a/libraries/chain/include/eosio/chain/merkle.hpp
+++ b/libraries/chain/include/eosio/chain/merkle.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <eosio/chain/thread_utils.hpp>
 #include <eosio/chain/types.hpp>
 #include <fc/io/raw.hpp>
 #include <bit>
@@ -13,9 +14,9 @@ inline digest_type hash_combine(const digest_type& a, const digest_type& b) {
    return digest_type::hash(std::make_pair(std::cref(a), std::cref(b)));
 }
 
-template <class It, bool async = false>
+template <class It, bool async = false, SupportsASIOPost Executor>
 requires std::is_same_v<std::decay_t<typename std::iterator_traits<It>::value_type>, digest_type>
-inline digest_type calculate_merkle_pow2(const It& start, const It& end) {
+inline digest_type calculate_merkle_pow2(const It& start, const It& end, Executor& executor) {
    assert(end >= start + 2);
    auto size = static_cast<size_t>(end - start);
    assert(std::bit_floor(size) == size);
@@ -24,19 +25,20 @@ inline digest_type calculate_merkle_pow2(const It& start, const It& end) {
       return hash_combine(start[0], start[1]);
    else {
       if (async && size >= 256) {
-         auto async_calculate_merkle_pow2 = [&start, &size](auto fut) {
+         auto async_calculate_merkle_pow2 = [&start, &size, &executor](auto fut) {
             size_t slice_size = size / fut.size();
 
             for (size_t i=0; i<fut.size(); ++i)
-               fut[i] = std::async(std::launch::async, calculate_merkle_pow2<It>,
-                                   start + slice_size * i, start + slice_size * (i+1));
+               fut[i] = post_async_task(executor, [s=start + slice_size * i, e=start + slice_size * (i+1), &executor]() {
+                  return calculate_merkle_pow2<It>(s, e, executor);
+               });
 
             std::array<digest_type, fut.size()> res;
 
             for (size_t i=0; i<fut.size(); ++i)
                res[i] = fut[i].get();
 
-            return calculate_merkle_pow2(res.begin(), res.end());
+            return calculate_merkle_pow2(res.begin(), res.end(), executor);
          };
 
          if (size >= 2048) {
@@ -47,7 +49,7 @@ inline digest_type calculate_merkle_pow2(const It& start, const It& end) {
          return async_calculate_merkle_pow2(std::array<std::future<digest_type>, 2>());
       } else {
          auto mid = start + size / 2;
-         return hash_combine(calculate_merkle_pow2(start, mid), calculate_merkle_pow2(mid, end));
+         return hash_combine(calculate_merkle_pow2(start, mid, executor), calculate_merkle_pow2(mid, end, executor));
       }
    }
 }
@@ -67,10 +69,10 @@ inline digest_type calculate_merkle_pow2(const It& start, const It& end) {
 // log2 recursion OK, uses less than 5KB stack space for 4 billion digests
 // appended (or 0.25% of default 2MB thread stack size on Ubuntu).
 // ------------------------------------------------------------------------
-template <class It>
+template <class It, SupportsASIOPost Executor = boost::asio::system_executor>
 requires std::random_access_iterator<It> &&
          std::is_same_v<std::decay_t<typename std::iterator_traits<It>::value_type>, digest_type>
-inline digest_type calculate_merkle(const It& start, const It& end) {
+inline digest_type calculate_merkle(const It& start, const It& end, Executor&& executor = boost::asio::system_executor()) {
    assert(end >= start);
    auto size = static_cast<size_t>(end - start);
    if (size <= 1)
@@ -78,10 +80,10 @@ inline digest_type calculate_merkle(const It& start, const It& end) {
 
    auto midpoint = std::bit_floor(size);
    if (size == midpoint)
-      return detail::calculate_merkle_pow2<It, true>(start, end);
+      return detail::calculate_merkle_pow2<It, true>(start, end, executor);
 
    auto mid = start + midpoint;
-   return detail::hash_combine(detail::calculate_merkle_pow2<It, true>(start, mid),
+   return detail::hash_combine(detail::calculate_merkle_pow2<It, true>(start, mid, executor),
                                calculate_merkle(mid, end));
 }
 
@@ -91,11 +93,11 @@ inline digest_type calculate_merkle(const It& start, const It& end) {
 // takes a container or `std::span` of `digest_type`, returns the root digest
 // for the sequence of digests in the container.
 // --------------------------------------------------------------------------
-template <class Cont>
+template <class Cont, SupportsASIOPost Executor = boost::asio::system_executor>
 requires std::random_access_iterator<decltype(Cont().begin())> &&
          std::is_same_v<std::decay_t<typename Cont::value_type>, digest_type>
-inline digest_type calculate_merkle(const Cont& ids) {
-   return calculate_merkle(ids.begin(), ids.end()); // cbegin not supported for std::span until C++23.
+inline digest_type calculate_merkle(const Cont& ids, Executor&& executor = boost::asio::system_executor()) {
+   return calculate_merkle(ids.begin(), ids.end(), executor); // cbegin not supported for std::span until C++23.
 }
 
 


### PR DESCRIPTION
Some experimentation on #1124 to use chain's thread pool instead of `std::async` which creates and destroys threads. The performance improvement from using a thread pool in a small isolated test does appear significant, though even if it was minor I'd still be interested because the creation and destruction of threads like this may have other tricky side effects in a large application. Plus it impairs externally setting thread affinity (e.g. forcing the main thread to stay on fastest core for fastest contract execution).

Approximately[^1] what I see is a 50-60% performance improvement.

[^1]: Unfortunately the box I use for super accurate performance testing -- where all cores are fixed to same speed and low power mode is distabled -- is tied up in other things at the moment. So I get some variance in this test based on what cores happen to get the threads etc

<details>
<summary>Performance Test Code</summary>

```cpp
BOOST_DATA_TEST_CASE(merkle_perf_test, boost::unit_test::data::make({8u, 42u, 660u, 2222u})){
   const std::vector<digest_type> digests = create_test_digests(sample);
   incremental_merkle_tree tree;
   for (size_t j=0; j<digests.size(); ++j)
      tree.append(digests[j]);

#ifdef NEWCODE
   eosio::chain::named_thread_pool<struct merkleit> thread_pool;
   thread_pool.start(4, [](const fc::exception&){}, [](size_t){});
#endif

   unsigned long long t0 = __builtin_readcyclecounter();
   for(unsigned i=0; i < 50000; ++i) {
      BOOST_CHECK_EQUAL(calculate_merkle(std::span(digests.begin(), digests.end())
#ifdef NEWCODE
         ,thread_pool.get_executor()
#endif
      ), tree.get_root());
   }
   unsigned long long t1 = __builtin_readcyclecounter();
   printf("%4u>>%llu\n", sample, t1-t0);
}
```
</details>

Problems (besides some aspects that feel a little ugly to me):

* chain thread pool has default of 2 threads while merkle stuff needs/wants 4. If we are content with launching 4 threads for merkle stuff seems no problem just changing chain thread default to 4. But more concerning,
* The chain thread pool works on other tasks. So it's possible in the larger application the merkle code will see increased latency in completion since it will be competing with those other tasks. asio `post()` doesn't guarantee ordering so it's possible in theory for merkle work to be starved for some pathological work load.
The solution here could be we just maintain a separate merkle thread pool. Again -- if we were content with launching 4 threads currently it seems no problem to just keep 4 threads hanging around all the time.
* I wasn't entirely sure how to plumb through the thread pool in to `finality_root` & `block_header_state` just yet. At the moment, `calculate_merkle()` will default to using the `system_executor` when not given an executor to use. This will use a process wide asio managed thread pool.which is not desirable (at least, it doesn't fit our current threading pattern). Though, funny enough, the performance is good strictly with using `system_executor` since that thread pool is persistent unlike the `aync()`s

I didn't run tests. I might have broke something.