### PR TITLE
[1.2.0-rc2 -> main] Updated docs with latest nodeos --help output

### DIFF
--- a/docs/01_nodeos/03_plugins/chain_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/chain_plugin/index.md
@@ -291,7 +291,6 @@ Config Options for eosio::chain_plugin:
                                         If set to 0, no blocks are be written
                                         to the block log; block log file is
                                         removed after startup.
-
 ```
 
 ## Dependencies


### PR DESCRIPTION
Effectively an empty diff because #1459 already in `main`.

Merges `release/1.2` into `main` including #1469.