### PR TITLE
[1.1.5 -> 1.2.0-rc2] fix state history race on disconnect: drain session strand before destroying session

### DIFF
--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -25,6 +25,8 @@ public:
 
    virtual void block_applied(const chain::block_num_type applied_block_num) = 0;
 
+   virtual void drain_strand() = 0;
+
    virtual ~session_base() = default;
 };
 
@@ -51,6 +53,11 @@ public:
       if(applied_block_num < next_block_cursor)
          next_block_cursor = applied_block_num;
       awake_if_idle();
+   }
+
+   // allow main thread to drain the strand before destruction -- some awake_if_idle() post()s may be inflight
+   void drain_strand() {
+      boost::asio::post(strand, boost::asio::use_future([](){})).get();
    }
 
 private:

--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -57,7 +57,7 @@ public:
 
    // allow main thread to drain the strand before destruction -- some awake_if_idle() post()s may be inflight
    void drain_strand() {
-      boost::asio::post(strand, boost::asio::use_future([](){})).get();
+      chain::post_async_task(strand, [](){}).get();
    }
 
 private:


### PR DESCRIPTION
1.2 merge of #1446