### PR TITLE
add missing check for MAX_NUM_ARRAY_ELEMENTS in the std::array pack/unpack. Also c++20 syntax update.

### DIFF
--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -672,12 +672,14 @@ namespace fc {
     template<typename Stream, typename T, std::size_t S>
     inline auto pack( Stream& s, const std::array<T, S>& value ) -> std::enable_if_t<std::is_trivially_copyable_v<T>>
     {
+       static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.write((const char*)value.data(), S * sizeof(T));
     }
 
     template<typename Stream, typename T, std::size_t S>
     inline auto pack( Stream& s, const std::array<T, S>& value ) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
     {
+       static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        for( std::size_t i = 0; i < S; ++i ) {
           fc::raw::pack( s, value[i] );
        }
@@ -686,12 +688,14 @@ namespace fc {
     template<typename Stream, typename T, std::size_t S>
     inline auto unpack( Stream& s, std::array<T, S>& value )  -> std::enable_if_t<std::is_trivially_copyable_v<T>>
     {
+       static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.read((char*)value.data(), S * sizeof(T));
     }
 
     template<typename Stream, typename T, std::size_t S>
     inline auto unpack( Stream& s, std::array<T, S>& value )  -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
     {
+       static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        for( std::size_t i = 0; i < S; ++i ) {
           fc::raw::unpack( s, value[i] );
        }

--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -145,31 +145,31 @@ namespace fc {
        usec = fc::microseconds(usec_as_int64);
     } FC_RETHROW_EXCEPTIONS( warn, "" ) }
 
-    template<typename Stream, typename T, size_t N>
-    inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
+    template<typename Stream, NotTriviallyCopyable T, size_t N>
+    inline void pack( Stream& s, const fc::array<T,N>& v)
     {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        for (uint64_t i = 0; i < N; ++i)
          fc::raw::pack(s, v.data[i]);
     }
 
-    template<typename Stream, typename T, size_t N>
-    inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<std::is_trivially_copyable_v<T>>
+    template<typename Stream, TriviallyCopyable T, size_t N>
+    inline void pack( Stream& s, const fc::array<T,N>& v)
     {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.write((const char*)&v.data[0], N*sizeof(T));
     }
 
-    template<typename Stream, typename T, size_t N>
-    inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
+    template<typename Stream, NotTriviallyCopyable T, size_t N>
+    inline void unpack( Stream& s, fc::array<T,N>& v)
     { try {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        for (uint64_t i = 0; i < N; ++i)
           fc::raw::unpack(s, v.data[i]);
     } FC_RETHROW_EXCEPTIONS( warn, "fc::array<${type},${length}>", ("type",fc::get_typename<T>::name())("length",N) ) }
 
-    template<typename Stream, typename T, size_t N>
-    inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<std::is_trivially_copyable_v<T>>
+    template<typename Stream, TriviallyCopyable T, size_t N>
+    inline void unpack( Stream& s, fc::array<T,N>& v)
     { try {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.read((char*)&v.data[0], N*sizeof(T));
@@ -669,15 +669,15 @@ namespace fc {
       }
     }
 
-    template<typename Stream, typename T, std::size_t S>
-    inline auto pack( Stream& s, const std::array<T, S>& value ) -> std::enable_if_t<std::is_trivially_copyable_v<T>>
+    template<typename Stream, TriviallyCopyable T, std::size_t S>
+    inline void pack( Stream& s, const std::array<T, S>& value )
     {
        static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.write((const char*)value.data(), S * sizeof(T));
     }
 
-    template<typename Stream, typename T, std::size_t S>
-    inline auto pack( Stream& s, const std::array<T, S>& value ) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
+    template<typename Stream, NotTriviallyCopyable T, std::size_t S>
+    inline void pack( Stream& s, const std::array<T, S>& value )
     {
        static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        for( std::size_t i = 0; i < S; ++i ) {
@@ -685,15 +685,15 @@ namespace fc {
        }
     }
 
-    template<typename Stream, typename T, std::size_t S>
-    inline auto unpack( Stream& s, std::array<T, S>& value )  -> std::enable_if_t<std::is_trivially_copyable_v<T>>
+    template<typename Stream, TriviallyCopyable T, std::size_t S>
+    inline void unpack( Stream& s, std::array<T, S>& value )
     {
        static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.read((char*)value.data(), S * sizeof(T));
     }
 
-    template<typename Stream, typename T, std::size_t S>
-    inline auto unpack( Stream& s, std::array<T, S>& value )  -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
+    template<typename Stream, NotTriviallyCopyable T, std::size_t S>
+    inline void unpack( Stream& s, std::array<T, S>& value )
     {
        static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        for( std::size_t i = 0; i < S; ++i ) {

--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -146,7 +146,7 @@ namespace fc {
     } FC_RETHROW_EXCEPTIONS( warn, "" ) }
 
     template<typename Stream, typename T, size_t N>
-    inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<!is_trivial_array<T>>
+    inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
     {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        for (uint64_t i = 0; i < N; ++i)
@@ -154,14 +154,14 @@ namespace fc {
     }
 
     template<typename Stream, typename T, size_t N>
-    inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<is_trivial_array<T>>
+    inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<std::is_trivially_copyable_v<T>>
     {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.write((const char*)&v.data[0], N*sizeof(T));
     }
 
     template<typename Stream, typename T, size_t N>
-    inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<!is_trivial_array<T>>
+    inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
     { try {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        for (uint64_t i = 0; i < N; ++i)
@@ -169,7 +169,7 @@ namespace fc {
     } FC_RETHROW_EXCEPTIONS( warn, "fc::array<${type},${length}>", ("type",fc::get_typename<T>::name())("length",N) ) }
 
     template<typename Stream, typename T, size_t N>
-    inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<is_trivial_array<T>>
+    inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<std::is_trivially_copyable_v<T>>
     { try {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.read((char*)&v.data[0], N*sizeof(T));
@@ -670,13 +670,13 @@ namespace fc {
     }
 
     template<typename Stream, typename T, std::size_t S>
-    inline auto pack( Stream& s, const std::array<T, S>& value ) -> std::enable_if_t<is_trivial_array<T>>
+    inline auto pack( Stream& s, const std::array<T, S>& value ) -> std::enable_if_t<std::is_trivially_copyable_v<T>>
     {
        s.write((const char*)value.data(), S * sizeof(T));
     }
 
     template<typename Stream, typename T, std::size_t S>
-    inline auto pack( Stream& s, const std::array<T, S>& value ) -> std::enable_if_t<!is_trivial_array<T>>
+    inline auto pack( Stream& s, const std::array<T, S>& value ) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
     {
        for( std::size_t i = 0; i < S; ++i ) {
           fc::raw::pack( s, value[i] );
@@ -684,13 +684,13 @@ namespace fc {
     }
 
     template<typename Stream, typename T, std::size_t S>
-    inline auto unpack( Stream& s, std::array<T, S>& value )  -> std::enable_if_t<is_trivial_array<T>>
+    inline auto unpack( Stream& s, std::array<T, S>& value )  -> std::enable_if_t<std::is_trivially_copyable_v<T>>
     {
        s.read((char*)value.data(), S * sizeof(T));
     }
 
     template<typename Stream, typename T, std::size_t S>
-    inline auto unpack( Stream& s, std::array<T, S>& value )  -> std::enable_if_t<!is_trivial_array<T>>
+    inline auto unpack( Stream& s, std::array<T, S>& value )  -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
     {
        for( std::size_t i = 0; i < S; ++i ) {
           fc::raw::unpack( s, value[i] );

--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -145,7 +145,7 @@ namespace fc {
        usec = fc::microseconds(usec_as_int64);
     } FC_RETHROW_EXCEPTIONS( warn, "" ) }
 
-    template<typename Stream, NotTriviallyCopyable T, size_t N>
+    template<typename Stream, NotTrivialScalar T, size_t N>
     inline void pack( Stream& s, const fc::array<T,N>& v)
     {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
@@ -153,14 +153,14 @@ namespace fc {
          fc::raw::pack(s, v.data[i]);
     }
 
-    template<typename Stream, TriviallyCopyable T, size_t N>
+    template<typename Stream, TrivialScalar T, size_t N>
     inline void pack( Stream& s, const fc::array<T,N>& v)
     {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.write((const char*)&v.data[0], N*sizeof(T));
     }
 
-    template<typename Stream, NotTriviallyCopyable T, size_t N>
+    template<typename Stream, NotTrivialScalar T, size_t N>
     inline void unpack( Stream& s, fc::array<T,N>& v)
     { try {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
@@ -168,7 +168,7 @@ namespace fc {
           fc::raw::unpack(s, v.data[i]);
     } FC_RETHROW_EXCEPTIONS( warn, "fc::array<${type},${length}>", ("type",fc::get_typename<T>::name())("length",N) ) }
 
-    template<typename Stream, TriviallyCopyable T, size_t N>
+    template<typename Stream, TrivialScalar T, size_t N>
     inline void unpack( Stream& s, fc::array<T,N>& v)
     { try {
        static_assert( N <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
@@ -669,14 +669,14 @@ namespace fc {
       }
     }
 
-    template<typename Stream, TriviallyCopyable T, std::size_t S>
+    template<typename Stream, TrivialScalar T, std::size_t S>
     inline void pack( Stream& s, const std::array<T, S>& value )
     {
        static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.write((const char*)value.data(), S * sizeof(T));
     }
 
-    template<typename Stream, NotTriviallyCopyable T, std::size_t S>
+    template<typename Stream, NotTrivialScalar T, std::size_t S>
     inline void pack( Stream& s, const std::array<T, S>& value )
     {
        static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
@@ -685,14 +685,14 @@ namespace fc {
        }
     }
 
-    template<typename Stream, TriviallyCopyable T, std::size_t S>
+    template<typename Stream, TrivialScalar T, std::size_t S>
     inline void unpack( Stream& s, std::array<T, S>& value )
     {
        static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );
        s.read((char*)value.data(), S * sizeof(T));
     }
 
-    template<typename Stream, NotTriviallyCopyable T, std::size_t S>
+    template<typename Stream, NotTrivialScalar T, std::size_t S>
     inline void unpack( Stream& s, std::array<T, S>& value )
     {
        static_assert( S <= MAX_NUM_ARRAY_ELEMENTS, "number of elements in array is too large" );

--- a/libraries/libfc/include/fc/io/raw_fwd.hpp
+++ b/libraries/libfc/include/fc/io/raw_fwd.hpp
@@ -32,10 +32,10 @@ namespace fc {
    namespace raw {
 
     template<class T>
-    concept TriviallyCopyable = std::is_trivially_copyable_v<T>;
+    concept TrivialScalar = std::is_scalar_v<T> && !std::is_pointer_v<T>;
 
     template<class T>
-    concept NotTriviallyCopyable = !std::is_trivially_copyable_v<T>;
+    concept NotTrivialScalar = !TrivialScalar<T>;
    
     template<typename T>
     inline size_t pack_size(  const T& v );
@@ -77,10 +77,10 @@ namespace fc {
     template<typename Stream, typename K, typename V> inline void pack( Stream& s, const std::pair<K,V>& value );
     template<typename Stream, typename K, typename V> inline void unpack( Stream& s, std::pair<K,V>& value );
 
-   template<typename Stream, TriviallyCopyable T, std::size_t S> inline void pack( Stream& s, const std::array<T,S>& value );
-   template<typename Stream, NotTriviallyCopyable T, std::size_t S> inline void pack( Stream& s, const std::array<T,S>& value );
-   template<typename Stream, TriviallyCopyable T, std::size_t S> inline void unpack( Stream& s, std::array<T,S>& value );
-   template<typename Stream, NotTriviallyCopyable T, std::size_t S> inline void unpack( Stream& s, std::array<T,S>& value );
+   template<typename Stream, TrivialScalar T, std::size_t S> inline void pack( Stream& s, const std::array<T,S>& value );
+   template<typename Stream, NotTrivialScalar T, std::size_t S> inline void pack( Stream& s, const std::array<T,S>& value );
+   template<typename Stream, TrivialScalar T, std::size_t S> inline void unpack( Stream& s, std::array<T,S>& value );
+   template<typename Stream, NotTrivialScalar T, std::size_t S> inline void unpack( Stream& s, std::array<T,S>& value );
 
     template<typename Stream> inline void pack( Stream& s, const variant_object& v );
     template<typename Stream> inline void unpack( Stream& s, variant_object& v );
@@ -125,10 +125,10 @@ namespace fc {
     template<typename Stream> inline void pack( Stream& s, const std::vector<char>& value );
     template<typename Stream> inline void unpack( Stream& s, std::vector<char>& value );
 
-   template<typename Stream, TriviallyCopyable T, std::size_t N> inline void pack( Stream& s, const fc::array<T,N>& v);
-   template<typename Stream, NotTriviallyCopyable T, std::size_t N> inline void pack( Stream& s, const fc::array<T,N>& v);
-   template<typename Stream, TriviallyCopyable T, std::size_t N> inline void unpack( Stream& s, fc::array<T,N>& v);
-   template<typename Stream, NotTriviallyCopyable T, std::size_t N> inline void unpack( Stream& s, fc::array<T,N>& v);
+   template<typename Stream, TrivialScalar T, std::size_t N> inline void pack( Stream& s, const fc::array<T,N>& v);
+   template<typename Stream, NotTrivialScalar T, std::size_t N> inline void pack( Stream& s, const fc::array<T,N>& v);
+   template<typename Stream, TrivialScalar T, std::size_t N> inline void unpack( Stream& s, fc::array<T,N>& v);
+   template<typename Stream, NotTrivialScalar T, std::size_t N> inline void unpack( Stream& s, fc::array<T,N>& v);
 
     template<typename Stream> inline void pack( Stream& s, const bool& v );
     template<typename Stream> inline void unpack( Stream& s, bool& v );

--- a/libraries/libfc/include/fc/io/raw_fwd.hpp
+++ b/libraries/libfc/include/fc/io/raw_fwd.hpp
@@ -31,9 +31,6 @@ namespace fc {
 
    namespace raw {
     template<typename T>
-    constexpr bool is_trivial_array = std::is_scalar<T>::value == true && std::is_pointer<T>::value == false;
-
-    template<typename T>
     inline size_t pack_size(  const T& v );
 
     template <typename Stream> void unpack(Stream& s, eosio::chain::signed_block& v);
@@ -73,10 +70,10 @@ namespace fc {
     template<typename Stream, typename K, typename V> inline void pack( Stream& s, const std::pair<K,V>& value );
     template<typename Stream, typename K, typename V> inline void unpack( Stream& s, std::pair<K,V>& value );
 
-    template<typename Stream, typename T, std::size_t S> inline auto pack( Stream& s, const std::array<T,S>& value ) -> std::enable_if_t<is_trivial_array<T>>;
-    template<typename Stream, typename T, std::size_t S> inline auto pack( Stream& s, const std::array<T,S>& value ) -> std::enable_if_t<!is_trivial_array<T>>;
-    template<typename Stream, typename T, std::size_t S> inline auto unpack( Stream& s, std::array<T,S>& value ) -> std::enable_if_t<is_trivial_array<T>>;
-    template<typename Stream, typename T, std::size_t S> inline auto unpack( Stream& s, std::array<T,S>& value ) -> std::enable_if_t<!is_trivial_array<T>>;
+    template<typename Stream, typename T, std::size_t S> inline auto pack( Stream& s, const std::array<T,S>& value ) -> std::enable_if_t<std::is_trivially_copyable_v<T>>;
+    template<typename Stream, typename T, std::size_t S> inline auto pack( Stream& s, const std::array<T,S>& value ) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>;
+    template<typename Stream, typename T, std::size_t S> inline auto unpack( Stream& s, std::array<T,S>& value ) -> std::enable_if_t<std::is_trivially_copyable_v<T>>;
+    template<typename Stream, typename T, std::size_t S> inline auto unpack( Stream& s, std::array<T,S>& value ) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>;
 
     template<typename Stream> inline void pack( Stream& s, const variant_object& v );
     template<typename Stream> inline void unpack( Stream& s, variant_object& v );
@@ -121,10 +118,10 @@ namespace fc {
     template<typename Stream> inline void pack( Stream& s, const std::vector<char>& value );
     template<typename Stream> inline void unpack( Stream& s, std::vector<char>& value );
 
-    template<typename Stream, typename T, std::size_t N> inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<is_trivial_array<T>>;
-    template<typename Stream, typename T, std::size_t N> inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<!is_trivial_array<T>>;
-    template<typename Stream, typename T, std::size_t N> inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<is_trivial_array<T>>;
-    template<typename Stream, typename T, std::size_t N> inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<!is_trivial_array<T>>;
+    template<typename Stream, typename T, std::size_t N> inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<std::is_trivially_copyable_v<T>>;
+    template<typename Stream, typename T, std::size_t N> inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>;
+    template<typename Stream, typename T, std::size_t N> inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<std::is_trivially_copyable_v<T>>;
+    template<typename Stream, typename T, std::size_t N> inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>;
 
     template<typename Stream> inline void pack( Stream& s, const bool& v );
     template<typename Stream> inline void unpack( Stream& s, bool& v );

--- a/libraries/libfc/include/fc/io/raw_fwd.hpp
+++ b/libraries/libfc/include/fc/io/raw_fwd.hpp
@@ -30,6 +30,13 @@ namespace fc {
    template<typename Storage> class fixed_string;
 
    namespace raw {
+
+    template<class T>
+    concept TriviallyCopyable = std::is_trivially_copyable_v<T>;
+
+    template<class T>
+    concept NotTriviallyCopyable = !std::is_trivially_copyable_v<T>;
+   
     template<typename T>
     inline size_t pack_size(  const T& v );
 
@@ -70,10 +77,10 @@ namespace fc {
     template<typename Stream, typename K, typename V> inline void pack( Stream& s, const std::pair<K,V>& value );
     template<typename Stream, typename K, typename V> inline void unpack( Stream& s, std::pair<K,V>& value );
 
-    template<typename Stream, typename T, std::size_t S> inline auto pack( Stream& s, const std::array<T,S>& value ) -> std::enable_if_t<std::is_trivially_copyable_v<T>>;
-    template<typename Stream, typename T, std::size_t S> inline auto pack( Stream& s, const std::array<T,S>& value ) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>;
-    template<typename Stream, typename T, std::size_t S> inline auto unpack( Stream& s, std::array<T,S>& value ) -> std::enable_if_t<std::is_trivially_copyable_v<T>>;
-    template<typename Stream, typename T, std::size_t S> inline auto unpack( Stream& s, std::array<T,S>& value ) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>;
+   template<typename Stream, TriviallyCopyable T, std::size_t S> inline void pack( Stream& s, const std::array<T,S>& value );
+   template<typename Stream, NotTriviallyCopyable T, std::size_t S> inline void pack( Stream& s, const std::array<T,S>& value );
+   template<typename Stream, TriviallyCopyable T, std::size_t S> inline void unpack( Stream& s, std::array<T,S>& value );
+   template<typename Stream, NotTriviallyCopyable T, std::size_t S> inline void unpack( Stream& s, std::array<T,S>& value );
 
     template<typename Stream> inline void pack( Stream& s, const variant_object& v );
     template<typename Stream> inline void unpack( Stream& s, variant_object& v );
@@ -118,10 +125,10 @@ namespace fc {
     template<typename Stream> inline void pack( Stream& s, const std::vector<char>& value );
     template<typename Stream> inline void unpack( Stream& s, std::vector<char>& value );
 
-    template<typename Stream, typename T, std::size_t N> inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<std::is_trivially_copyable_v<T>>;
-    template<typename Stream, typename T, std::size_t N> inline auto pack( Stream& s, const fc::array<T,N>& v) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>;
-    template<typename Stream, typename T, std::size_t N> inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<std::is_trivially_copyable_v<T>>;
-    template<typename Stream, typename T, std::size_t N> inline auto unpack( Stream& s, fc::array<T,N>& v) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>;
+   template<typename Stream, TriviallyCopyable T, std::size_t N> inline void pack( Stream& s, const fc::array<T,N>& v);
+   template<typename Stream, NotTriviallyCopyable T, std::size_t N> inline void pack( Stream& s, const fc::array<T,N>& v);
+   template<typename Stream, TriviallyCopyable T, std::size_t N> inline void unpack( Stream& s, fc::array<T,N>& v);
+   template<typename Stream, NotTriviallyCopyable T, std::size_t N> inline void unpack( Stream& s, fc::array<T,N>& v);
 
     template<typename Stream> inline void pack( Stream& s, const bool& v );
     template<typename Stream> inline void unpack( Stream& s, bool& v );


### PR DESCRIPTION
Add missing check for `MAX_NUM_ARRAY_ELEMENTS` in the `std::array` versions.
Also c++20 syntax update.

Resolves #1422.