### PR TITLE
[2.0.0-dev] remove corountine workarounds required for gcc10

### DIFF
--- a/plugins/state_history_plugin/CMakeLists.txt
+++ b/plugins/state_history_plugin/CMakeLists.txt
@@ -5,7 +5,3 @@ add_library( state_history_plugin
 
 target_link_libraries( state_history_plugin state_history chain_plugin eosio_chain appbase )
 target_include_directories( state_history_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11 )
-   target_compile_options( state_history_plugin PRIVATE "-fcoroutines" )
-endif()


### PR DESCRIPTION
With ubuntu22 having gcc11, don't need these any more :tada: 