### PR TITLE
[1.1.4 -> main] Test fix: Pause production before shutdown

### DIFF
--- a/tests/ship_restart_test.py
+++ b/tests/ship_restart_test.py
@@ -59,6 +59,7 @@ try:
     Print("Stand up cluster")
 
     specificExtraNodeosArgs={}
+    specificExtraNodeosArgs[prodNodeId]="--plugin eosio::producer_api_plugin"
     specificExtraNodeosArgs[shipNodeId]="--plugin eosio::state_history_plugin --trace-history --chain-state-history --finality-data-history --state-history-stride 200 --plugin eosio::net_api_plugin --plugin eosio::producer_api_plugin"
 
     if cluster.launch(topo="mesh", pnodes=totalProducerNodes, totalNodes=totalNodes,
@@ -78,6 +79,9 @@ try:
     shipNode = cluster.getNode(shipNodeId)
 
     Print("Shutdown producer and SHiP nodes")
+    prodNode.processUrllibRequest("producer", "pause", exitOnError=True)
+    blockNum = prodNode.getHeadBlockNum()
+    shipNode.waitForBlock(blockNum)
     prodNode.kill(signal.SIGTERM)
     shipNode.kill(signal.SIGTERM)
 


### PR DESCRIPTION
Pause production before shutting down to avoid a race-condition of killing the producer right as it is producing. This should make sure the SHiP node has all the produced blocks.

Merges `release/1.1` into `main` including #1413 

Resolves #1409