### PR TITLE
SC: Fix read_only flag in call traces and make code cleaner in read only processing

### DIFF
--- a/libraries/chain/host_context.cpp
+++ b/libraries/chain/host_context.cpp
@@ -44,11 +44,6 @@ int64_t host_context::execute_sync_call(name call_receiver, uint64_t flags, std:
    // If current call is read only, or read_only flag from the user is read only,
    // next call must be read only
    bool is_next_call_read_only = is_read_only() || has_field(flags, sync_call_flags::force_read_only);
-   // Update next call's flags based on is_next_call_read_only
-   uint64_t updated_flags = flags;  // get the default values
-   if (is_next_call_read_only) {
-      updated_flags = set_field(flags, sync_call_flags::force_read_only);
-   }
 
    // As early as possible, create the call trace of this new sync call in the parent's
    // (sender's) trace to record entire trace of the sync call, including any exceptions
@@ -108,7 +103,7 @@ int64_t host_context::execute_sync_call(name call_receiver, uint64_t flags, std:
 
          try {
             // use a new sync_call_context for next sync call
-            sync_call_context call_ctx(control, trx_context, ordinal, get_current_action_trace(), get_sync_call_sender(), call_receiver, receiver_account->is_privileged(), depth, updated_flags, data);
+            sync_call_context call_ctx(control, trx_context, ordinal, get_current_action_trace(), get_sync_call_sender(), call_receiver, receiver_account->is_privileged(), depth, is_next_call_read_only, data);
 
             // execute the sync call
             auto rc = control.get_wasm_interface().do_sync_call(receiver_account->code_hash, receiver_account->vm_type, receiver_account->vm_version, call_ctx);

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -36,7 +36,6 @@ public:
    const uint32_t               ordinal = 1;
    action_trace&                current_action_trace;
    const account_name           sender{};
-   const uint64_t               flags = 0;
    // `read_only` represents what the read only status of the call context.
    // It tells the executing smart contract code whether or not it is in
    // read-only mode and therefore whether or not the system will enforce that it

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -22,7 +22,7 @@ enum class sync_call_flags : uint64_t {
 class sync_call_context : public host_context {
 public:
 
-   sync_call_context(controller& con, transaction_context& trx_ctx, uint32_t ordinal, action_trace& current_action_trace, account_name sender, account_name receiver, bool privileged, uint32_t sync_call_depth, uint64_t flags, std::span<const char> data);
+   sync_call_context(controller& con, transaction_context& trx_ctx, uint32_t ordinal, action_trace& current_action_trace, account_name sender, account_name receiver, bool privileged, uint32_t sync_call_depth, bool read_only, std::span<const char> data);
 
    uint32_t get_call_data(std::span<char> memory) const override;
    void set_call_return_value(std::span<const char> return_value) override;

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -8,14 +8,18 @@ namespace eosio { namespace chain {
 // When a new flag is added, its enum value must be 1 bit left shift from the last flag.
 // Update all_allowed_bits to include the newly added enum value.
 enum class sync_call_flags : uint64_t {
-   read_only        = 1ull<<0,
-   all_allowed_bits = read_only
+   // `force_read_only` is a user's directive to the system, telling the system whether
+   // the new call context created must operate in read-only mode or if it is
+   // free to operate under its most permissible mode.
+   force_read_only  = 1ull<<0,
+
+   all_allowed_bits = force_read_only
 };
 
 class sync_call_context : public host_context {
 public:
 
-   sync_call_context(controller& con, transaction_context& trx_ctx, uint32_t ordinal, action_trace& current_action_trace, account_name sender, account_name receiver, bool privileged, uint32_t sync_call_depth, uint64_t flags, bool is_caller_read_only, std::span<const char> data);
+   sync_call_context(controller& con, transaction_context& trx_ctx, uint32_t ordinal, action_trace& current_action_trace, account_name sender, account_name receiver, bool privileged, uint32_t sync_call_depth, uint64_t flags, std::span<const char> data);
 
    uint32_t get_call_data(std::span<char> memory) const override;
    void set_call_return_value(std::span<const char> return_value) override;
@@ -24,21 +28,25 @@ public:
 
    bool is_sync_call() const override { return true; }
 
-   bool is_read_only()const override;
+   bool is_read_only() const override { return read_only; };
    action_name get_sender() const override;
    void console_append(std::string_view val) override;
    void store_console_marker() override;
 
-   uint32_t               ordinal = 1;
-   action_trace&          current_action_trace;
-   account_name           sender{};
-   uint64_t               flags = 0;
-   const bool             is_caller_read_only = false;
-   std::span<const char>  data{}; // includes function name, arguments, and other information
-   std::vector<char>      return_value{};
+   const uint32_t               ordinal = 1;
+   action_trace&                current_action_trace;
+   const account_name           sender{};
+   const uint64_t               flags = 0;
+   // `read_only` represents what the read only status of the call context.
+   // It tells the executing smart contract code whether or not it is in
+   // read-only mode and therefore whether or not the system will enforce that it
+   // is only allowed to do read-only activities
+   const bool                   read_only = false;
+   const std::span<const char>  data{}; // includes function name, arguments, and other information
+   std::vector<char>            return_value{};
 
-   bool has_recipient(account_name account)const override;
-   void update_db_usage( const account_name& payer, int64_t delta ) override;
+   bool has_recipient(account_name account) const override;
+   void update_db_usage(const account_name& payer, int64_t delta) override;
    bool is_context_free()const override;
 };
 

--- a/libraries/chain/include/eosio/chain/sync_call_context.hpp
+++ b/libraries/chain/include/eosio/chain/sync_call_context.hpp
@@ -11,6 +11,9 @@ enum class sync_call_flags : uint64_t {
    // `force_read_only` is a user's directive to the system, telling the system whether
    // the new call context created must operate in read-only mode or if it is
    // free to operate under its most permissible mode.
+   // When the flag is not set, the new call context inherits the
+   // `readonlyness` from the calling context; that is, if the calling context
+   // is read only, the system will enforce read only in the new call context.
    force_read_only  = 1ull<<0,
 
    all_allowed_bits = force_read_only

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -14,14 +14,13 @@ sync_call_context::sync_call_context(controller&           con,
                                      bool                  privileged,
                                      uint32_t              sync_call_depth,
                                      uint64_t              flags,
-                                     bool                  is_caller_read_only,
                                      std::span<const char> data)
    : host_context(con, trx_ctx, receiver, privileged, sync_call_depth)
    , ordinal(ordinal)
    , current_action_trace(current_action_trace)
    , sender(sender)
    , flags(flags)
-   , is_caller_read_only(is_caller_read_only)
+   , read_only(has_field(flags, sync_call_flags::force_read_only))
    , data(data)
 {
 }
@@ -47,11 +46,6 @@ void sync_call_context::set_call_return_value(std::span<const char> rv) {
               "sync call return value size must be less or equal to ${s} bytes", ("s", max_sync_call_data_size));
 
    return_value.assign(rv.data(), rv.data() + rv.size());
-}
-
-bool sync_call_context::is_read_only()const {
-   // If caller is read-only, callee must be read only too
-   return (is_caller_read_only || has_field(flags, sync_call_flags::read_only));
 }
 
 // Returns the sender of any sync call initiated by this apply_context or sync_call_ctx

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -19,7 +19,6 @@ sync_call_context::sync_call_context(controller&           con,
    , ordinal(ordinal)
    , current_action_trace(current_action_trace)
    , sender(sender)
-   , flags(flags)
    , read_only(has_field(flags, sync_call_flags::force_read_only))
    , data(data)
 {

--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -13,13 +13,13 @@ sync_call_context::sync_call_context(controller&           con,
                                      account_name          receiver,
                                      bool                  privileged,
                                      uint32_t              sync_call_depth,
-                                     uint64_t              flags,
+                                     bool                  read_only,
                                      std::span<const char> data)
    : host_context(con, trx_ctx, receiver, privileged, sync_call_depth)
    , ordinal(ordinal)
    , current_action_trace(current_action_trace)
    , sender(sender)
-   , read_only(has_field(flags, sync_call_flags::force_read_only))
+   , read_only(read_only)
    , data(data)
 {
 }


### PR DESCRIPTION
* Fix read_only flag in call traces such that `read_only` flag is `true` for all subsequent call traces after the first call whose `read_only` flag is `true`
* Rename `read_only` enum to `force_read_only` and introduce `read_only` to call_context to make code cleaner
* Add more comments explaining read_only request by the user and read_only state of the call_context
* Add tests to verify `read_only` flag values are correct in call traces

Resolves https://github.com/AntelopeIO/spring/issues/1408