### PR TITLE
[1.1.4] Test fix: Use unique file name

### DIFF
--- a/tests/spring_util_bls_test.py
+++ b/tests/spring_util_bls_test.py
@@ -61,8 +61,8 @@ def test_create_pop_from_file():
     pop = results["Proof of Possession"]
 
     # save private key to a file
-    private_key_file = "tmp_key_file_dlkdx1x56pjy"
-    with open(private_key_file, 'w') as file:
+    private_key_file = "tmp_key_file_ulkdx1x42pjx"
+    with open(private_key_file, 'w+') as file:
         file.write(private_key)
 
     # use the private key file to create POP


### PR DESCRIPTION
Use a unique file name and open with truncate to avoid already exists error. Use `tempfile` to generate unique files.

Not convinced this is the actual problem of #1351, but seems like a reasonable guess.

Resolves #1351 