### PR TITLE
[1.1.5] fix state history race on disconnect: drain session strand before destroying session

### DIFF
--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -25,6 +25,8 @@ public:
 
    virtual void block_applied(const chain::block_num_type applied_block_num) = 0;
 
+   virtual void drain_strand() = 0;
+
    virtual ~session_base() = default;
 };
 
@@ -51,6 +53,11 @@ public:
       if(applied_block_num < next_block_cursor)
          next_block_cursor = applied_block_num;
       awake_if_idle();
+   }
+
+   // allow main thread to drain the strand before destruction -- some awake_if_idle() post()s may be inflight
+   void drain_strand() {
+      boost::asio::post(strand, boost::asio::use_future([](){})).get();
    }
 
 private:


### PR DESCRIPTION
A state_history session runs two corountines: one to read from the websocket and one to write to the websocket. A failure on either corountine will cause it to complete as well as indicate to the other countinue that it should complete as well. Completion of either corountine ends up here,
https://github.com/AntelopeIO/spring/blob/f7657a241de6dcb0c6314abb180800f345ac4ce3/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp#L73-L81
Since the timing of those completions can be indeterminate, a simple counter is used to detect that both have completed. When that occurs `session` indicates externally that it is done and it's ready to be destroyed. "done" means the `session` is no longer using any of its members such as the `stream`, etc -- sounds safe to destroy right? This done indication winds up here,
https://github.com/AntelopeIO/spring/blob/f7657a241de6dcb0c6314abb180800f345ac4ce3/plugins/state_history_plugin/state_history_plugin.cpp#L118-L121
Where a small piece of work is submitted to the main thread to remove the session from `connections`.

While this erasure is queued up on the main thread, the main thread may be doing other work that results in the `on_accepted_block()` signal firing. This will cause state_history to,
https://github.com/AntelopeIO/spring/blob/f7657a241de6dcb0c6314abb180800f345ac4ce3/plugins/state_history_plugin/state_history_plugin.cpp#L161-L163
Remember the erasure is still queued up on the main thread, so the "done" session is still in this list. `block_applied()` is very simple and calls `awake_if_idle()`
https://github.com/AntelopeIO/spring/blob/f7657a241de6dcb0c6314abb180800f345ac4ce3/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp#L49-L54
https://github.com/AntelopeIO/spring/blob/f7657a241de6dcb0c6314abb180800f345ac4ce3/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp#L67-L71
Critically, `awake_if_idle()` `post()`s to the "done" session's strand.

Now 1 of 3 things can happen based on timing:
1) The `wake_timer.cancel_one()` posted to the "done" session's strand completes prior to the erasure on main thread. This is fine.
2) The erasure occurs on the main thread prior to the strand starting `wake_timer.cancel_one()`. This is also fine -- the strand is destroyed and any pending work is dropped.
3) The erasure occurs on the main thread simultaneously to the strand executing `wake_timer.cancel_one()` (or also during any phase where the strand's internal code is otherwise running). This will result in undefined behavior as the `session` and its members (including the `strand`) will be in various stages of destruction.

To resolve this problem, can drain any potential pending queued `wake_timer.cancel_one()` prior to destruction. Since we're blocking the main thread during draining, we can be sure no new calls to `block_applied()` occur.

The premise above points to the same line that #1419 fails on, so will mark this resolving it.