### PR TITLE
[1.2.0-rc2 -> main] Migrate Performance Test Harness Actions to @v4

### DIFF
--- a/.github/workflows/performance_harness_run.yaml
+++ b/.github/workflows/performance_harness_run.yaml
@@ -88,10 +88,11 @@ jobs:
 
         - name: Upload builddir
           if: steps.downloadBuild.outputs.downloaded-file != ''
-          uses: AntelopeIO/upload-artifact-large-chunks-action@v1
+          uses: actions/upload-artifact@v4
           with:
             name: ${{github.event.inputs.platform-choice}}-build
-            path: build.tar.zst
+            path: ./build/build.tar.zst
+            compression-level: 0
 
   build-base:
     name: Run Build Workflow
@@ -111,7 +112,7 @@ jobs:
       image: ${{fromJSON(needs.platform-cache.outputs.platforms)[github.event.inputs.platform-choice].image}}
     steps:
       - name: Download builddir
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{github.event.inputs.platform-choice}}-build
       - name: Extract Build Directory
@@ -146,12 +147,13 @@ jobs:
         run: |
           tar -pc build/PHSRLogs | zstd --long -T0 -9 > PHSRLogs.tar.zst
       - name: Upload results
-        uses: AntelopeIO/upload-artifact-large-chunks-action@v1
+        uses: actions/upload-artifact@v4
         with:
           name: performance-test-results
           path: PHSRLogs.tar.zst
+          compression-level: 0
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: performance-test-report
           path: ./build/PHSRLogs/**/report.json


### PR DESCRIPTION
This PR updates the github actions for the PerformanceTestHarness. Upload and download artifacts where updated, and the upload artifact was migrated to a standard action. Any `upload-artifact` or `download-artifact` actions where migrated to `@v4`

See this github note on deprecation of `@v3` `upload-actions`
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

Merges `release/1.2` into `main` including #1481 

Resolve #1476 
