### PR TITLE
[2.0.0-dev] avoid copying action when computing action digest

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -135,8 +135,8 @@ void apply_context::exec_one()
 
       if( control.is_builtin_activated( builtin_protocol_feature_t::action_return_value ) ) {
          act_digest =   generate_action_digest(
-                           [this](const char* data, uint32_t datalen) {
-                              return trx_context.hash_with_checktime<digest_type>(data, datalen);
+                           [this]() {
+                              return trx_context.checktime();
                            },
                            *act,
                            action_return_value

--- a/libraries/libfc/include/fc/crypto/digest.hpp
+++ b/libraries/libfc/include/fc/crypto/digest.hpp
@@ -12,4 +12,35 @@ namespace fc {
       fc::raw::pack( enc, value );
       return enc.result();
    }
+
+   template <typename DigestType, typename F>
+   class hash_encoder_with_checktime : public DigestType::encoder {
+      public:
+         hash_encoder_with_checktime(size_t checktime_block_size, F&& checktime) : DigestType::encoder(),
+                                                                                   checktime_block_size(checktime_block_size),
+                                                                                   checktime(std::forward<F>(checktime)) {}
+
+         void write(const char* d, uint32_t dlen) {
+            while (dlen > checktime_block_size) {
+               DigestType::encoder::write(d, checktime_block_size);
+               d    += checktime_block_size;
+               dlen -= checktime_block_size;
+               checktime();
+            }
+            DigestType::encoder::write(d, dlen);
+            encoded_since_checktime += dlen;
+            if(encoded_since_checktime > checktime_block_size) {
+               checktime();
+               encoded_since_checktime = 0;
+            }
+         }
+
+      private:
+         size_t encoded_since_checktime = 0;
+         const size_t checktime_block_size = 0;
+         F checktime;
+      };
+
+   template<typename F>
+   using sha256_encoder_with_checktime = hash_encoder_with_checktime<sha256, F>;
 }


### PR DESCRIPTION
I was doing some research in this area and noticed that `generate_action_digest()` effectively copies an action's input and output (return) data. We can avoid the copy if we have a hash `encoder` that implements checktime. But, see comment about uncertainty of needing checktime here.