### PR TITLE
[1.2.0-rc2] P2P: Gossip BP peer enhancements

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3392,9 +3392,8 @@ struct controller_impl {
    void update_peer_keys() {
       if (!peer_keys_db.is_active())
          return;
-      // Since get_top_producer_keys() can't be called on startup, call it on first call to update_peer_keys().
       // if syncing or replaying old blocks don't bother updating peer keys.
-      if (peer_keys_db.last_block_num_update() > 0 && fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
+      if (fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
          return;
 
       try {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3390,11 +3390,12 @@ struct controller_impl {
    } /// start_block
 
    void update_peer_keys() {
-      // if syncing or replaying old blocks don't bother updating peer keys
-      if (peer_keys_db.last_block_num_update() > 0) { // can't have been updated unless active
-         if (!peer_keys_db.is_active() || fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
-            return;
-      }
+      if (!peer_keys_db.is_active())
+         return;
+      // Since get_top_producer_keys() can't be called on startup, call it on first call to update_peer_keys().
+      // if syncing or replaying old blocks don't bother updating peer keys.
+      if (peer_keys_db.last_block_num_update() > 0 && fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
+         return;
 
       try {
          auto block_num = chain_head.block_num() + 1;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3391,8 +3391,10 @@ struct controller_impl {
 
    void update_peer_keys() {
       // if syncing or replaying old blocks don't bother updating peer keys
-      if (!peer_keys_db.is_active() || fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
-         return;
+      if (peer_keys_db.last_update() > 0) { // can't have been updated unless active
+         if (!peer_keys_db.is_active() || fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
+            return;
+      }
 
       try {
          auto block_num = chain_head.block_num() + 1;
@@ -5864,7 +5866,7 @@ std::optional<peer_info_t> controller::get_peer_info(name n) const {
 }
 
 bool controller::configured_peer_keys_updated() {
-   return my->peer_keys_db.configured_peer_keys_updated();
+   return my->peer_keys_db.is_active() && my->peer_keys_db.configured_peer_keys_updated();
 }
 
 getpeerkeys_res_t controller::get_top_producer_keys() {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3391,7 +3391,7 @@ struct controller_impl {
 
    void update_peer_keys() {
       // if syncing or replaying old blocks don't bother updating peer keys
-      if (peer_keys_db.last_update() > 0) { // can't have been updated unless active
+      if (peer_keys_db.last_block_num_update() > 0) { // can't have been updated unless active
          if (!peer_keys_db.is_active() || fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
             return;
       }
@@ -5857,7 +5857,7 @@ chain_id_type controller::get_chain_id()const {
    return my->chain_id;
 }
 
-void controller::set_peer_keys_retrieval_active(peer_name_set_t configured_bp_peers) {
+void controller::set_peer_keys_retrieval_active(name_set_t configured_bp_peers) {
    my->peer_keys_db.set_active(std::move(configured_bp_peers));
 }
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -429,7 +429,7 @@ namespace eosio::chain {
 
          chain_id_type get_chain_id()const;
 
-         void set_peer_keys_retrieval_active(peer_name_set_t configured_bp_peers);
+         void set_peer_keys_retrieval_active(name_set_t configured_bp_peers);
          std::optional<peer_info_t> get_peer_info(name n) const;  // thread safe
          bool configured_peer_keys_updated(); // thread safe
          // used for testing, only call with an active pending block from main thread

--- a/libraries/chain/include/eosio/chain/peer_keys_db.hpp
+++ b/libraries/chain/include/eosio/chain/peer_keys_db.hpp
@@ -27,7 +27,7 @@ struct peer_info_t {
 };
 
 using peer_key_map_t = boost::unordered_flat_map<name, peer_info_t, std::hash<name>>;
-using peer_name_set_t = flat_set<name>;
+using name_set_t = flat_set<name>;
 
 /**
  * This class caches the on-chain public keys that BP use to sign the `gossip_bp_peers`
@@ -39,7 +39,7 @@ public:
    peer_keys_db_t() = default;
 
    // called on startup with configured bp peers of the node
-   void set_active(peer_name_set_t configured_bp_peers) {
+   void set_active(name_set_t configured_bp_peers) {
       _configured_bp_peers = std::move(configured_bp_peers);
       _active = true;
    }
@@ -48,7 +48,7 @@ public:
    bool is_active() const { return _active; }
 
    // must be called from the main thread
-   block_num_type last_update() const { return _last_block_num; }
+   block_num_type last_block_num_update() const { return _last_block_num; }
 
    // must be called from the main thread
    // return true if update_peer_keys should be called with new map of peer keys
@@ -67,7 +67,7 @@ public:
 private:
    bool               _active = false;       // if not active (the default), no update occurs
    block_num_type     _last_block_num = 0;
-   peer_name_set_t    _configured_bp_peers;  // no updates occurs
+   name_set_t         _configured_bp_peers;  // no updates occurs
    std::atomic<bool>  _configured_bp_peers_updated{false};
 
    mutable fc::mutex  _m;

--- a/libraries/chain/include/eosio/chain/peer_keys_db.hpp
+++ b/libraries/chain/include/eosio/chain/peer_keys_db.hpp
@@ -48,6 +48,9 @@ public:
    bool is_active() const { return _active; }
 
    // must be called from the main thread
+   block_num_type last_update() const { return _last_block_num; }
+
+   // must be called from the main thread
    // return true if update_peer_keys should be called with new map of peer keys
    bool should_update(block_num_type block_num) { return _active && (_last_block_num == 0 || block_num % 120 == 0); }
 

--- a/libraries/chain/include/eosio/chain/peer_keys_db.hpp
+++ b/libraries/chain/include/eosio/chain/peer_keys_db.hpp
@@ -48,9 +48,6 @@ public:
    bool is_active() const { return _active; }
 
    // must be called from the main thread
-   block_num_type last_block_num_update() const { return _last_block_num; }
-
-   // must be called from the main thread
    // return true if update_peer_keys should be called with new map of peer keys
    bool should_update(block_num_type block_num) { return _active && (_last_block_num == 0 || block_num % 120 == 0); }
 

--- a/libraries/chain/peer_keys_db.cpp
+++ b/libraries/chain/peer_keys_db.cpp
@@ -17,11 +17,12 @@ bool peer_keys_db_t::configured_peer_keys_updated() {
 
 void peer_keys_db_t::update_peer_keys(block_num_type block_num, const getpeerkeys_res_t& v) {
    assert(_active);
-   _last_block_num = block_num;
 
    if (v.empty())
       return;
    
+   _last_block_num = block_num;
+
    // create hash_map of current top selected producers (according to "getpeerkeys"_n in system contracts)
    // ----------------------------------------------------------------------------------------------------
    peer_key_map_t current;

--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -63,7 +63,9 @@ void net_api_plugin::plugin_startup() {
             INVOKE_R_R(net_mgr, status, std::string), 201),
        CALL_WITH_400(net, net_ro, net_mgr, connections,
             INVOKE_R_V(net_mgr, connections), 201),
-   } );
+       CALL_WITH_400(net, net_ro, net_mgr, bp_gossip_peers,
+            INVOKE_R_V(net_mgr, bp_gossip_peers), 201),
+  } );
 }
 
 void net_api_plugin::plugin_initialize(const variables_map& options) {

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -43,7 +43,7 @@ class bp_connection_manager {
       flat_map<net_utils::endpoint, account_name>   auto_bp_accounts;       // --p2p-auto-bp-peer endpoint->account
       // p2p-bp-gossip-endpoint
       name_set_t                                    my_bp_gossip_accounts;  // producer account of --p2p-bp-gossip-endpoint, for bp gossip
-      flat_set<bp_gossip_endpoint_t>                bp_gossip_endpoints;    // [inbound_endpoint,outbound_ip_address] to bp gossip
+      std::vector<bp_gossip_endpoint_t>             bp_gossip_endpoints;    // [inbound_endpoint,outbound_ip_address] to bp gossip
    } config; // thread safe only because modified at plugin startup currently
 
    // the following members are only accessed from main thread
@@ -193,7 +193,7 @@ public:
                         "Invalid p2p-bp-gossip-endpoint outbound ip address ${p}, syntax ip-address", ("p", outbound_ip_address));
 
             fc_dlog(self()->get_logger(), "Setting p2p-bp-gossip-endpoint ${a} -> ${i},${o}", ("a", account)("i", inbound_server_endpoint)("o", outbound_ip_address));
-            config.bp_gossip_endpoints.emplace(inbound_server_endpoint, outbound_ip_address);
+            config.bp_gossip_endpoints.emplace_back(inbound_server_endpoint, outbound_ip_address);
          } catch (chain::name_type_exception&) {
             EOS_ASSERT(false, chain::plugin_config_exception,
                        "The account ${a} supplied by --p2p-bp-gossip-endpoint option is invalid", ("a", aname));

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -60,10 +60,12 @@ class bp_connection_manager {
    const Derived* self() const { return static_cast<const Derived*>(this); }
 
    template <template <typename...> typename Container, typename... Rest>
+   requires std::is_same_v<typename Container<account_name, Rest...>::value_type, account_name>
    static std::string to_string(const Container<account_name, Rest...>& peers) {
       return boost::algorithm::join(peers | boost::adaptors::transformed([](auto& p) { return p.to_string(); }), ",");
    }
    template <template <typename...> typename Container, typename... Rest>
+   requires std::is_same_v<typename Container<std::string, Rest...>::value_type, std::string>
    static std::string to_string(const Container<std::string, Rest...>& peers) {
       return boost::algorithm::join(peers, ",");
    }

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -42,7 +42,7 @@ class bp_connection_manager {
       flat_map<account_name, net_utils::endpoint>   auto_bp_addresses;      // --p2p-auto-bp-peer account->endpoint
       flat_map<net_utils::endpoint, account_name>   auto_bp_accounts;       // --p2p-auto-bp-peer endpoint->account
       // p2p-bp-gossip-endpoint, producer account -> [inbound_endpoint,outbound_ip_address] for bp gossip
-      flat_map<account_name, std::vector<bp_gossip_endpoint_t>>  my_bp_gossip_accounts;
+      std::unordered_map<account_name, std::vector<bp_gossip_endpoint_t>>  my_bp_gossip_accounts;
    } config; // thread safe only because modified at plugin startup currently
 
    // the following members are only accessed from main thread
@@ -198,6 +198,10 @@ public:
                         "Invalid p2p-bp-gossip-endpoint outbound ip address ${p}, syntax ip-address", ("p", outbound_ip_address));
 
             fc_dlog(self()->get_logger(), "Setting p2p-bp-gossip-endpoint ${a} -> ${i},${o}", ("a", account)("i", inbound_server_endpoint)("o", outbound_ip_address));
+            EOS_ASSERT(std::ranges::find_if(config.my_bp_gossip_accounts[account],
+                                            [&](const auto& e) { return e.server_endpoint == inbound_server_endpoint; }) == config.my_bp_gossip_accounts[account].end(),
+                       chain::plugin_config_exception, "Duplicate p2p-bp-gossip-endpoint for: ${a}, inbound server endpoint: ${i}",
+                       ("a", account)("i", inbound_server_endpoint));
             config.my_bp_gossip_accounts[account].emplace_back(inbound_server_endpoint, outbound_ip_address);
             EOS_ASSERT(config.my_bp_gossip_accounts[account].size() <= max_bp_gossip_peers_per_producer, chain::plugin_config_exception,
                        "Too many p2p-bp-gossip-endpoint for ${a}, max ${m}", ("a", account)("m", max_bp_gossip_peers_per_producer));
@@ -269,7 +273,7 @@ public:
       std::string type;
       std::tie(e.host, e.port, type) = eosio::net_utils::split_host_port_type(conn->log_p2p_address);
 
-      if (config.auto_bp_accounts.count(e)) {
+      if (config.auto_bp_accounts.contains(e)) {
          conn->bp_connection = Connection::bp_connection_type::bp_config;
       }
    }

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -41,9 +41,8 @@ class bp_connection_manager {
       // p2p-auto-bp-peer
       flat_map<account_name, net_utils::endpoint>   auto_bp_addresses;      // --p2p-auto-bp-peer account->endpoint
       flat_map<net_utils::endpoint, account_name>   auto_bp_accounts;       // --p2p-auto-bp-peer endpoint->account
-      // p2p-bp-gossip-endpoint
-      name_set_t                                    my_bp_gossip_accounts;  // producer account of --p2p-bp-gossip-endpoint, for bp gossip
-      std::vector<bp_gossip_endpoint_t>             bp_gossip_endpoints;    // [inbound_endpoint,outbound_ip_address] to bp gossip
+      // p2p-bp-gossip-endpoint, producer account -> [inbound_endpoint,outbound_ip_address] for bp gossip
+      flat_map<account_name, std::vector<bp_gossip_endpoint_t>>  my_bp_gossip_accounts;
    } config; // thread safe only because modified at plugin startup currently
 
    // the following members are only accessed from main thread
@@ -117,7 +116,12 @@ public:
    bool bp_gossip_enabled() const { return !config.my_bp_gossip_accounts.empty(); }
    // return true if auto bp peering of manually configured bp peers is configured or if bp gossip enabled
    bool auto_bp_peering_enabled() const { return !config.auto_bp_addresses.empty() || bp_gossip_enabled(); }
-   name_set_t my_bp_gossip_accounts() const { return config.my_bp_gossip_accounts; }
+   name_set_t my_bp_gossip_accounts() const {
+      name_set_t result;
+      for (const auto& a : config.my_bp_gossip_accounts)
+         result.insert(a.first);
+      return result;
+   }
    bool bp_gossip_initialized() { return !!get_gossip_bp_initial_send_buffer(); }
 
    // Only called at plugin startup.
@@ -170,7 +174,6 @@ public:
                        "p2p-bp-gossip-endpoint ${e} must consist of bp-account-name,inbound-server-endpoint,outbound-ip-address separated by commas", ("e", entry));
             aname = entry.substr(0, comma_pos);
             account_name account(aname);
-            config.my_bp_gossip_accounts.emplace(account);
             auto rest = entry.substr(comma_pos + 1);
             comma_pos = rest.find(',');
             EOS_ASSERT(comma_pos != std::string::npos, chain::plugin_config_exception,
@@ -195,7 +198,9 @@ public:
                         "Invalid p2p-bp-gossip-endpoint outbound ip address ${p}, syntax ip-address", ("p", outbound_ip_address));
 
             fc_dlog(self()->get_logger(), "Setting p2p-bp-gossip-endpoint ${a} -> ${i},${o}", ("a", account)("i", inbound_server_endpoint)("o", outbound_ip_address));
-            config.bp_gossip_endpoints.emplace_back(inbound_server_endpoint, outbound_ip_address);
+            config.my_bp_gossip_accounts[account].emplace_back(inbound_server_endpoint, outbound_ip_address);
+            EOS_ASSERT(config.my_bp_gossip_accounts[account].size() <= max_bp_gossip_peers_per_producer, chain::plugin_config_exception,
+                       "Too many p2p-bp-gossip-endpoint for ${a}, max ${m}", ("a", account)("m", max_bp_gossip_peers_per_producer));
          } catch (chain::name_type_exception&) {
             EOS_ASSERT(false, chain::plugin_config_exception,
                        "The account ${a} supplied by --p2p-bp-gossip-endpoint option is invalid", ("a", aname));
@@ -215,42 +220,43 @@ public:
       block_timestamp_type expire = self()->head_block_time.load() + bp_gossip_peer_expiration;
       fc_dlog(self()->get_logger(), "Updating BP gossip_bp_peers_message with expiration ${e}", ("e", expire));
       for (const auto& my_bp_account : config.my_bp_gossip_accounts) { // my_bp_gossip_accounts not modified after plugin startup
-         for (const auto& le : config.bp_gossip_endpoints) {
-            fc_dlog(self()->get_logger(), "Updating BP gossip_bp_peers_message for ${a} address ${s}", ("a", my_bp_account)("s", le.server_endpoint));
-            std::optional<peer_info_t> peer_info = cc.get_peer_info(my_bp_account);
-            if (peer_info && peer_info->key) {
-               if (!initial_updated) {
-                  // update initial so always an active one
-                  gossip_bp_peers_message::signed_bp_peer signed_empty{{.producer_name = my_bp_account}}; // .server_endpoint not set for initial message
-                  signed_empty.sig = self()->sign_compact(*peer_info->key, signed_empty.digest());
-                  EOS_ASSERT(signed_empty.sig != signature_type{}, chain::plugin_config_exception,
-                             "Unable to sign empty gossip bp peer, private key not found for ${k}", ("k", peer_info->key->to_string({})));
-                  initial_gossip_msg_factory.set_initial_send_buffer(signed_empty);
-                  initial_updated = true;
-               }
-               // update gossip_bps
-               auto& prod_idx = gossip_bps.index.get<by_producer>();
-               gossip_bp_peers_message::signed_bp_peer peer{
-                  { .producer_name = my_bp_account,
-                    .server_endpoint = le.server_endpoint,
-                    .outbound_ip_address = le.outbound_ip_address,
-                    .expiration = expire }
-               };
-               peer.sig = self()->sign_compact(*peer_info->key, peer.digest());
-               EOS_ASSERT(peer.sig != signature_type{}, chain::plugin_config_exception,
-                          "Unable to sign bp peer ${p}, private key not found for ${k}", ("p", peer.producer_name)("k", peer_info->key->to_string({})));
-               if (auto i = prod_idx.find(boost::make_tuple(my_bp_account, boost::cref(le.server_endpoint))); i != prod_idx.end()) {
-                  gossip_bps.index.modify(i, [&peer](auto& v) {
-                     v.outbound_ip_address = peer.outbound_ip_address;
-                     v.expiration = peer.expiration;
-                     v.sig = peer.sig;
-                  });
-               } else {
-                  gossip_bps.index.emplace(peer);
-               }
-            } else {
-               fc_wlog(self()->get_logger(), "On-chain peer-key not found for configured BP ${a}", ("a", my_bp_account));
+         const auto& bp_account = my_bp_account.first;
+         std::optional<peer_info_t> peer_info = cc.get_peer_info(bp_account);
+         if (peer_info && peer_info->key) {
+            for (const auto& le : my_bp_account.second) {
+               fc_dlog(self()->get_logger(), "Updating BP gossip_bp_peers_message for ${a} address ${s}", ("a", bp_account)("s", le.server_endpoint));
+                  if (!initial_updated) {
+                     // update initial so always an active one
+                     gossip_bp_peers_message::signed_bp_peer signed_empty{{.producer_name = bp_account}}; // .server_endpoint not set for initial message
+                     signed_empty.sig = self()->sign_compact(*peer_info->key, signed_empty.digest());
+                     EOS_ASSERT(signed_empty.sig != signature_type{}, chain::plugin_config_exception,
+                                "Unable to sign empty gossip bp peer of ${a}, private key not found for ${k}", ("a", bp_account)("k", peer_info->key->to_string({})));
+                     initial_gossip_msg_factory.set_initial_send_buffer(signed_empty);
+                     initial_updated = true;
+                  }
+                  // update gossip_bps
+                  auto& prod_idx = gossip_bps.index.get<by_producer>();
+                  gossip_bp_peers_message::signed_bp_peer peer{
+                     { .producer_name = bp_account,
+                       .server_endpoint = le.server_endpoint,
+                       .outbound_ip_address = le.outbound_ip_address,
+                       .expiration = expire }
+                  };
+                  peer.sig = self()->sign_compact(*peer_info->key, peer.digest());
+                  EOS_ASSERT(peer.sig != signature_type{}, chain::plugin_config_exception,
+                             "Unable to sign bp peer ${p}, private key not found for ${k}", ("p", peer.producer_name)("k", peer_info->key->to_string({})));
+                  if (auto i = prod_idx.find(boost::make_tuple(bp_account, boost::cref(le.server_endpoint))); i != prod_idx.end()) {
+                     gossip_bps.index.modify(i, [&peer](auto& v) {
+                        v.outbound_ip_address = peer.outbound_ip_address;
+                        v.expiration = peer.expiration;
+                        v.sig = peer.sig;
+                     });
+                  } else {
+                     gossip_bps.index.emplace(peer);
+                  }
             }
+         } else {
+            fc_wlog(self()->get_logger(), "On-chain peer-key not found for configured BP ${a}", ("a", bp_account));
          }
       }
    }

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -378,11 +378,11 @@ public:
       };
 
       const auto head_block_time = self()->head_block_time.load();
-      const block_timestamp_type expire = head_block_time + bp_gossip_peer_expiration_variance;
+      const block_timestamp_type latest_acceptable_expiration_time = head_block_time + bp_gossip_peer_expiration_variance;
       auto is_expiration_valid = [&](const gossip_bp_peers_message::signed_bp_peer& peer) -> bool {
          if (initial_msg)
             return true; // initial message has no expiration
-         return peer.expiration > head_block_time && peer.expiration < expire;
+         return peer.expiration > head_block_time && peer.expiration < latest_acceptable_expiration_time;
       };
 
       fc::lock_guard g(gossip_bps.mtx);

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -21,7 +21,7 @@ class bp_connection_manager {
  public:
 #endif
 
-   static constexpr size_t max_bp_peers_per_producer = 4;
+   static constexpr size_t max_bp_peers_per_producer = 8;
    gossip_bp_index_t      gossip_bps;
 
    struct listen_endpoint_t {
@@ -210,7 +210,7 @@ public:
                gossip_bp_peers_message::bp_peer peer{
                   .producer_name = my_bp_account,
                   .server_address = le.server_address,
-                  .outbound_server_address = le.outbound_server_address};
+                  .outbound_server_address = le.outbound_address};
                peer.sig = self()->sign_compact(*peer_info->key, peer.digest());
                EOS_ASSERT(peer.sig != signature_type{}, chain::plugin_config_exception,
                           "Unable to sign bp peer ${p}, private key not found for ${k}", ("p", peer.producer_name)("k", peer_info->key->to_string({})));

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -452,5 +452,15 @@ public:
          active_schedule_version = schedule.version;
       }
    }
+
+   // RPC called from http threads
+   vector<gossip_bp_peers_message::bp_peer> bp_gossip_peers() const {
+      fc::lock_guard g(gossip_bps.mtx);
+      vector<gossip_bp_peers_message::bp_peer> peers;
+      for (const auto& p : gossip_bps.index) {
+         peers.emplace_back(p);
+      }
+      return peers;
+   }
 };
 } // namespace eosio::auto_bp_peering

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -58,14 +58,14 @@ class bp_connection_manager {
    Derived*       self() { return static_cast<Derived*>(this); }
    const Derived* self() const { return static_cast<const Derived*>(this); }
 
-   template <template <typename...> typename Container, typename... Rest>
-   requires std::is_same_v<typename Container<account_name, Rest...>::value_type, account_name>
-   static std::string to_string(const Container<account_name, Rest...>& peers) {
+   template <typename Container>
+   requires std::is_same_v<typename Container::value_type, account_name>
+   static std::string to_string(const Container& peers) {
       return boost::algorithm::join(peers | boost::adaptors::transformed([](auto& p) { return p.to_string(); }), ",");
    }
-   template <template <typename...> typename Container, typename... Rest>
-   requires std::is_same_v<typename Container<std::string, Rest...>::value_type, std::string>
-   static std::string to_string(const Container<std::string, Rest...>& peers) {
+   template <typename Container>
+   requires std::is_same_v<typename Container::value_type, std::string>
+   static std::string to_string(const Container& peers) {
       return boost::algorithm::join(peers, ",");
    }
 

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -58,14 +58,14 @@ class bp_connection_manager {
    Derived*       self() { return static_cast<Derived*>(this); }
    const Derived* self() const { return static_cast<const Derived*>(this); }
 
-   template <typename Container>
-   requires std::is_same_v<typename Container::value_type, account_name>
-   static std::string to_string(const Container& peers) {
+   template <template <typename...> typename Container, typename... Rest>
+   requires std::is_same_v<typename Container<account_name, Rest...>::value_type, account_name>
+   static std::string to_string(const Container<account_name, Rest...>& peers) {
       return boost::algorithm::join(peers | boost::adaptors::transformed([](auto& p) { return p.to_string(); }), ",");
    }
-   template <typename Container>
-   requires std::is_same_v<typename Container::value_type, std::string>
-   static std::string to_string(const Container& peers) {
+   template <template <typename...> typename Container, typename... Rest>
+   requires std::is_same_v<typename Container<std::string, Rest...>::value_type, std::string>
+   static std::string to_string(const Container<std::string, Rest...>& peers) {
       return boost::algorithm::join(peers, ",");
    }
 

--- a/plugins/net_plugin/include/eosio/net_plugin/buffer_factory.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/buffer_factory.hpp
@@ -156,7 +156,7 @@ namespace eosio {
          const uint32_t which_size = fc::raw::pack_size( unsigned_int( which ) );
          // content size
          size_t s = fc::raw::pack_size( unsigned_int((uint32_t)gossip_bp_peers.index.size()) ); // match vector pack
-         for (const auto& peer : gossip_bp_peers.index.get<by_producer>()) {
+         for (const gossip_bp_peers_message::signed_bp_peer& peer : gossip_bp_peers.index.get<by_producer>()) {
             s += fc::raw::pack_size( peer );
          }
          const uint32_t payload_size = which_size + s;
@@ -169,7 +169,7 @@ namespace eosio {
          ds.write( header, message_header_size );
          fc::raw::pack( ds, unsigned_int( which ) );
          fc::raw::pack( ds, unsigned_int((uint32_t)gossip_bp_peers.index.size()) );
-         for (const auto& peer : gossip_bp_peers.index.get<by_producer>()) {
+         for (const gossip_bp_peers_message::signed_bp_peer& peer : gossip_bp_peers.index.get<by_producer>()) {
             fc::raw::pack( ds, peer );
          }
 
@@ -180,7 +180,7 @@ namespace eosio {
    struct gossip_buffer_initial_factory : public buffer_factory {
 
       // called on startup
-      void set_initial_send_buffer(const gossip_bp_peers_message::bp_peer& signed_empty) {
+      void set_initial_send_buffer(const gossip_bp_peers_message::signed_bp_peer& signed_empty) {
          send_buffer = create_initial_send_buffer(signed_empty);
       }
 
@@ -191,7 +191,7 @@ namespace eosio {
 
    private:
 
-      static send_buffer_type create_initial_send_buffer(const gossip_bp_peers_message::bp_peer& signed_empty) {
+      static send_buffer_type create_initial_send_buffer(const gossip_bp_peers_message::signed_bp_peer& signed_empty) {
          constexpr uint32_t which = to_index(msg_type_t::gossip_bp_peers_message);
 
          // match net_message static_variant pack

--- a/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
@@ -11,11 +11,11 @@ namespace eosio {
 
 struct gossip_bp_index_t {
    using gossip_bps_index_container_t = boost::multi_index_container<
-      gossip_bp_peers_message::bp_peer,
+      gossip_bp_peers_message::signed_bp_peer,
       indexed_by<
          ordered_unique<
             tag<struct by_producer>,
-            composite_key< gossip_bp_peers_message::bp_peer,
+            composite_key< gossip_bp_peers_message::signed_bp_peer,
                member<gossip_bp_peers_message::bp_peer, name, &gossip_bp_peers_message::bp_peer::producer_name>,
                member<gossip_bp_peers_message::bp_peer, std::string, &gossip_bp_peers_message::bp_peer::server_address>
             >,
@@ -23,7 +23,7 @@ struct gossip_bp_index_t {
          >,
          ordered_unique<
             tag< struct by_sig >,
-            member< gossip_bp_peers_message::bp_peer, chain::signature_type, &gossip_bp_peers_message::bp_peer::sig > >
+            member< gossip_bp_peers_message::signed_bp_peer, chain::signature_type, &gossip_bp_peers_message::signed_bp_peer::sig > >
          >
       >;
 

--- a/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
@@ -21,10 +21,15 @@ struct gossip_bp_index_t {
             >,
             composite_key_compare< std::less<>, std::less<> >
          >,
+         ordered_non_unique<
+            tag< struct by_expiry >,
+            member< gossip_bp_peers_message::bp_peer, block_timestamp_type, &gossip_bp_peers_message::bp_peer::expiration >
+         >,
          ordered_unique<
             tag< struct by_sig >,
-            member< gossip_bp_peers_message::signed_bp_peer, chain::signature_type, &gossip_bp_peers_message::signed_bp_peer::sig > >
+            member< gossip_bp_peers_message::signed_bp_peer, chain::signature_type, &gossip_bp_peers_message::signed_bp_peer::sig >
          >
+      >
       >;
 
    alignas(hardware_destructive_interference_sz)

--- a/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
@@ -17,7 +17,7 @@ struct gossip_bp_index_t {
             tag<struct by_producer>,
             composite_key< gossip_bp_peers_message::signed_bp_peer,
                member<gossip_bp_peers_message::bp_peer, name, &gossip_bp_peers_message::bp_peer::producer_name>,
-               member<gossip_bp_peers_message::bp_peer, std::string, &gossip_bp_peers_message::bp_peer::server_address>
+               member<gossip_bp_peers_message::bp_peer, std::string, &gossip_bp_peers_message::bp_peer::server_endpoint>
             >,
             composite_key_compare< std::less<>, std::less<> >
          >,

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -41,6 +41,7 @@ namespace eosio {
         string                            disconnect( const string& endpoint );
         std::optional<connection_status>  status( const string& endpoint )const;
         vector<connection_status>         connections()const;
+        vector<gossip_bp_peers_message::bp_peer> bp_gossip_peers()const;
 
         struct p2p_per_connection_metrics {
             struct connection_metric {

--- a/plugins/net_plugin/include/eosio/net_plugin/net_utils.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_utils.hpp
@@ -127,7 +127,7 @@ namespace detail {
    inline std::tuple<std::string, std::string, std::string> split_host_port_type(const std::string& peer_add) {
 
       using std::string;
-      // host:port[:trx|:blk][:nobpgoss][:<rate>]   // nobpgoss & rate are discarded
+      // host:port[:trx|:blk][:<rate>]   // rate is discarded
       if (peer_add.empty()) return {};
 
       constexpr bool should_throw = false;

--- a/plugins/net_plugin/include/eosio/net_plugin/net_utils.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_utils.hpp
@@ -127,7 +127,7 @@ namespace detail {
    inline std::tuple<std::string, std::string, std::string> split_host_port_type(const std::string& peer_add) {
 
       using std::string;
-      // host:port[:trx|:blk][:<rate>]   // rate is discarded
+      // host:port[:trx|:blk][:nobpgoss][:<rate>]   // nobpgoss & rate are discarded
       if (peer_add.empty()) return {};
 
       constexpr bool should_throw = false;

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -140,13 +140,15 @@ namespace eosio {
       struct bp_peer {
          eosio::name               producer_name;
          std::string               server_address;
-         // sig over [producer_name, server_address]
+         std::string               outbound_server_address;
+         // sig over [producer_name, server_address, outbound_server_address]
          signature_type            sig;
 
          digest_type digest() const;
          bool operator==(const bp_peer&) const = default;
          bool operator<(const bp_peer& rhs) const {
-            return std::tie(producer_name, server_address) < std::tie(rhs.producer_name, rhs.server_address);
+            return std::tie(producer_name, server_address, outbound_server_address) <
+                   std::tie(rhs.producer_name, rhs.server_address, rhs.outbound_server_address);
          }
       };
 
@@ -215,7 +217,7 @@ FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
 FC_REFLECT( eosio::block_nack_message, (id) )
 FC_REFLECT( eosio::block_notice_message, (previous)(id) )
-FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(server_address)(sig) )
+FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(server_address)(outbound_server_address)(sig) )
 FC_REFLECT( eosio::gossip_bp_peers_message, (peers) )
 
 /**

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -139,16 +139,16 @@ namespace eosio {
    struct gossip_bp_peers_message {
       struct bp_peer {
          eosio::name               producer_name;
-         std::string               server_address;          // externally available address to connect to
-         std::string               outbound_server_address; // empty if equal to server_address host
+         std::string               server_endpoint;         // externally available address to connect to
+         std::string               outbound_ip_address;     // empty if equal to server_endpoint ip address
          block_timestamp_type      expiration;              // head block to remove bp_peer
 
          digest_type digest() const;
 
-         bool operator==(const bp_peer&) const = default; // todo: only compare producer_name, server_address ?
+         bool operator==(const bp_peer&) const = default;
          bool operator<(const bp_peer& rhs) const {
-            // [producer_name, server_address] is unique
-            return std::tie(producer_name, server_address) < std::tie(rhs.producer_name, rhs.server_address);
+            // [producer_name, server_endpoint] is unique
+            return std::tie(producer_name, server_endpoint) < std::tie(rhs.producer_name, rhs.server_endpoint);
          }
       };
       struct signed_bp_peer : bp_peer {
@@ -220,7 +220,7 @@ FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
 FC_REFLECT( eosio::block_nack_message, (id) )
 FC_REFLECT( eosio::block_notice_message, (previous)(id) )
-FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(server_address)(outbound_server_address)(expiration) )
+FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(server_endpoint)(outbound_ip_address)(expiration) )
 FC_REFLECT_DERIVED(eosio::gossip_bp_peers_message::signed_bp_peer, (eosio::gossip_bp_peers_message::bp_peer), (sig) )
 FC_REFLECT( eosio::gossip_bp_peers_message, (peers) )
 

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -139,20 +139,23 @@ namespace eosio {
    struct gossip_bp_peers_message {
       struct bp_peer {
          eosio::name               producer_name;
-         std::string               server_address;
-         std::string               outbound_server_address;
-         // sig over [producer_name, server_address, outbound_server_address]
-         signature_type            sig;
+         std::string               server_address;          // externally available address to connect to
+         std::string               outbound_server_address; // empty if equal to server_address host
+         block_timestamp_type      expiration;              // head block to remove bp_peer
 
          digest_type digest() const;
-         bool operator==(const bp_peer&) const = default;
+
+         bool operator==(const bp_peer&) const = default; // todo: only compare producer_name, server_address ?
          bool operator<(const bp_peer& rhs) const {
-            return std::tie(producer_name, server_address, outbound_server_address) <
-                   std::tie(rhs.producer_name, rhs.server_address, rhs.outbound_server_address);
+            // [producer_name, server_address] is unique
+            return std::tie(producer_name, server_address) < std::tie(rhs.producer_name, rhs.server_address);
          }
       };
+      struct signed_bp_peer : bp_peer {
+         signature_type            sig;
+      };
 
-      std::vector<bp_peer> peers;
+      std::vector<signed_bp_peer> peers;
    };
 
    using net_message = std::variant<handshake_message,
@@ -217,7 +220,8 @@ FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
 FC_REFLECT( eosio::block_nack_message, (id) )
 FC_REFLECT( eosio::block_notice_message, (previous)(id) )
-FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(server_address)(outbound_server_address)(sig) )
+FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(server_address)(outbound_server_address)(expiration) )
+FC_REFLECT_DERIVED(eosio::gossip_bp_peers_message::signed_bp_peer, (eosio::gossip_bp_peers_message::bp_peer), (sig) )
 FC_REFLECT( eosio::gossip_bp_peers_message, (peers) )
 
 /**

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -823,6 +823,7 @@ namespace eosio {
       string                  log_remote_endpoint_port;
       string                  local_endpoint_ip;
       string                  local_endpoint_port;
+      string                  short_agent_name;
       // kept in sync with last_handshake_recv.fork_db_root_num, only accessed from connection strand
       uint32_t                peer_fork_db_root_num = 0;
 
@@ -1034,6 +1035,7 @@ namespace eosio {
             ( "_port", log_remote_endpoint_port )
             ( "_lip", local_endpoint_ip )
             ( "_lport", local_endpoint_port )
+            ( "_agent", short_agent_name )
             ( "_nver", protocol_version.load() );
          return mvo;
       }
@@ -3282,6 +3284,7 @@ namespace eosio {
             return;
          }
 
+         short_agent_name = msg.agent.substr( msg.agent.size() > 1 && msg.agent[0] == '"' ? 1 : 0, 15);
          log_p2p_address = msg.p2p_address;
          fc::unique_lock g_conn( conn_mtx );
          p2p_address = msg.p2p_address;
@@ -4293,7 +4296,7 @@ namespace eosio {
            "    eosproducer3,p2p.blk.eos.io:9876:blk\n")
          ("p2p-producer-peer", boost::program_options::value<vector<string>>()->composing()->multitoken(),
            "Producer peer name of this node used to retrieve peer key from on-chain peerkeys table. Private key of peer key should be configured via signature-provider.")
-         ( "agent-name", bpo::value<string>()->default_value("EOS Test Agent"), "The name supplied to identify this node amongst the peers.")
+         ( "agent-name", bpo::value<string>()->default_value("Vault Agent"), "The name supplied to identify this node amongst the peers.")
          ( "allowed-connection", bpo::value<vector<string>>()->multitoken()->default_value({"any"}, "any"), "Can be 'any' or 'producers' or 'specified' or 'none'. If 'specified', peer-key must be specified at least once. If only 'producers', peer-key is not required. 'producers' and 'specified' may be combined.")
          ( "peer-key", bpo::value<vector<string>>()->composing()->multitoken(), "Optional public key of peer allowed to connect.  May be used multiple times.")
          ( "peer-private-key", bpo::value<vector<string>>()->composing()->multitoken(),
@@ -4321,6 +4324,7 @@ namespace eosio {
            "   _port  \tremote port number of peer\n\n"
            "   _lip   \tlocal IP address connected to peer\n\n"
            "   _lport \tlocal port number connected to peer\n\n"
+           "   _agent \tfirst 15 characters of agent-name of peer\n\n"
            "   _nver  \tp2p protocol version\n\n")
          ( "p2p-keepalive-interval-ms", bpo::value<int>()->default_value(def_keepalive_interval), "peer heartbeat keepalive message interval in milliseconds")
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3741,9 +3741,7 @@ namespace eosio {
    digest_type gossip_bp_peers_message::bp_peer::digest() const {
       digest_type::encoder enc;
       fc::raw::pack(enc, my_impl->chain_id);
-      fc::raw::pack(enc, producer_name);
-      fc::raw::pack(enc, server_address);
-
+      fc::raw::pack(enc, *this);
       return enc.result();
    }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4640,6 +4640,10 @@ namespace eosio {
       return my->connections.connection_statuses();
    }
 
+   vector<gossip_bp_peers_message::bp_peer> net_plugin::bp_gossip_peers()const {
+      return my->bp_gossip_peers();
+   }
+
    constexpr uint16_t net_plugin_impl::to_protocol_version(uint16_t v) {
       if (v >= net_version_base) {
          v -= net_version_base;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4268,9 +4268,9 @@ namespace eosio {
            " The optional 'trx' and 'blk' indicates to peers that only transactions 'trx' or blocks 'blk' should be sent."
            " Examples:\n"
            "   192.168.0.100:9876:1MiB/s\n"
-           "   node.eos.io:9876:trx:1512KB/s\n"
-           "   node.eos.io:9876:0.5GB/s\n"
-           "   [2001:db8:85a3:8d3:1319:8a2e:370:7348]:9876:250KB/s")
+           "   node.eos.io:9877:trx:1512KB/s\n"
+           "   node.eos.io:9878:0.5GB/s\n"
+           "   [2001:db8:85a3:8d3:1319:8a2e:370:7348]:9879:250KB/s")
          ( "p2p-server-address", bpo::value< vector<string> >(),
            "An externally accessible host:port for identifying this node. Defaults to p2p-listen-endpoint."
            " May be used as many times as p2p-listen-endpoint."

--- a/plugins/net_plugin/tests/auto_bp_peering_unittest.cpp
+++ b/plugins/net_plugin/tests/auto_bp_peering_unittest.cpp
@@ -84,18 +84,18 @@ BOOST_AUTO_TEST_CASE(test_set_bp_peers) {
          "producer3,127.0.0.1:8890"s,
          "producer4,127.0.0.1:8891"s
    });
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer1"_n], endpoint("127.0.0.1", "8888"));
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer2"_n], endpoint("127.0.0.1", "8889"));
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer3"_n], endpoint("127.0.0.1", "8890"));
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer4"_n], endpoint("127.0.0.1", "8891"));
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_addresses["producer1"_n], endpoint("127.0.0.1", "8888"));
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_addresses["producer2"_n], endpoint("127.0.0.1", "8889"));
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_addresses["producer3"_n], endpoint("127.0.0.1", "8890"));
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_addresses["producer4"_n], endpoint("127.0.0.1", "8891"));
 
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_accounts[endpoint("127.0.0.1", "8888")], "producer1"_n);
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_accounts[endpoint("127.0.0.1", "8889")], "producer2"_n);
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_accounts[endpoint("127.0.0.1", "8890")], "producer3"_n);
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_accounts[endpoint("127.0.0.1", "8891")], "producer4"_n);
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_accounts[endpoint("127.0.0.1", "8888")], "producer1"_n);
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_accounts[endpoint("127.0.0.1", "8889")], "producer2"_n);
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_accounts[endpoint("127.0.0.1", "8890")], "producer3"_n);
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_accounts[endpoint("127.0.0.1", "8891")], "producer4"_n);
 }
 
-bool operator==(const eosio::chain::peer_name_set_t& a, const eosio::chain::peer_name_set_t& b) {
+bool operator==(const eosio::chain::name_set_t& a, const eosio::chain::name_set_t& b) {
    return std::equal(a.begin(), a.end(), b.begin(), b.end());
 }
 
@@ -104,7 +104,7 @@ bool operator==(const std::vector<std::string>& a, const std::vector<std::string
 }
 
 namespace boost::container {
-std::ostream& boost_test_print_type(std::ostream& os, const eosio::chain::peer_name_set_t& accounts) {
+std::ostream& boost_test_print_type(std::ostream& os, const eosio::chain::name_set_t& accounts) {
    os << "{";
    const char* sep = "";
    for (auto e : accounts) {
@@ -148,7 +148,7 @@ const eosio::chain::producer_authority_schedule test_schedule2{
      { "prodd"_n, {} }, { "prodh"_n, {} }, { "prodl"_n, {} } }
 };
 
-const eosio::chain::peer_name_set_t producers_minus_prodkt{
+const eosio::chain::name_set_t producers_minus_prodkt{
    "proda"_n, "prodb"_n, "prodc"_n, "prodd"_n, "prode"_n, "prodf"_n,
    "prodg"_n, "prodh"_n, "prodi"_n, "prodj"_n,
    // "prodk"_n, not part of the peer addresses
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    plugin.on_pending_schedule(test_schedule1);
 
    BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{}));
-   BOOST_TEST(plugin.pending_bps == (eosio::chain::peer_name_set_t{ "prodj"_n, "prodm"_n }));
+   BOOST_TEST(plugin.pending_bps == (eosio::chain::name_set_t{ "prodj"_n, "prodm"_n }));
    BOOST_CHECK_EQUAL(plugin.pending_schedule_version, 0u);
 
    // when it is in sync and on_pending_schedule is called
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{}));
 
    plugin.on_pending_schedule(reset_schedule1);
-   BOOST_TEST(plugin.pending_bps == eosio::chain::peer_name_set_t{});
+   BOOST_TEST(plugin.pending_bps == eosio::chain::name_set_t{});
 }
 
 BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
    plugin.on_active_schedule(test_schedule1);
 
    BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{}));
-   BOOST_TEST(plugin.get_active_bps() == (eosio::chain::peer_name_set_t{ "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n }));
+   BOOST_TEST(plugin.get_active_bps() == (eosio::chain::name_set_t{ "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n }));
    BOOST_CHECK_EQUAL(plugin.active_schedule_version, 0u);
 
    // when it is in sync and on_active_schedule is called

--- a/tests/auto_bp_gossip_peering_test.py
+++ b/tests/auto_bp_gossip_peering_test.py
@@ -141,6 +141,8 @@ try:
         # retrieve the connections in each node and check if each connects to the other bps in the schedule
         connections = cluster.nodes[nodeId].processUrllibRequest("net", "connections")
         if Utils.Debug: Utils.Print(f"v1/net/connections: {connections}")
+        bp_peers = cluster.nodes[nodeId].processUrllibRequest("net", "bp_gossip_peers")
+        if Utils.Debug: Utils.Print(f"v1/net/bp_gossip_peers: {bp_peers}")
         peers = []
         for conn in connections["payload"]:
             if conn["is_socket_open"] is False:
@@ -166,6 +168,11 @@ try:
             Utils.Print(f"ERROR: expect {name} has connections to {scheduled_producers}, got connections to {peers}")
             connection_failure = True
             break
+        for p in bp_peers["payload"]:
+            if p["producer_name"] not in peers:
+                Utils.Print(f"ERROR: expect bp peer {p} in peer list")
+                connection_failure = True
+                break
 
     testSuccessful = not connection_failure
 

--- a/tests/auto_bp_gossip_peering_test.py
+++ b/tests/auto_bp_gossip_peering_test.py
@@ -168,11 +168,16 @@ try:
             Utils.Print(f"ERROR: expect {name} has connections to {scheduled_producers}, got connections to {peers}")
             connection_failure = True
             break
+        num_peers_found = 0
         for p in bp_peers["payload"]:
             if p["producer_name"] not in peers:
                 Utils.Print(f"ERROR: expect bp peer {p} in peer list")
                 connection_failure = True
                 break
+            else:
+                num_peers_found += 1
+
+        assert(num_peers_found == len(peers))
 
     testSuccessful = not connection_failure
 

--- a/tests/auto_bp_gossip_peering_test.py
+++ b/tests/auto_bp_gossip_peering_test.py
@@ -125,9 +125,11 @@ try:
             errorExit(f"Failed to relaunch node {nodeId}")
 
     # give time for messages to be gossiped around
+    cluster.getNode(producerNodes-1).waitForHeadToAdvance(blocksToAdvance=60)
+    blockNum = cluster.getNode(0).getBlockNum()
     for nodeId in range(0, producerNodes):
-        Utils.Print("Wait for defproducert on node ", nodeId)
-        cluster.getNode(nodeId).waitForHeadToAdvance(5)
+        Utils.Print(f"Wait for block ${blockNum} on node ", nodeId)
+        cluster.getNode(nodeId).waitForBlock(blockNum)
 
     # retrieve the producer stable producer schedule
     scheduled_producers = []

--- a/tests/auto_bp_gossip_peering_test.py
+++ b/tests/auto_bp_gossip_peering_test.py
@@ -9,8 +9,8 @@ from TestHarness import Cluster, TestHelper, Utils, WalletMgr, createAccountKeys
 # auto_bp_gossip_peering_test
 #
 # This test sets up  a cluster with 21 producers nodeos, each nodeos is configured with only one producer and only
-# connects to the bios node. Moreover, each producer nodeos is also configured with a p2p-producer-peer so that each
-# one can automatically establish p2p connections to other bps. Test verifies connections are established when
+# connects to the bios node. Moreover, each producer nodeos is also configured with a p2p-bp-gossip-endpoint so that
+# each one can automatically establish p2p connections to other bps. Test verifies connections are established when
 # producer schedule is active.
 #
 ###############################################################
@@ -115,13 +115,14 @@ try:
         Utils.Print("Wait for last regpeerkey to be final on ", nodeId)
         cluster.getNode(nodeId).waitForTransFinalization(trans['transaction_id'])
 
-    # relaunch with p2p-producer-peer
+    # relaunch with p2p-bp-gossip-endpoint
     for nodeId in range(0, producerNodes):
-        Utils.Print(f"Relaunch node {nodeId} with p2p-producer-peer")
+        Utils.Print(f"Relaunch node {nodeId} with p2p-bp-gossip-endpoint")
         node = cluster.getNode(nodeId)
         node.kill(signal.SIGTERM)
         producer_name = "defproducer" + chr(ord('a') + nodeId)
-        if not node.relaunch(chainArg=" --enable-stale-production --p2p-producer-peer " + producer_name):
+        server_address = getHostName(nodeId)
+        if not node.relaunch(chainArg=f" --enable-stale-production --p2p-bp-gossip-endpoint {producer_name},{server_address},127.0.0.1"):
             errorExit(f"Failed to relaunch node {nodeId}")
 
     # give time for messages to be gossiped around


### PR DESCRIPTION
 
- Add new `p2p-bp-gossip-endpoint <producer account>,<advertised inbound connection endpoint>,<outbound connection IP address>`
    - Where `<producer account>` is the previous `p2p-producer-peer`. The BP producer account used for producing and used for registering an on-chain producer peer key.
    - Where `<advertised inbound connection endpoint>` is an externally reachable IP address or domain name with port.
    - Where `<outbound connection IP address>` is the IP address this node will connection from. This is provided so that BPs using a firewall can add this entry to allow connection. Required and must be a valid IP address.
    - Only communicated over bp gossip messages, not sent to non-bp-gossip peers.
    - `p2p-bp-gossip-endpoint` can be specified more than once if multiple endpoints for a node should be gossiped or if in a test network more than one BP peer key is handled by the nodeos.
    - `<producer account>`, `<advertised inbound connection endpoint>` combination must be unique. 8 unique bp gossip entries are allowed across all BP nodes for a specific producer account.
    - Examples for producer `defproda`:
      -  `p2p-bp-gossip-endpoint = defproda,p2p.proddomain.com:9876,173.194.219.100`
      -  `p2p-bp-gossip-endpoint = defproda,p2p.proddomain2.com:9875,173.194.219.99`

- Add `expiration` to `gossip_bp_peers_message::bp_peer`
  - Part of the signed data
  - Used to time-out a `bp_peer` entry
  - Hard code expiration time to be 1hr.
  - Use head-block time + expiration time.
  - Configured `p2p-bp-gossip-endpoint` will send out an updated signed `bp_peer` entry every 1/2 of expiration time (30 minutes) which will be gossiped to all its bp gossip peers.
  - Error if expiration greater than 1.25 hr of current block time.
  - Error if expiration less than current block time.
  - Remove bp_peer entries when they expire
  - If more than 8 `bp_peer` entries received from single producer than Error.
  - Update existing expiration of bp_peers that match same [`producer_name`,`server_endpoint`.]

- Increase from 4 to 8 allowed `bp_peer` entries per producer.
  - Duplicate connections will naturally be de-dupped by peer.

- Add API `/v1/net/bp_gossip_peers` which will return the current set of known bp gossip peers.
  - Include all information in `gossip_bp_peers_message::bp_peer`
  - Can be queried to retrieve data for firewall

- Add `agent-name` as an option of `peer-log-format` so it can be included in every peer log statement if desired.
 
- Update p2p help with valid examples.

```
  --p2p-bp-gossip-endpoint arg          The BP account, inbound connection
                                        endpoint, outbound connection IP
                                        address. The BP account is the producer
                                        peer name to retrieve peer-key from
                                        on-chain peerkeys table registered
                                        on-chain via regpeerkey action. The
                                        inbound connection endpoint is
                                        typically the listen endpoint of this
                                        node. The outbound connection IP
                                        address is typically the IP address of
                                        this node. Peer will use this value to
                                        allow access through firewall. Private
                                        key of peer-key should be configured
                                        via signature-provider.
                                         Syntax: bp_account,inbound_endpoint,ou
                                        tbound_ip_address
                                         Example:
                                           myprod,myhostname.com:9876,198.51.10
                                        0.1
                                           myprod,myhostname2.com:9876,[2001:0d
                                        b8:85a3:0000:0000:8a2e:0370:7334]
```

Resolves #1496