### PR TITLE
Do not allow truncate-at-block when in savanna transition

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2146,13 +2146,18 @@ struct controller_impl {
 
       if (conf.truncate_at_block > 0 && chain_head.is_valid()) {
          if (chain_head.block_num() == conf.truncate_at_block && fork_db_has_root()) {
-            fork_db_.apply<void>([&](auto& fork_db) {
-               if (auto head = fork_db.head(); head && head->block_num() > conf.truncate_at_block) {
-                  ilog("Removing blocks past truncate-at-block ${t} from fork database with head at ${h}",
-                        ("t", conf.truncate_at_block)("h", head->block_num()));
-                  fork_db.remove(conf.truncate_at_block + 1);
-               }
-            });
+            if (fork_db_.version_in_use() == fork_database::in_use_t::both) {
+               // in savanna transition
+               wlog("In the middle of Savanna transition, truncate-at-block not allowed, ignoring truncate-at-block ${b}", ("b", conf.truncate_at_block));
+            } else {
+               fork_db_.apply<void>([&](auto& fork_db) {
+                  if (auto head = fork_db.head(); head && head->block_num() > conf.truncate_at_block) {
+                     ilog("Removing blocks past truncate-at-block ${t} from fork database with head at ${h}",
+                           ("t", conf.truncate_at_block)("h", head->block_num()));
+                     fork_db.remove(conf.truncate_at_block + 1);
+                  }
+               });
+            }
          }
       }
 


### PR DESCRIPTION
Currently truncating blocks from the fork database is not supported during Savanna transition. Check for Savanna transition and log a warning instead of removing blocks from the fork database.

See #1467, specifically: https://github.com/AntelopeIO/spring/issues/1467#issuecomment-2847646584 for more details.

Example output:
```
info  2025-05-02T16:44:48.903 nodeos    controller.cpp:1489           transition_to_savann ] Transitioning to savanna, IF Genesis Block 94, IF Critical Block 94
debug 2025-05-02T16:44:48.903 nodeos    block_state.cpp:203           create_transition_bl ] Create transition block 95
info  2025-05-02T16:44:48.903 nodeos    controller.cpp:1534           operator()           ] Transition to instant finality happening after block 95, First IF Proper Block 96
warn  2025-05-02T16:44:48.906 nodeos    controller.cpp:2151           ~controller_impl     ] In the middle of Savanna transition, truncate-at-block not allowed, ignoring truncate-at-block 94
info  2025-05-02T16:44:48.910 nodeos    block_handle.cpp:21           write                ] Writing chain_head block 94 0000005e2b1243b2792ceabce7dee67f5136b2da663c60702c5629ce4660b537
info  2025-05-02T16:44:48.910 nodeos    fork_database.cpp:696         close                ] Persisting to fork_database file: /home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_read_terminate_at_block_test126283/node_01/blocks/reversible/fork_db.dat
info  2025-05-02T16:44:48.910 nodeos    fork_database.cpp:170         close_impl           ] Writing fork_database 1 blocks with root 94:0000005e2b1243b2792ceabce7dee67f5136b2da663c60702c5629ce4660b537 and head 95:0000005fdbbea7818c6463165d9f67d6655c459279945808dd822b13e61ed259
info  2025-05-02T16:44:48.910 nodeos    fork_database.cpp:170         close_impl           ] Writing fork_database 1 blocks with root 94:0000005e2b1243b2792ceabce7dee67f5136b2da663c60702c5629ce4660b537 and head 95:0000005fdbbea7818c6463165d9f67d6655c459279945808dd822b13e61ed259
```

Resolves #1467 