### PR TITLE
Update logging.json GELF example 

### DIFF
--- a/libraries/libfc/src/log/gelf_appender.cpp
+++ b/libraries/libfc/src/log/gelf_appender.cpp
@@ -147,6 +147,10 @@ namespace fc
       });
 
     }
+    catch (std::exception& ex)
+    {
+      std::cerr << "error opening GELF socket to endpoint " << my->cfg.endpoint << ", " << ex.what() << "\n";
+    }
     catch (...)
     {
       std::cerr << "error opening GELF socket to endpoint " << my->cfg.endpoint << "\n";

--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -43,7 +43,7 @@
       "name": "net",
       "type": "gelf",
       "args": {
-        "endpoint": "10.10.10.10:12201",
+        "endpoint": "my_server.example.com:12201",
         "host": "host_name",
         "_network": "jungle"
       },


### PR DESCRIPTION
Change the example `logging.json` to have a GELF endpoint that doesn't resolve so that a GELF thread is not created and does not continuously try to send log messages.

Also improve the error message when unable to connect to configured GELF endpoint.