### PR TITLE
Optimize fork database open/read

### DIFF
--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -132,9 +132,11 @@ namespace eosio::chain {
    template<class BSP>
    void fork_database_impl<BSP>::open_impl( const char* desc, const std::filesystem::path& fork_db_file, fc::cfile_datastream& ds, validator_t& validator ) {
       bsp_t _root = std::make_shared<bs_t>();
-      fc::raw::unpack( ds, pending_savanna_lib_id );
+      block_id_type savanna_lib_id;
+      fc::raw::unpack( ds, savanna_lib_id );
       fc::raw::unpack( ds, *_root );
-      reset_root_impl( _root );
+      reset_root_impl( _root ); // resets pending_savanna_lib_id
+      set_pending_savanna_lib_id_impl( savanna_lib_id );
 
       unsigned_int size; fc::raw::unpack( ds, size );
       for( uint32_t i = 0, n = size.value; i < n; ++i ) {

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -253,8 +253,7 @@ namespace eosio::chain {
          if (qc_claim.is_strong_qc) {
             // it is not possible to claim a future block, skip if pending is already a higher height
             block_num_type current_lib = block_header::num_from_id(pending_savanna_lib_id);
-            block_num_type block_num = n->block_num();
-            if (block_num > current_lib) {
+            if (qc_claim.block_num > current_lib) {
                // claim has already been verified, update LIB even if unable to verify block
                // We evaluate a block extension qc and advance lib if strong.
                // This is done before evaluating the block. It is possible the block


### PR DESCRIPTION
Optimize opening/reading of the fork database by correctly setting the `pending_savanna_lib_id`. Also don't bother looking up qc claimed block if it can't result in a higher pending savanna LIB.