### PR TITLE
[1.1.4] Test fix: Pause production before shutdown

### DIFF
--- a/tests/ship_restart_test.py
+++ b/tests/ship_restart_test.py
@@ -4,7 +4,6 @@ import os
 import tempfile
 import shutil
 import signal
-import time
 
 from TestHarness import Cluster, TestHelper, Utils, WalletMgr
 

--- a/tests/ship_restart_test.py
+++ b/tests/ship_restart_test.py
@@ -60,6 +60,7 @@ try:
     Print("Stand up cluster")
 
     specificExtraNodeosArgs={}
+    specificExtraNodeosArgs[prodNodeId]="--plugin eosio::producer_api_plugin"
     specificExtraNodeosArgs[shipNodeId]="--plugin eosio::state_history_plugin --trace-history --chain-state-history --finality-data-history --state-history-stride 200 --plugin eosio::net_api_plugin --plugin eosio::producer_api_plugin"
 
     if cluster.launch(topo="mesh", pnodes=totalProducerNodes, totalNodes=totalNodes,
@@ -79,9 +80,9 @@ try:
     shipNode = cluster.getNode(shipNodeId)
 
     Print("Shutdown producer and SHiP nodes")
+    prodNode.processUrllibRequest("producer", "pause", exitOnError=True)
+    time.sleep(0.5) # give time for any blocks to propagate
     prodNode.kill(signal.SIGTERM)
-    # prodNode might have produced but not gotten to shipNode yet, wait to allow block to arrive
-    time.sleep(0.5)
     shipNode.kill(signal.SIGTERM)
 
     shipDir               = os.path.join(Utils.getNodeDataDir(shipNodeId), "state-history")

--- a/tests/ship_restart_test.py
+++ b/tests/ship_restart_test.py
@@ -81,7 +81,8 @@ try:
 
     Print("Shutdown producer and SHiP nodes")
     prodNode.processUrllibRequest("producer", "pause", exitOnError=True)
-    time.sleep(0.5) # give time for any blocks to propagate
+    blockNum = prodNode.getHeadBlockNum()
+    shipNode.waitForBlock(blockNum)
     prodNode.kill(signal.SIGTERM)
     shipNode.kill(signal.SIGTERM)
 

--- a/tests/ship_restart_test.py
+++ b/tests/ship_restart_test.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import shutil
 import signal
+import time
 
 from TestHarness import Cluster, TestHelper, Utils, WalletMgr
 
@@ -79,6 +80,8 @@ try:
 
     Print("Shutdown producer and SHiP nodes")
     prodNode.kill(signal.SIGTERM)
+    # prodNode might have produced but not gotten to shipNode yet, wait to allow block to arrive
+    time.sleep(0.5)
     shipNode.kill(signal.SIGTERM)
 
     shipDir               = os.path.join(Utils.getNodeDataDir(shipNodeId), "state-history")


### PR DESCRIPTION
Pause production before shutting down to avoid a race-condition of killing the producer right as it is producing. This should make sure the SHiP node has all the produced blocks.

Resolves #1409