### PR TITLE
avoid copying action when computing action digest

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -134,13 +134,7 @@ void apply_context::exec_one()
       } FC_RETHROW_EXCEPTIONS( warn, "${receiver} <= ${account}::${action} pending console output: ${console}", ("console", _pending_console_output)("account", act->account)("action", act->name)("receiver", receiver) )
 
       if( control.is_builtin_activated( builtin_protocol_feature_t::action_return_value ) ) {
-         act_digest =   generate_action_digest(
-                           [this](const char* data, uint32_t datalen) {
-                              return trx_context.hash_with_checktime<digest_type>(data, datalen);
-                           },
-                           *act,
-                           action_return_value
-                        );
+         act_digest = generate_action_digest(*act, action_return_value);
       } else {
          act_digest = digest_type::hash(*act);
       }

--- a/libraries/chain/include/eosio/chain/action.hpp
+++ b/libraries/chain/include/eosio/chain/action.hpp
@@ -95,36 +95,21 @@ namespace eosio { namespace chain {
       }
    };
 
-   template <typename Hasher>
-   auto generate_action_digest(Hasher&& hash, const action& act, const vector<char>& action_output) {
-      using hash_type = decltype(hash(nullptr, 0));
-      hash_type hashes[2];
-      const action_base* base = &act;
-      const auto action_base_size   = fc::raw::pack_size(*base);
-      const auto action_input_size  = fc::raw::pack_size(act.data);
-      const auto action_output_size = fc::raw::pack_size(action_output);
-      const auto rhs_size           = action_input_size + action_output_size;
-      std::vector<char> buff;
-      buff.reserve(std::max(action_base_size, rhs_size));
-      {
-         buff.resize(action_base_size);
-         fc::datastream<char*> ds(buff.data(), action_base_size);
-         fc::raw::pack(ds, *base);
-         hashes[0] = hash(buff.data(), action_base_size);
-      }
-      {
-         buff.resize(rhs_size);
-         fc::datastream<char*> ds(buff.data(), rhs_size);
-         fc::raw::pack(ds, act.data);
-         fc::raw::pack(ds, action_output);
-         hashes[1] = hash(buff.data(), rhs_size);
-      }
-      auto hashes_size = fc::raw::pack_size(hashes[0]) + fc::raw::pack_size(hashes[1]);
-      buff.resize(hashes_size); // may cause reallocation but in practice will be unlikely
-      fc::datastream<char*> ds(buff.data(), hashes_size);
-      fc::raw::pack(ds, hashes[0]);
-      fc::raw::pack(ds, hashes[1]);
-      return hash(buff.data(), hashes_size);
+   digest_type generate_action_digest(const action& act, const vector<char>& action_output) {
+      digest_type hashes[2];
+      const action_base& base = act;
+
+      fc::sha256::encoder enc;
+      fc::raw::pack(enc, base);
+      hashes[0] = enc.result();
+
+      enc.reset();
+      fc::raw::pack(enc, std::make_pair(act.data, action_output));
+      hashes[1] = enc.result();
+
+      enc.reset();
+      fc::raw::pack(enc, std::make_pair(hashes[0], hashes[1]));
+      return enc.result();
    }
 
    struct action_notice : public action {

--- a/libraries/chain/include/eosio/chain/action.hpp
+++ b/libraries/chain/include/eosio/chain/action.hpp
@@ -104,8 +104,7 @@ namespace eosio { namespace chain {
       hashes[0] = enc.result();
 
       enc.reset();
-      fc::raw::pack(enc, act.data);
-      fc::raw::pack(enc, action_output);
+      fc::raw::pack(enc, act.data, action_output);
       hashes[1] = enc.result();
 
       enc.reset();

--- a/libraries/chain/include/eosio/chain/action.hpp
+++ b/libraries/chain/include/eosio/chain/action.hpp
@@ -96,7 +96,7 @@ namespace eosio { namespace chain {
    };
 
    inline digest_type generate_action_digest(const action& act, const vector<char>& action_output) {
-      digest_type hashes[2];
+      std::array<digest_type,2> hashes;
       const action_base& base = act;
 
       fc::sha256::encoder enc;
@@ -104,11 +104,12 @@ namespace eosio { namespace chain {
       hashes[0] = enc.result();
 
       enc.reset();
-      fc::raw::pack(enc, std::make_pair(act.data, action_output));
+      fc::raw::pack(enc, act.data);
+      fc::raw::pack(enc, action_output);
       hashes[1] = enc.result();
 
       enc.reset();
-      fc::raw::pack(enc, std::make_pair(hashes[0], hashes[1]));
+      fc::raw::pack(enc, hashes);
       return enc.result();
    }
 

--- a/libraries/chain/include/eosio/chain/action.hpp
+++ b/libraries/chain/include/eosio/chain/action.hpp
@@ -95,7 +95,7 @@ namespace eosio { namespace chain {
       }
    };
 
-   digest_type generate_action_digest(const action& act, const vector<char>& action_output) {
+   inline digest_type generate_action_digest(const action& act, const vector<char>& action_output) {
       digest_type hashes[2];
       const action_base& base = act;
 
@@ -111,10 +111,6 @@ namespace eosio { namespace chain {
       fc::raw::pack(enc, std::make_pair(hashes[0], hashes[1]));
       return enc.result();
    }
-
-   struct action_notice : public action {
-      account_name receiver;
-   };
 
 } } /// namespace eosio::chain
 


### PR DESCRIPTION
I was doing some research in this area and noticed that `generate_action_digest()` effectively copies an action's input and output (return) data. This is a refactor that avoids that. Discussion on removing checktime at https://github.com/AntelopeIO/spring/pull/1411#discussion_r2051923833. Not really expecting a notable perf improvement but a cleanup nonetheless.