### PR TITLE
Updated docs with nodeos --help output

### DIFF
--- a/docs/01_nodeos/03_plugins/chain_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/chain_plugin/index.md
@@ -36,8 +36,6 @@ Command Line Options for eosio::chain_plugin:
   --force-all-checks                    do not skip any validation checks while
                                         replaying blocks (useful for replaying
                                         blocks from untrusted source)
-  --disable-replay-opts                 disable optimizations that specifically
-                                        target replay
   --replay-blockchain                   clear chain state database and replay
                                         all blocks
   --hard-replay-blockchain              clear chain state database, recover as
@@ -45,13 +43,19 @@ Command Line Options for eosio::chain_plugin:
                                         log, and then replay those blocks
   --delete-all-blocks                   clear chain state database and block
                                         log
-  --truncate-at-block arg (=0)          stop hard replay / block log recovery
-                                        at this block number (if set to
-                                        non-zero number)
-  --terminate-at-block arg (=0)         terminate after reaching this block
-                                        number (if set to a non-zero number)
+  --truncate-at-block arg (=0)          Stop hard replay / block log recovery
+                                        at this block number (if non-zero). Can
+                                        also be used with terminate-at-block to
+                                        prune any received blocks from fork
+                                        database on exit.
+  --terminate-at-block arg (=0)         Stops the node after reaching the
+                                        specified block number (if non-zero).
+                                        Use RPC endpoint /v1/producer/pause_at_
+                                        block to pause at a specific block
+                                        instead. Combine with truncate-at-block
+                                        to prune blocks beyond the specified
+                                        number from the fork database on exit.
   --snapshot arg                        File to read Snapshot State from
-
 ```
 
 ## Options
@@ -63,9 +67,48 @@ Config Options for eosio::chain_plugin:
   --blocks-dir arg (="blocks")          the location of the blocks directory
                                         (absolute path or relative to
                                         application data dir)
+  --blocks-log-stride arg               split the block log file when the head
+                                        block number is the multiple of the
+                                        stride
+                                        When the stride is reached, the current
+                                        block log and index will be renamed
+                                        '<blocks-retained-dir>/blocks-<start
+                                        num>-<end num>.log/index'
+                                        and a new current block log and index
+                                        will be created with the most recent
+                                        block. All files following
+                                        this format will be used to construct
+                                        an extended block log.
+  --max-retained-block-files arg        the maximum number of blocks files to
+                                        retain so that the blocks in those
+                                        files can be queried.
+                                        When the number is reached, the oldest
+                                        block file would be moved to archive
+                                        dir or deleted if the archive dir is
+                                        empty.
+                                        The retained block log files should not
+                                        be manipulated by users.
+  --blocks-retained-dir arg             the location of the blocks retained
+                                        directory (absolute path or relative to
+                                        blocks dir).
+                                        If the value is empty, it is set to the
+                                        value of blocks dir.
+  --blocks-archive-dir arg              the location of the blocks archive
+                                        directory (absolute path or relative to
+                                        blocks dir).
+                                        If the value is empty, blocks files
+                                        beyond the retained limit will be
+                                        deleted.
+                                        All files in the archive directory are
+                                        completely under user's control, i.e.
+                                        they won't be accessed by nodeos
+                                        anymore.
   --state-dir arg (="state")            the location of the state directory
                                         (absolute path or relative to
                                         application data dir)
+  --finalizers-dir arg (="finalizers")  the location of the finalizers safety
+                                        data directory (absolute path or
+                                        relative to application data dir)
   --protocol-features-dir arg (="protocol_features")
                                         the location of the protocol_features
                                         directory (absolute path or relative to
@@ -96,6 +139,11 @@ Config Options for eosio::chain_plugin:
                                         e.g. 50 for 50%
   --chain-threads arg (=2)              Number of worker threads in controller
                                         thread pool
+  --vote-threads arg                    Number of worker threads in vote
+                                        processor thread pool. If set to 0,
+                                        voting disabled, votes are not
+                                        propagatged on P2P network. Defaults to
+                                        4 on producer nodes.
   --contracts-console                   print contract's output to console
   --deep-mind                           print deeper information about chain
                                         operations
@@ -137,7 +185,8 @@ Config Options for eosio::chain_plugin:
                                         as well as some transactions not yet
                                         included in the blockchain;
                                         transactions received by the node are
-                                        relayed if valid.                                        
+                                        relayed if valid.
+
   --api-accept-transactions arg (=1)    Allow API transactions to be evaluated
                                         and relayed if valid.
   --validation-mode arg (=full)         Chain validation mode ("full" or
@@ -186,12 +235,16 @@ Config Options for eosio::chain_plugin:
                                         ('auto', 'all', 'none').
                                         'auto' - EOS VM OC tier-up is enabled
                                         for eosio.* accounts, read-only trxs,
-                                        and applying blocks.
+                                        and except on producers applying
+                                        blocks.
                                         'all'  - EOS VM OC tier-up is enabled
                                         for all contract execution.
                                         'none' - EOS VM OC tier-up is
                                         completely disabled.
 
+  --eos-vm-oc-whitelist arg (=xsat,vaulta)
+                                        EOS VM OC tier-up whitelist account
+                                        suffixes for tier-up runtime 'auto'.
   --enable-account-queries arg (=0)     enable queries to find accounts by
                                         various metadata.
   --transaction-retry-max-storage-size-gb arg
@@ -200,16 +253,16 @@ Config Options for eosio::chain_plugin:
                                         feature. Setting above 0 enables this
                                         feature.
   --transaction-retry-interval-sec arg (=20)
-                                        How often, in seconds, to resend an 
-                                        incoming transaction to network if not 
+                                        How often, in seconds, to resend an
+                                        incoming transaction to network if not
                                         seen in a block.
-                                        Needs to be at least twice as large as 
+                                        Needs to be at least twice as large as
                                         p2p-dedup-cache-expire-time-sec.
   --transaction-retry-max-expiration-sec arg (=120)
-                                        Maximum allowed transaction expiration 
-                                        for retry transactions, will retry 
+                                        Maximum allowed transaction expiration
+                                        for retry transactions, will retry
                                         transactions up to this value.
-                                        Should be larger than 
+                                        Should be larger than
                                         transaction-retry-interval-sec.
   --transaction-finality-status-max-storage-size-gb arg
                                         Maximum size (in GiB) allowed to be
@@ -226,6 +279,8 @@ Config Options for eosio::chain_plugin:
                                         transaction's Finality Status will
                                         remain available from being first
                                         identified.
+  --disable-replay-opts                 disable optimizations that specifically
+                                        target replay
   --integrity-hash-on-start             Log the state integrity hash on startup
   --integrity-hash-on-stop              Log the state integrity hash on
                                         shutdown

--- a/docs/01_nodeos/03_plugins/http_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/http_plugin/index.md
@@ -29,6 +29,60 @@ Config Options for eosio::http_plugin:
                                         The local IP and port to listen for
                                         incoming http connections; set blank to
                                         disable.
+  --http-category-address arg           The local IP and port to listen for
+                                        incoming http category connections.
+                                        Syntax: category,address
+                                            Where the address can be
+                                        <hostname>:port, <ipaddress>:port or
+                                        unix socket path;
+                                            in addition, unix socket path must
+                                        starts with '/', './' or '../'. When
+                                        relative path
+                                            is used, it is relative to the data
+                                        path.
+
+                                            Valid categories include chain_ro,
+                                        chain_rw, db_size, net_ro, net_rw,
+                                        producer_ro
+                                            producer_rw, snapshot, trace_api,
+                                        prometheus, and test_control.
+
+                                            A single `hostname:port`
+                                        specification can be used by multiple
+                                        categories
+                                            However, two specifications having
+                                        the same port with different hostname
+                                        strings
+                                            are always considered as
+                                        configuration error regardless of
+                                        whether they can be resolved
+                                            into the same set of IP addresses.
+
+                                          Examples:
+                                            chain_ro,127.0.0.1:8080
+                                            chain_ro,127.0.0.1:8081
+                                            chain_rw,localhost:8081 # ERROR!,
+                                        same port with different addresses
+                                            chain_rw,[::1]:8082
+                                            net_ro,localhost:8083
+                                            net_rw,server.domain.net:8084
+                                            producer_ro,/tmp/absolute_unix_path
+                                        .sock
+                                            producer_rw,./relative_unix_path.so
+                                        ck
+                                            trace_api,:8086 # listen on all
+                                        network interfaces
+
+                                          Notice that the behavior for `[::1]`
+                                        is platform dependent. For system with
+                                        IPv4 mapped IPv6 networking
+                                          is enabled, using `[::1]` will listen
+                                        on both IPv4 and IPv6; other systems
+                                        like FreeBSD, it will only
+                                          listen on IPv6. On the other hand,
+                                        the specfications without hostnames
+                                        like `:8086` will always listen on
+                                          both IPv4 and IPv6 on all platforms.
   --access-control-allow-origin arg     Specify the Access-Control-Allow-Origin
                                         to be returned on each request
   --access-control-allow-headers arg    Specify the Access-Control-Allow-Header
@@ -43,19 +97,19 @@ Config Options for eosio::http_plugin:
   --http-max-bytes-in-flight-mb arg (=500)
                                         Maximum size in megabytes http_plugin
                                         should use for processing http
-                                        requests. -1 for unlimited. 429 error
+                                        requests. -1 for unlimited. 503 error
                                         response when exceeded.
   --http-max-in-flight-requests arg (=-1)
                                         Maximum number of requests http_plugin
                                         should use for processing http
-                                        requests. 429 error response when
+                                        requests. 503 error response when
                                         exceeded.
-  --http-max-response-time-ms arg (=30) Maximum time for processing a request,
-                                        -1 for unlimited
+  --http-max-response-time-ms arg (=15) Maximum time on main thread for
+                                        processing a request, -1 for unlimited
   --verbose-http-errors                 Append the error log to HTTP responses
   --http-validate-host arg (=1)         If set to false, then any incoming
                                         "Host" header is considered valid
-  --http-alias arg                      Additionaly acceptable values for the
+  --http-alias arg                      Additionally acceptable values for the
                                         "Host" header of incoming HTTP
                                         requests, can be specified multiple
                                         times.  Includes http/s_server_address
@@ -64,8 +118,7 @@ Config Options for eosio::http_plugin:
                                         pool
   --http-keep-alive arg (=1)            If set to false, do not keep HTTP
                                         connections alive, even if client
-                                        requests.
-```
+                                        requests.```
 
 ## Dependencies
 

--- a/docs/01_nodeos/03_plugins/producer_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/producer_plugin/index.md
@@ -27,6 +27,11 @@ Config Options for eosio::producer_plugin:
                                         chain is stale.
   -x [ --pause-on-startup ]             Start this node in a state where
                                         production is paused
+  --production-pause-vote-timeout-ms arg (=6000)
+                                        Received vote timeout. If no vote from
+                                        producer-name finalizers or other
+                                        finalizers then pauses block
+                                        production. 0 disables.
   --max-transaction-time arg (=499)     Setting this value (in milliseconds)
                                         will restrict the allowed transaction
                                         execution time to a value potentially
@@ -37,6 +42,10 @@ Config Options for eosio::producer_plugin:
                                         the DPOS Irreversible Block for a chain
                                         this node will produce blocks on (use
                                         negative value to indicate unlimited)
+  --max-reversible-blocks arg (=3600)   Maximum allowed reversible blocks
+                                        beyond irreversible before block
+                                        production is paused. Specify 0 to
+                                        disable.
   -p [ --producer-name ] arg            ID of producer controlled by this node
                                         (e.g. inita; may specify multiple
                                         times)
@@ -45,26 +54,26 @@ Config Options for eosio::producer_plugin:
                                         <public-key>=<provider-spec>
                                         Where:
                                            <public-key>    is a string form of
-                                                           a valid EOS public
-                                                           key
-
+                                                           a valid Antelope
+                                                           public key,
+                                                           including BLS
+                                                           finalizer key
                                            <provider-spec> is a string in the
                                                            form <provider-type>
                                                            :<data>
-
                                            <provider-type> is KEY, KEOSD, or SE
-
                                            KEY:<data>      is a string form of
-                                                           a valid EOS
+                                                           a valid Antelope
                                                            private key which
                                                            maps to the provided
                                                            public key
-
                                            KEOSD:<data>    is the URL where
                                                            keosd is available
-                                                           and the approptiate
+                                                           and the appropriate
                                                            wallet(s) are
                                                            unlocked
+
+
   --greylist-account arg                account that can not access to extended
                                         CPU/NET virtual resources
   --greylist-limit arg (=1000)          Limit (between 1 and 1000) on the
@@ -73,7 +82,7 @@ Config Options for eosio::producer_plugin:
                                         enforced subjectively; use 1000 to not
                                         enforce any limit)
   --produce-block-offset-ms arg (=450)  The minimum time to reserve at the end
-                                        of a production round for blocks to 
+                                        of a production round for blocks to
                                         propagate to the next block producer.
   --max-block-cpu-usage-threshold-us arg (=5000)
                                         Threshold of CPU block production to
@@ -93,7 +102,11 @@ Config Options for eosio::producer_plugin:
   --subjective-account-max-failures arg (=3)
                                         Sets the maximum amount of failures
                                         that are allowed for a given account
-                                        per block.
+                                        per window size.
+  --subjective-account-max-failures-window-size arg (=1)
+                                        Sets the window size in number of
+                                        blocks for subjective-account-max-failu
+                                        res.
   --subjective-account-decay-time-minutes arg (=1440)
                                         Sets the time to return full subjective
                                         cpu for accounts
@@ -114,6 +127,16 @@ Config Options for eosio::producer_plugin:
   --snapshots-dir arg (="snapshots")    the location of the snapshots directory
                                         (absolute path or relative to
                                         application data dir)
+  --read-only-threads arg               Number of worker threads in read-only
+                                        execution thread pool. Defaults to 0 if
+                                        configured as producer, otherwise
+                                        defaults to 3. Max 128.
+  --read-only-write-window-time-us arg (=200000)
+                                        Time in microseconds the write window
+                                        lasts.
+  --read-only-read-window-time-us arg (=60000)
+                                        Time in microseconds the read window
+                                        lasts.
 ```
 
 ## Dependencies

--- a/docs/01_nodeos/03_plugins/resource_monitor_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/resource_monitor_plugin/index.md
@@ -31,12 +31,20 @@ Config Options for eosio::resource_monitor_plugin:
                                         Threshold in terms of percentage of
                                         used space vs total space. If used
                                         space is above (threshold - 5%), a
-                                        warning is generated.  Unless
+                                        warning is generated. Unless
                                         resource-monitor-not-shutdown-on-thresh
                                         old-exceeded is enabled, a graceful
                                         shutdown is initiated if used space is
                                         above the threshold. The value should
                                         be between 6 and 99
+  --resource-monitor-space-absolute-gb arg
+                                        Absolute threshold in gibibytes of
+                                        remaining space; applied to each
+                                        monitored directory. If remaining space
+                                        is less than value for any monitored
+                                        directories then threshold is
+                                        considered exceeded.Overrides
+                                        resource-monitor-space-threshold value.
   --resource-monitor-not-shutdown-on-threshold-exceeded
                                         Used to indicate nodeos will not
                                         shutdown when threshold is exceeded.
@@ -44,8 +52,7 @@ Config Options for eosio::resource_monitor_plugin:
                                         Number of resource monitor intervals
                                         between two consecutive warnings when
                                         the threshold is hit. Should be between
-                                        1 and 450
-```
+                                        1 and 450```
 
 ## Plugin Dependencies
 

--- a/docs/01_nodeos/03_plugins/state_history_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/state_history_plugin/index.md
@@ -35,8 +35,43 @@ Config Options for eosio::state_history_plugin:
                                         the location of the state-history
                                         directory (absolute path or relative to
                                         application data dir)
+  --state-history-retained-dir arg      the location of the state history
+                                        retained directory (absolute path or
+                                        relative to state-history dir).
+  --state-history-archive-dir arg       the location of the state history
+                                        archive directory (absolute path or
+                                        relative to state-history dir).
+                                        If the value is empty string, blocks
+                                        files beyond the retained limit will be
+                                        deleted.
+                                        All files in the archive directory are
+                                        completely under user's control, i.e.
+                                        they won't be accessed by nodeos
+                                        anymore.
+  --state-history-stride arg            split the state history log files when
+                                        the block number is the multiple of the
+                                        stride
+                                        When the stride is reached, the current
+                                        history log and index will be renamed
+                                        '*-history-<start num>-<end
+                                        num>.log/index'
+                                        and a new current history log and index
+                                        will be created with the most recent
+                                        blocks. All files following
+                                        this format will be used to construct
+                                        an extended history log.
+  --max-retained-history-files arg      the maximum number of history file
+                                        groups to retain so that the blocks in
+                                        those files can be queried.
+                                        When the number is reached, the oldest
+                                        history file would be moved to archive
+                                        dir or deleted if the archive dir is
+                                        empty.
+                                        The retained history log files should
+                                        not be manipulated by users.
   --trace-history                       enable trace history
   --chain-state-history                 enable chain state history
+  --finality-data-history               enable finality data history
   --state-history-endpoint arg (=127.0.0.1:8080)
                                         the endpoint upon which to listen for
                                         incoming connections. Caution: only


### PR DESCRIPTION
Seems we have missed a number of updates.

Could look into "back-porting" these as needed to `1.2.0-rc2` if desired. Seems like these should be auto-generated instead of manually updating.