### PR TITLE
[1.2.0-rc2] Performance Workflow Move Upload Out of Build Dir

### DIFF
--- a/.github/workflows/performance_harness_run.yaml
+++ b/.github/workflows/performance_harness_run.yaml
@@ -85,13 +85,12 @@ jobs:
             target: ${{github.sha}}
             artifact-name: ${{github.event.inputs.platform-choice}}-build
             fail-on-missing-target: false
-
         - name: Upload builddir
           if: steps.downloadBuild.outputs.downloaded-file != ''
           uses: actions/upload-artifact@v4
           with:
             name: ${{github.event.inputs.platform-choice}}-build
-            path: ./build/build.tar.zst
+            path: build.tar.zst
             compression-level: 0
 
   build-base:

--- a/.github/workflows/performance_harness_run.yaml
+++ b/.github/workflows/performance_harness_run.yaml
@@ -117,6 +117,8 @@ jobs:
           name: ${{github.event.inputs.platform-choice}}-build
       - name: Extract Build Directory
         run: |
+          # https://github.com/actions/runner/issues/2033  -- need this because of full version label test looking at git revs
+          chown -R $(id -u):$(id -g) $PWD
           zstdcat build.tar.zst | tar x
       - if: ${{ needs.v.outputs.spring-target != 'DEFAULT' }}
         name: Download Prev Spring Version

--- a/.github/workflows/performance_harness_run.yaml
+++ b/.github/workflows/performance_harness_run.yaml
@@ -116,8 +116,6 @@ jobs:
           name: ${{github.event.inputs.platform-choice}}-build
       - name: Extract Build Directory
         run: |
-          # https://github.com/actions/runner/issues/2033  -- need this because of full version label test looking at git revs
-          chown -R $(id -u):$(id -g) $PWD
           zstdcat build.tar.zst | tar x
       - if: ${{ needs.v.outputs.spring-target != 'DEFAULT' }}
         name: Download Prev Spring Version


### PR DESCRIPTION
Changes upload directory for `build.tar.zst`. Fixes test failing when workflow was unable to find tarred binaries `build.targ.zst`

Fixes #1476 