### PR TITLE
P2P Feature: Transaction notice

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/buffer_factory.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/buffer_factory.hpp
@@ -124,6 +124,15 @@ namespace eosio {
          return send_buffer;
       }
 
+      /// caches result for subsequent calls, only provide same packed_transaction_ptr instance for each invocation.
+      /// Do not use get_send_buffer() with get_notice_send_buffer(), only one valid per trx_buffer_factory instance.
+      const send_buffer_type& get_notice_send_buffer( const packed_transaction_ptr& trx ) {
+         if( !send_buffer ) {
+            send_buffer = buffer_factory::create_send_buffer( transaction_notice_message{trx->id(), trx->expiration()} );
+         }
+         return send_buffer;
+      }
+
    private:
 
       static send_buffer_type create_send_buffer( const packed_transaction_ptr& trx ) {

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -136,6 +136,11 @@ namespace eosio {
       block_id_type id;
    };
 
+   struct transaction_notice_message {
+      transaction_id_type id;
+      time_point_sec      expiration;
+   };
+
    struct gossip_bp_peers_message {
       struct bp_peer {
          eosio::name               producer_name;
@@ -165,7 +170,8 @@ namespace eosio {
                                     vote_message,
                                     block_nack_message,
                                     block_notice_message,
-                                    gossip_bp_peers_message>;
+                                    gossip_bp_peers_message,
+                                    transaction_notice_message>;
 
    // see protocol net_message
    enum class msg_type_t {
@@ -181,7 +187,8 @@ namespace eosio {
       vote_message           = fc::get_index<net_message, vote_message>(),
       block_nack_message     = fc::get_index<net_message, block_nack_message>(),
       block_notice_message   = fc::get_index<net_message, block_notice_message>(),
-      gossip_bp_peers_message= fc::get_index<net_message, gossip_bp_peers_message>(),
+      gossip_bp_peers_message    = fc::get_index<net_message, gossip_bp_peers_message>(),
+      transaction_notice_message = fc::get_index<net_message, transaction_notice_message>(),
       unknown
    };
 
@@ -215,6 +222,7 @@ FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
 FC_REFLECT( eosio::block_nack_message, (id) )
 FC_REFLECT( eosio::block_notice_message, (previous)(id) )
+FC_REFLECT( eosio::transaction_notice_message, (id)(expiration) )
 FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(server_address)(sig) )
 FC_REFLECT( eosio::gossip_bp_peers_message, (peers) )
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3167,6 +3167,12 @@ namespace eosio {
          return true;
       }
 
+      auto ds = pending_message_buffer.create_datastream();
+      unsigned_int which{};
+      fc::raw::unpack( ds, which );
+      transaction_notice_message msg;
+      fc::raw::unpack( ds, msg );
+
       // todo
 
       return true;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -79,9 +79,9 @@ namespace eosio {
       std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::milliseconds(config::block_interval_ms)).count();
 
    struct node_transaction_state {
-      transaction_id_type id;
-      time_point_sec  expires;        /// time after which this may be purged.
-      uint32_t        connection_id = 0;
+      transaction_id_type         id;
+      time_point_sec              expires;     // time after which this may be purged.
+      mutable flat_set<uint32_t>  connections; // not indexed, hence mutable
    };
 
    struct by_expiry;
@@ -89,13 +89,9 @@ namespace eosio {
    typedef multi_index_container<
       node_transaction_state,
       indexed_by<
-         ordered_unique<
+         hashed_unique<
             tag<by_id>,
-            composite_key< node_transaction_state,
-               member<node_transaction_state, transaction_id_type, &node_transaction_state::id>,
-               member<node_transaction_state, uint32_t, &node_transaction_state::connection_id>
-            >,
-            composite_key_compare< std::less<transaction_id_type>, std::less<> >
+            member<node_transaction_state, transaction_id_type, &node_transaction_state::id>
          >,
          ordered_non_unique<
             tag< by_expiry >,
@@ -2594,16 +2590,19 @@ namespace eosio {
    bool dispatch_manager::add_peer_txn( const transaction_id_type& id, const time_point_sec& trx_expires,
                                         uint32_t connection_id, const time_point_sec& now ) {
       fc::lock_guard g( local_txns_mtx );
-      auto tptr = local_txns.get<by_id>().find( std::make_tuple( std::ref( id ), connection_id ) );
-      bool added = (tptr == local_txns.end());
-      if( added ) {
+      bool added = false;
+      if (auto tptr = local_txns.get<by_id>().find( std::ref( id ) ); tptr != local_txns.end()) {
+         if (tptr->connections.insert(connection_id).second)
+            added = true;
+      } else {
          // expire at either transaction expiration or configured max expire time whichever is less
          time_point_sec expires{now.to_time_point() + my_impl->p2p_dedup_cache_expire_time_us};
          expires = std::min( trx_expires, expires );
          local_txns.insert( node_transaction_state{
             .id = id,
             .expires = expires,
-            .connection_id = connection_id} );
+            .connections = {connection_id}} );
+         added = true;
       }
       return added;
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3173,10 +3173,11 @@ namespace eosio {
          return true;
       }
       bool have_trx = my_impl->dispatcher.have_txn( ptr->id() );
-      size_t connection_count = my_impl->dispatcher.add_peer_txn( ptr->id(), ptr->expiration(), true, connection_id );
+      size_t connection_count = my_impl->dispatcher.add_peer_txn( ptr->id(), ptr->expiration(), connection_id, true );
       if (connection_count > def_max_trx_per_connection) {
          peer_wlog(this, "Max tracked trx reached ${c}, closing", ("c", connection_count));
          close();
+         return true;
       }
 
       if( have_trx ) {
@@ -3207,7 +3208,7 @@ namespace eosio {
       transaction_notice_message msg;
       fc::raw::unpack( ds, msg );
 
-      size_t connection_count = my_impl->dispatcher.add_peer_txn( msg.id, msg.expiration, false, connection_id );
+      size_t connection_count = my_impl->dispatcher.add_peer_txn( msg.id, msg.expiration, connection_id, false );
       if (connection_count > def_max_trx_per_connection) {
          peer_wlog(this, "Max tracked trx reached ${c}, closing", ("c", connection_count));
          close();


### PR DESCRIPTION
### P2P Transaction propagation enhancement

- No change for API RPC calls
- Transaction received over P2P connection
  - Record trx id and connection id and that we have the trx
  - If trx id already received then drop the transaction
  - If trx.size() > 200 bytes (may change this to 0, going to run some perf tests)
    - send to all connections
    ``` 
      transaction_notice_message { 
         transaction_id_type id; 
         time_point_sec      expiration;
      };
      ```
    - If transaction_notice_message or trx (pending tracked ids) exceeds 100K for connection, disconnect.
    - Also verify expiration not more than on-chain configured max.
    - clear all transaction ids from local cache when connection closes
  - Queue transaction for speculative execution
- If transaction fails to speculatively execute
  - Drop it
  - Do not immediately remove trx id from recorded transactions
    - Prevents immediately trying it again if received from another connection
- If transaction succeeds
  - Broadcast to all P2P connections not received trx or transaction-notify from
- On receive of `transaction_notice_message` record trx id and connection id but not that we have the transaction

#### Notes:

A transaction request message is not needed. Transactions are broadcast to nodes that are known not to have the transaction. A node knows a connection does not have a transaction because it has not received the trx or a `transaction_notify` from that connection.

`transaction_notice_message` is not propagated when received. `transaction_notice_message` is only sent when a transaction is received. Since transactions are verified (speculatively executed) before being broadcast this will normally provide enough time for `transaction_notice_message` to be received from nodes that already have the transaction.

Backward compatible with previous versions of net protocol. Will not send `transaction_notice_message` to any connections not at latest net protocol. Since no `transaction_notice_message` received from older versions all transactions will be broadcast to them if not received from them.