### PR TITLE
[1.2.0-rc2 -> main] fix state history race on disconnect: drain session strand before destroying session

### DIFF
--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/session.hpp
@@ -25,6 +25,8 @@ public:
 
    virtual void block_applied(const chain::block_num_type applied_block_num) = 0;
 
+   virtual void drain_strand() = 0;
+
    virtual ~session_base() = default;
 };
 
@@ -51,6 +53,11 @@ public:
       if(applied_block_num < next_block_cursor)
          next_block_cursor = applied_block_num;
       awake_if_idle();
+   }
+
+   // allow main thread to drain the strand before destruction -- some awake_if_idle() post()s may be inflight
+   void drain_strand() {
+      chain::post_async_task(strand, [](){}).get();
    }
 
 private:


### PR DESCRIPTION
main merge of #1448 + #1446