### PR TITLE
Support truncate-at-block with terminate-at-block

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2150,7 +2150,7 @@ struct controller_impl {
                if (auto head = fork_db.head(); head->block_num() > conf.truncate_at_block) {
                   ilog("Removing blocks past truncate-at-block ${t} from fork database with head at ${h}",
                         ("t", conf.truncate_at_block)("h", head->block_num()));
-                  fork_db.remove(conf.truncate_at_block);
+                  fork_db.remove(conf.truncate_at_block + 1);
                }
             });
          }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2147,7 +2147,7 @@ struct controller_impl {
       if (conf.truncate_at_block > 0 && chain_head.is_valid()) {
          if (chain_head.block_num() == conf.truncate_at_block && fork_db_has_root()) {
             fork_db_.apply<void>([&](auto& fork_db) {
-               if (auto head = fork_db.head(); head->block_num() > conf.truncate_at_block) {
+               if (auto head = fork_db.head(); head && head->block_num() > conf.truncate_at_block) {
                   ilog("Removing blocks past truncate-at-block ${t} from fork database with head at ${h}",
                         ("t", conf.truncate_at_block)("h", head->block_num()));
                   fork_db.remove(conf.truncate_at_block + 1);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2080,6 +2080,10 @@ struct controller_impl {
          db.undo();
       }
 
+      EOS_ASSERT(conf.terminate_at_block == 0 || conf.terminate_at_block > chain_head.block_num(),
+                 plugin_config_exception, "--terminate-at-block ${t} not greater than chain head ${h}",
+                 ("t", conf.terminate_at_block)("h", chain_head.block_num()));
+
       protocol_features.init( db );
 
       // At startup, no transaction specific logging is possible
@@ -2139,6 +2143,19 @@ struct controller_impl {
 
    ~controller_impl() {
       pending.reset();
+
+      if (conf.truncate_at_block > 0 && chain_head.is_valid()) {
+         if (chain_head.block_num() == conf.truncate_at_block && fork_db_has_root()) {
+            fork_db_.apply<void>([&](auto& fork_db) {
+               if (auto head = fork_db.head(); head->block_num() > conf.truncate_at_block) {
+                  ilog("Removing blocks past truncate-at-block ${t} from fork database with head at ${h}",
+                        ("t", conf.truncate_at_block)("h", head->block_num()));
+                  fork_db.remove(conf.truncate_at_block);
+               }
+            });
+         }
+      }
+
       //only log this not just if configured to, but also if initialization made it to the point we'd log the startup too
       if(okay_to_print_integrity_hash_on_stop && conf.integrity_hash_on_stop)
          ilog( "chain database stopped with hash: ${hash}", ("hash", calculate_integrity_hash()) );

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -103,6 +103,7 @@ namespace eosio::chain {
       void             reset_root_impl( const bsp_t& root_bs );
       void             advance_root_impl( const block_id_type& id );
       void             remove_impl( const block_id_type& id );
+      void             remove_impl( block_num_type block_num );
       bsp_t            head_impl(include_root_t include_root) const;
       bool             set_pending_savanna_lib_id_impl(const block_id_type& id);
       branch_t         fetch_branch_impl( const block_id_type& h, uint32_t trim_after_block_num ) const;
@@ -586,6 +587,24 @@ namespace eosio::chain {
 
       for( const auto& block_id : remove_queue ) {
          index.erase( block_id );
+      }
+   }
+
+   template<class BSP>
+   void fork_database_t<BSP>::remove( block_num_type block_num ) {
+      std::lock_guard g( my->mtx );
+      return my->remove_impl( block_num );
+   }
+
+   template<class BSP>
+   void fork_database_impl<BSP>::remove_impl( block_num_type block_num ) {
+      // doesn't matter which index as there is no index over block_num
+      for (auto itr = index.template get<0>().begin(); itr != index.template get<0>().end(); ) {
+         if ((*itr)->block_num() >= block_num) {
+            itr = index.erase(itr);
+         } else {
+            ++itr;
+         }
       }
    }
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -150,6 +150,7 @@ namespace eosio::chain {
             uint32_t                 maximum_variable_signature_length = chain::config::default_max_variable_signature_length;
             bool                     disable_all_subjective_mitigations = false; //< for developer & testing purposes, can be configured using `disable-all-subjective-mitigations` when `EOSIO_DEVELOPER` build option is provided
             uint32_t                 terminate_at_block     = 0;
+            uint32_t                 truncate_at_block      = 0;
             uint32_t                 num_configured_p2p_peers = 0;
             bool                     integrity_hash_on_start= false;
             bool                     integrity_hash_on_stop = false;

--- a/libraries/chain/include/eosio/chain/fork_database.hpp
+++ b/libraries/chain/include/eosio/chain/fork_database.hpp
@@ -82,6 +82,11 @@ namespace eosio::chain {
 
       void remove( const block_id_type& id );
 
+      /**
+       * Remove all blocks >= block_num
+       */
+      void remove( block_num_type block_num);
+
       bool is_valid() const; // sanity checks on this fork_db
 
       bool   has_root() const;

--- a/tests/nodeos_read_terminate_at_block_test.py
+++ b/tests/nodeos_read_terminate_at_block_test.py
@@ -60,7 +60,7 @@ def executeTest(cluster, testNodeId, testNodeArgs, resultMsgs):
         testNode = cluster.getNode(testNodeId)
         assert not testNode.verifyAlive() # resets pid so reluanch works
         peers = testNode.rmFromCmd('--p2p-peer-address')
-        testNode.relaunch(addSwapFlags={"--terminate-at-block": "9999999"})
+        testNode.relaunch(addSwapFlags={"--terminate-at-block": "0", "--truncate-at-block": "0"})
 
         # Wait for node to start up.
         time.sleep(3)
@@ -134,7 +134,7 @@ def checkReplay(testNode, testNodeArgs):
     ]))
 
     assert not testNode.verifyAlive()
-    testNode.relaunch(chainArg="--replay-blockchain", addSwapFlags={"--terminate-at-block": "9999999"})
+    testNode.relaunch(chainArg="--replay-blockchain", addSwapFlags={"--terminate-at-block": "0", "--truncate-at-block": "0"})
 
     # Wait for node to finish up.
     time.sleep(3)
@@ -213,7 +213,7 @@ def executeSnapshotBlocklogTest(cluster, testNodeId, resultMsgs, nodeArgs, termA
         assert testNode.kill(signal.SIGTERM)
 
     # Start from snapshot, replay through block log and terminate at specified block
-    chainArg=f'--snapshot {testNode.getLatestSnapshot()} --replay-blockchain --terminate-at-block {termAtBlock}'
+    chainArg=f'--snapshot {testNode.getLatestSnapshot()} --replay-blockchain --terminate-at-block {termAtBlock} --truncate-at-block {termAtBlock}'
     testNode.relaunch(chainArg=chainArg, waitForTerm=True)
 
     # Check the node stops at the correct block by checking the log.
@@ -268,10 +268,10 @@ try:
         0 : "--enable-stale-production"
     }
     regularNodeosArgs = {
-        1 : "--read-mode irreversible --terminate-at-block 100",
-        2 : "--read-mode head --terminate-at-block 125",
-        3 : "--read-mode speculative --terminate-at-block 150",
-        4 : "--read-mode irreversible --terminate-at-block 180"
+        1 : "--read-mode irreversible --terminate-at-block 100 --truncate-at-block 100",
+        2 : "--read-mode head --terminate-at-block 125 --truncate-at-block 125",
+        3 : "--read-mode speculative --terminate-at-block 150 --truncate-at-block 150",
+        4 : "--read-mode irreversible --terminate-at-block 180 --truncate-at-block 180"
     }
     replayNodeosArgs = {
         5 : "--read-mode irreversible",

--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -167,6 +167,19 @@ BOOST_FIXTURE_TEST_CASE(add_remove_test, generate_fork_db_state) try {
    BOOST_TEST(branch[1] == bsp11b);
 } FC_LOG_AND_RETHROW();
 
+BOOST_FIXTURE_TEST_CASE(remove_block_num_test, generate_fork_db_state) try {
+   BOOST_TEST(fork_db.size() == 14);
+   fork_db.remove(13); // remove all >= 13
+   BOOST_TEST(fork_db.size() == 8);
+
+   for (auto& i : all) {
+      if (i->block_num() < 13) {
+         BOOST_TEST(fork_db.get_block(i->id()) == i);
+      } else {
+         BOOST_TEST(!fork_db.get_block(i->id()));
+      }
+   }
+} FC_LOG_AND_RETHROW();
 
 // test `fork_database_t::validated_block_exists() const` member
 // -------------------------------------------------------------

--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -170,7 +170,7 @@ BOOST_FIXTURE_TEST_CASE(add_remove_test, generate_fork_db_state) try {
 BOOST_FIXTURE_TEST_CASE(remove_block_num_test, generate_fork_db_state) try {
    BOOST_TEST(fork_db.size() == 14);
    fork_db.remove(13); // remove all >= 13
-   BOOST_TEST(fork_db.size() == 8);
+   BOOST_TEST(fork_db.size() == 8); // 6 blocks >= 13
 
    for (auto& i : all) {
       if (i->block_num() < 13) {


### PR DESCRIPTION
When syncing, a node can load up the fork database with many blocks ahead of the current head. The `terminate-at-block` option terminates when the head reaches the specified `terminate-at-block`. On restart of the node after `terminate-at-block` this can be confusing as the node can process the blocks out of the fork database on restart. To avoid having these extra blocks in the fork database on shutdown, `truncate-at-block` can now be specified along with `terminate-at-block`. On shutdown due to a `terminate-at-block`, if `truncate-at-block` is specified then the fork database will have all blocks beyond `truncate-at-block` removed.

```
  --truncate-at-block arg (=0)          Stop hard replay / block log recovery
                                        at this block number (if non-zero). Can
                                        also be used with terminate-at-block to
                                        prune any received blocks from fork
                                        database on exit.
  --terminate-at-block arg (=0)         Stops the node after reaching the
                                        specified block number (if non-zero).
                                        Use RPC endpoint /v1/producer/pause_at_
                                        block to pause at a specific block
                                        instead. Combine with
                                        --truncate-at-block to prune blocks
                                        beyond the specified number from the
                                        fork database on exit.
```

Note: Existing `terminate-scenarios-test.py` continues to test `terminate-at-block` without `truncate-at-block`.  `nodeos_read_terminate_at_block_test.py` which expects the restarted node not to have extra blocks has been updated to use `truncate-at-block` with `terminate-at-block`.

Resolves #1365 