### PR TITLE
[1.2.0-rc2 -> main] Performance Workflow Move Upload Out of Build Dir

### DIFF
--- a/.github/workflows/performance_harness_run.yaml
+++ b/.github/workflows/performance_harness_run.yaml
@@ -85,13 +85,12 @@ jobs:
             target: ${{github.sha}}
             artifact-name: ${{github.event.inputs.platform-choice}}-build
             fail-on-missing-target: false
-
         - name: Upload builddir
           if: steps.downloadBuild.outputs.downloaded-file != ''
           uses: actions/upload-artifact@v4
           with:
             name: ${{github.event.inputs.platform-choice}}-build
-            path: ./build/build.tar.zst
+            path: build.tar.zst
             compression-level: 0
 
   build-base:


### PR DESCRIPTION
Changes upload directory for `build.tar.zst`. Fixes test failing when workflow was unable to find tarred binaries `build.targ.zst`

Fixes #1476 

Related PR in `release/1.2` branch https://github.com/AntelopeIO/spring/pull/1494