### PR TITLE
remove abieos usage from state history tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "libraries/rapidjson"]
 	path = libraries/rapidjson
 	url = https://github.com/Tencent/rapidjson/
-[submodule "tests/abieos"]
-	path = tests/abieos
-	url = https://github.com/AntelopeIO/abieos
 [submodule "libraries/libfc/include/fc/crypto/webauthn_json"]
 	path = libraries/libfc/include/fc/crypto/webauthn_json
 	url = https://github.com/Tencent/rapidjson/

--- a/libraries/state_history/abi.cpp
+++ b/libraries/state_history/abi.cpp
@@ -1,3 +1,6 @@
+#include <eosio/state_history/abi.hpp>
+#include <regex>
+
 extern const char* const state_history_plugin_abi = R"({
     "version": "eosio::abi/1.1",
     "structs": [
@@ -738,3 +741,10 @@ extern const char* const state_history_plugin_abi = R"({
         { "name": "resource_limits_config", "type": "resource_limits_config", "key_names": [] }
     ]
 })";
+
+namespace eosio::state_history {
+std::string ship_abi_without_tables() {
+    std::regex scrub_all_tables(R"(\{ "name": "[^"]+", "type": "[^"]+", "key_names": \[[^\]]*\] \},?)");
+    return std::regex_replace(state_history_plugin_abi, scrub_all_tables, "");
+}
+}

--- a/libraries/state_history/include/eosio/state_history/abi.hpp
+++ b/libraries/state_history/include/eosio/state_history/abi.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+namespace eosio::state_history {
+std::string ship_abi_without_tables();
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,17 +129,6 @@ add_np_test(NAME block_log_util_if_test COMMAND tests/block_log_util_test.py --a
 add_np_test(NAME block_log_retain_blocks_test COMMAND tests/block_log_retain_blocks_test.py -v ${UNSHARE})
 add_np_test(NAME block_log_retain_blocks_if_test COMMAND tests/block_log_retain_blocks_test.py --activate-if -v ${UNSHARE})
 
-option(ABIEOS_ONLY_LIBRARY "define and build the ABIEOS library" ON)
-set(ABIEOS_INSTALL_COMPONENT "dev")
-set(SKIP_SUBMODULE_TEST ON)
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-   set(CMAKE_BUILD_TYPE "StopAbieosFromTouchingThis")
-   add_subdirectory(abieos)
-   unset(CMAKE_BUILD_TYPE)
-else()
-   add_subdirectory(abieos)
-endif()
-
 add_subdirectory( TestHarness )
 add_subdirectory( trx_generator )
 add_subdirectory( PerformanceHarness )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,9 +146,9 @@ add_subdirectory( PerformanceHarness )
 
 find_package(Threads)
 add_executable(ship_client ship_client.cpp)
-target_link_libraries(ship_client abieos Boost::program_options Boost::system Boost::algorithm Boost::asio Boost::beast Threads::Threads)
+target_link_libraries(ship_client eosio_chain Boost::program_options Boost::system Boost::algorithm Boost::asio Boost::beast Threads::Threads)
 add_executable(ship_streamer ship_streamer.cpp)
-target_link_libraries(ship_streamer abieos Boost::program_options Boost::system Boost::asio Boost::beast Threads::Threads)
+target_link_libraries(ship_streamer eosio_chain Boost::program_options Boost::system Boost::asio Boost::beast Threads::Threads)
 
 add_np_test(NAME cluster_launcher COMMAND tests/cluster_launcher.py -v ${UNSHARE})
 add_np_test(NAME cluster_launcher_if COMMAND tests/cluster_launcher.py --activate-if -v ${UNSHARE})

--- a/tests/ship_client.cpp
+++ b/tests/ship_client.cpp
@@ -1,32 +1,30 @@
-#include <eosio/abi.hpp>
-#include <eosio/convert.hpp>
-#include <eosio/from_json.hpp>
-
-#include <rapidjson/document.h>
-#include <rapidjson/prettywriter.h>
-#include <rapidjson/stringbuffer.h>
-
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/local/stream_protocol.hpp>
 #include <boost/beast.hpp>
 #include <boost/program_options.hpp>
 
+#include <eosio/chain/abi_def.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+#include <fc/io/json.hpp>
+
 #include <iostream>
+#include <regex>
 #include <string>
 
+using mvo = fc::mutable_variant_object;
 using tcp = boost::asio::ip::tcp;
 using unixs = boost::asio::local::stream_protocol;
 namespace ws = boost::beast::websocket;
 
 namespace bpo = boost::program_options;
 
-
 int main(int argc, char* argv[]) {
    boost::asio::io_context ctx;
    boost::asio::ip::tcp::resolver resolver(ctx);
    ws::stream<boost::asio::ip::tcp::socket> tcp_stream(ctx);
-   eosio::abi abi;
+   eosio::chain::abi_def abidef;
+   eosio::chain::abi_serializer abi;
 
    unixs::socket unix_socket(ctx);
    ws::stream<unixs::socket> unix_stream(ctx);
@@ -58,7 +56,7 @@ int main(int argc, char* argv[]) {
       statehistory_server = socket_address.substr(socket_address.find("unix://") + strlen("unix://") + 1);
    } else {
       std::string::size_type colon = socket_address.find(':');
-      eosio::check(colon != std::string::npos, "Missing ':' seperator in Websocket address and port");
+      FC_ASSERT(colon != std::string::npos, "Missing ':' seperator in Websocket address and port");
       statehistory_server = socket_address.substr(0, colon);
       statehistory_port = socket_address.substr(colon + 1);
    }
@@ -66,23 +64,21 @@ int main(int argc, char* argv[]) {
    std::cerr << "[\n{\n   \"status\": \"construct\",\n   \"time\": " << time(NULL) << "\n},\n";
 
    try {
-      auto run = [&](auto& stream) { // C++20: [&]<typename SocketStream>(SocketStream& stream)
+      auto run = [&]<typename SocketStream>(SocketStream& stream) {
          {
             boost::beast::flat_buffer abi_buffer;
             stream.read(abi_buffer);
-            std::string abi_string((const char*)abi_buffer.data().data(),
-                                   abi_buffer.data().size());
-            eosio::json_token_stream token_stream(abi_string.data());
-            eosio::abi_def abidef =
-                eosio::from_json<eosio::abi_def>(token_stream);
-            eosio::convert(abidef, abi);
+            std::string abi_string = boost::beast::buffers_to_string(abi_buffer.data());
+            //remove all tables since their names are invalid; tables not needed for this test
+            std::regex scrub_all_tables(R"(\{ "name": "[^"]+", "type": "[^"]+", "key_names": \[[^\]]*\] \},?)");
+            abi_string = std::regex_replace(abi_string, scrub_all_tables, "");
+
+            abidef = fc::json::from_string(abi_string).as<eosio::chain::abi_def>();
+            abi = eosio::chain::abi_serializer(abidef, eosio::chain::abi_serializer::create_depth_yield_function());
          }
          stream.binary(true);
 
          std::cerr << "{\n   \"status\": \"set_abi\",\n   \"time\": " << time(NULL) << "\n},\n";
-
-         const eosio::abi_type& request_type = abi.abi_types.at("request");
-         const eosio::abi_type& result_type = abi.abi_types.at("result");
 
          bool is_first = true;
          uint32_t first_block_num = 0;
@@ -97,37 +93,29 @@ int main(int argc, char* argv[]) {
          };
 
          while(num_requests--) {
-            rapidjson::StringBuffer request_sb;
-            rapidjson::PrettyWriter<rapidjson::StringBuffer> request_writer(request_sb);
-
-            request_writer.StartArray();
-               request_writer.String(request_result_types[num_requests%2].get_status_request.c_str());
-               request_writer.StartObject();
-               request_writer.EndObject();
-            request_writer.EndArray();
-
-            stream.write(boost::asio::buffer(request_type.json_to_bin(request_sb.GetString(), [](){})));
+            const eosio::chain::bytes get_status_bytes = abi.variant_to_binary("request",
+               fc::variants{request_result_types[num_requests%2].get_status_request, mvo()},
+               eosio::chain::abi_serializer::create_depth_yield_function());
+            stream.write(boost::asio::buffer(get_status_bytes));
 
             boost::beast::flat_buffer buffer;
             stream.read(buffer);
 
-            eosio::input_stream is((const char*)buffer.data().data(), buffer.data().size());
-            rapidjson::Document result_document;
-            result_document.Parse(result_type.bin_to_json(is).c_str());
+            fc::datastream<const char*> ds((const char*)buffer.data().data(), buffer.data().size());
+            const fc::variant result = abi.binary_to_variant("result", ds, eosio::chain::abi_serializer::create_depth_yield_function());
 
-            eosio::check(!result_document.HasParseError(),                                      "Failed to parse result JSON from abieos");
-            eosio::check(result_document.IsArray(),                                             "result should have been an array (variant) but it's not");
-            eosio::check(result_document.Size() == 2,                                           "result was an array but did not contain 2 items like a variant should");
-            eosio::check(std::string(result_document[0].GetString()) == request_result_types[num_requests%2].get_status_result, "result type doesn't look like expected get_status_result_vX");
-            eosio::check(result_document[1].IsObject(),                                         "second item in result array is not an object");
-            eosio::check(result_document[1].HasMember("head"),                                  "cannot find 'head' in result");
-            eosio::check(result_document[1]["head"].IsObject(),                                 "'head' is not an object");
-            eosio::check(result_document[1]["head"].HasMember("block_num"),                     "'head' does not contain 'block_num'");
-            eosio::check(result_document[1]["head"]["block_num"].IsUint(),                      "'head.block_num' isn't a number");
-            eosio::check(result_document[1]["head"].HasMember("block_id"),                      "'head' does not contain 'block_id'");
-            eosio::check(result_document[1]["head"]["block_id"].IsString(),                     "'head.block_id' isn't a string");
+            FC_ASSERT(result.is_array(),                                                           "result should have been an array (variant) but it's not");
+            FC_ASSERT(result.size() == 2,                                                          "result was an array but did not contain 2 items like a variant should");
+            FC_ASSERT(result[(size_t)0] == request_result_types[num_requests%2].get_status_result, "result type doesn't look like expected get_status_result_vX");
+            const fc::variant_object& resultobj = result[(size_t)1].get_object();
+            FC_ASSERT(resultobj.contains("head"),                                                  "cannot find 'head' in result");
+            FC_ASSERT(resultobj["head"].is_object(),                                               "'head' is not an object");
+            FC_ASSERT(resultobj["head"].get_object().contains("block_num"),                        "'head' does not contain 'block_num'");
+            FC_ASSERT(resultobj["head"].get_object()["block_num"].is_integer(),                    "'head.block_num' isn't a number");
+            FC_ASSERT(resultobj["head"].get_object().contains("block_id"),                         "'head' does not contain 'block_id'");
+            FC_ASSERT(resultobj["head"].get_object()["block_id"].is_string(),                      "'head.block_id' isn't a string");
 
-            uint32_t this_block_num = result_document[1]["head"]["block_num"].GetUint();
+            uint32_t this_block_num = resultobj["head"]["block_num"].as_uint64();
 
             if(is_first) {
                std::cout << "[" << std::endl;
@@ -137,33 +125,18 @@ int main(int argc, char* argv[]) {
             else {
                std::cout << "," << std::endl;
             }
-            std::cout << "{ \"get_status_result_v0\":" << std::endl;
-
-            rapidjson::StringBuffer result_sb;
-            rapidjson::PrettyWriter<rapidjson::StringBuffer> result_writer(result_sb);
-            result_document[1].Accept(result_writer);
-            std::cout << result_sb.GetString() << std::endl << "}" << std::endl;
+            std::cout << "{ \"" << result[(size_t)0].as_string() << "\":" << std::endl;
+            std::cout << fc::json::to_pretty_string(resultobj) << std::endl << "}" << std::endl;
 
             last_block_num = this_block_num;
          }
 
          std::cout << "]" << std::endl;
 
-         rapidjson::StringBuffer done_sb;
-         rapidjson::PrettyWriter<rapidjson::StringBuffer> done_writer(done_sb);
-
-         done_writer.StartObject();
-            done_writer.Key("status");
-            done_writer.String("done");
-            done_writer.Key("time");
-            done_writer.Uint(time(NULL));
-            done_writer.Key("first_block_num");
-            done_writer.Uint(first_block_num);
-            done_writer.Key("last_block_num");
-            done_writer.Uint(last_block_num);
-         done_writer.EndObject();
-
-         std::cerr << done_sb.GetString() << std::endl << "]" << std::endl;
+         std::cerr << fc::json::to_pretty_string(mvo()("status", "done")
+                                                      ("time", time(NULL))
+                                                      ("first_block_num", first_block_num)
+                                                      ("last_block_num", last_block_num)) << std::endl << "]" << std::endl;
       };
 
       // unix socket

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -118,8 +118,7 @@ int main(int argc, char* argv[]) {
                                                     ("fetch_block", fetch_block)
                                                     ("fetch_traces", fetch_traces)
                                                     ("fetch_deltas", fetch_deltas)
-                                                    ("fetch_finality_data", fetch_finality_data)},
-         eosio::chain::abi_serializer::create_depth_yield_function());
+                                                    ("fetch_finality_data", fetch_finality_data)}, {});
       stream.write(boost::asio::buffer(get_status_bytes));
       stream.read_message_max(0);
 
@@ -132,12 +131,12 @@ int main(int argc, char* argv[]) {
          stream.read(buffer);
 
          fc::datastream<const char*> ds((const char*)buffer.data().data(), buffer.data().size());
-         const fc::variant result = abi.binary_to_variant("result", ds, eosio::chain::abi_serializer::create_depth_yield_function());
+         const fc::variant result = abi.binary_to_variant("result", ds, {});
 
          FC_ASSERT(result.is_array(),                                                        "result should have been an array (variant) but it's not");
          FC_ASSERT(result.size() == 2,                                                       "result was an array but did not contain 2 items like a variant should");
-         FC_ASSERT(result[(size_t)0] == "get_blocks_result_v1",                              "result type doesn't look like get_blocks_result_v1");
-         const fc::variant_object& resultobj = result[(size_t)1].get_object();
+         FC_ASSERT(result[0ul] == "get_blocks_result_v1",                                    "result type doesn't look like get_blocks_result_v1");
+         const fc::variant_object& resultobj = result[1ul].get_object();
          FC_ASSERT(resultobj.contains("head"),                                               "cannot find 'head' in result");
          FC_ASSERT(resultobj["head"].is_object(),                                            "'head' is not an object");
          FC_ASSERT(resultobj["head"].get_object().contains("block_num"),                     "'head' does not contain 'block_num'");

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]) {
          //state history may have 'bytes' larger than MAX_SIZE_OF_BYTE_ARRAYS, so divert 'bytes' to an impl that does not have that check
          abi.add_specialized_unpack_pack("bytes", std::make_pair<eosio::chain::abi_serializer::unpack_function, eosio::chain::abi_serializer::pack_function>(
             [](fc::datastream<const char*>& stream, bool is_array, bool is_optional, const eosio::chain::abi_serializer::yield_function_t& yield) {
-               FC_ASSERT(!is_array, "sorry, this kludge doesn't support arrays");
+               FC_ASSERT(!is_array, "sorry, this kludge doesn't support bytes[]");
                if(is_optional) {
                   bool present = false;
                   fc::raw::unpack(stream, present);

--- a/tests/ship_streamer.cpp
+++ b/tests/ship_streamer.cpp
@@ -1,19 +1,18 @@
-#include <eosio/abi.hpp>
-#include <eosio/from_json.hpp>
-#include <eosio/convert.hpp>
-
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/prettywriter.h>
-
 #include <boost/asio.hpp>
 #include <boost/beast.hpp>
 #include <boost/program_options.hpp>
 
+#include <eosio/chain/abi_def.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+#include <fc/io/json.hpp>
+
 #include <map>
 #include <set>
 #include <iostream>
+#include <regex>
 #include <string>
+
+using mvo = fc::mutable_variant_object;
 
 namespace bpo = boost::program_options;
 
@@ -21,7 +20,8 @@ int main(int argc, char* argv[]) {
    boost::asio::io_context ctx;
    boost::asio::ip::tcp::resolver resolver(ctx);
    boost::beast::websocket::stream<boost::asio::ip::tcp::socket> stream(ctx);
-   eosio::abi abi;
+   eosio::chain::abi_def abidef;
+   eosio::chain::abi_serializer abi;
 
    bpo::options_description cli("ship_streamer command line options");
    bool help = false;
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
    }
 
    std::string::size_type colon = socket_address.find(':');
-   eosio::check(colon != std::string::npos, "Missing ':' seperator in Websocket address and port");
+   FC_ASSERT(colon != std::string::npos, "Missing ':' seperator in Websocket address and port");
    std::string statehistory_server = socket_address.substr(0, colon);
    std::string statehistory_port = socket_address.substr(colon+1);
 
@@ -66,17 +66,14 @@ int main(int argc, char* argv[]) {
       {
          boost::beast::flat_buffer abi_buffer;
          stream.read(abi_buffer);
-         std::string abi_string((const char*)abi_buffer.data().data(), abi_buffer.data().size());
-         eosio::json_token_stream token_stream(abi_string.data());
-         eosio::abi_def abidef = eosio::from_json<eosio::abi_def>(token_stream);
-         eosio::convert(abidef, abi);
+         std::string abi_string = boost::beast::buffers_to_string(abi_buffer.data());
+         //remove all tables since their names are invalid; tables not needed for this test
+         std::regex scrub_all_tables(R"(\{ "name": "[^"]+", "type": "[^"]+", "key_names": \[[^\]]*\] \},?)");
+         abi_string = std::regex_replace(abi_string, scrub_all_tables, "");
+
+         abidef = fc::json::from_string(abi_string).as<eosio::chain::abi_def>();
+         abi = eosio::chain::abi_serializer(abidef, eosio::chain::abi_serializer::create_depth_yield_function());
       }
-
-      const eosio::abi_type& request_type = abi.abi_types.at("request");
-      const eosio::abi_type& result_type = abi.abi_types.at("result");
-
-      rapidjson::StringBuffer request_sb;
-      rapidjson::PrettyWriter<rapidjson::StringBuffer> request_writer(request_sb);
 
       //struct get_blocks_request_v0 {
       //   uint32_t                    start_block_num        = 0;
@@ -91,34 +88,20 @@ int main(int argc, char* argv[]) {
       //struct get_blocks_request_v1 : get_blocks_request_v0 {
       //   bool                        fetch_finality_data    = false;
       //};
-      request_writer.StartArray();
-
-         request_writer.String("get_blocks_request_v1"); // always send out latest version of request
-         request_writer.StartObject();
-         request_writer.Key("start_block_num");
-         request_writer.Uint(start_block_num);
-         request_writer.Key("end_block_num");
-         request_writer.String(std::to_string(end_block_num + 1).c_str()); // SHiP is (start-end] exclusive
-         request_writer.Key("max_messages_in_flight");
-         request_writer.String(std::to_string(std::numeric_limits<u_int32_t>::max()).c_str());
-         request_writer.Key("have_positions");
-         request_writer.StartArray();
-         request_writer.EndArray();
-         request_writer.Key("irreversible_only");
-         request_writer.Bool(irreversible_only);
-         request_writer.Key("fetch_block");
-         request_writer.Bool(fetch_block);
-         request_writer.Key("fetch_traces");
-         request_writer.Bool(fetch_traces);
-         request_writer.Key("fetch_deltas");
-         request_writer.Bool(fetch_deltas);
-         request_writer.Key("fetch_finality_data");
-         request_writer.Bool(fetch_finality_data);
-         request_writer.EndObject();
-      request_writer.EndArray();
 
       stream.binary(true);
-      stream.write(boost::asio::buffer(request_type.json_to_bin(request_sb.GetString(), [](){})));
+      const eosio::chain::bytes get_status_bytes = abi.variant_to_binary("request",
+         fc::variants{"get_blocks_request_v1", mvo()("start_block_num", start_block_num)
+                                                    ("end_block_num", std::to_string(end_block_num + 1)) // SHiP is (start-end] exclusive
+                                                    ("max_messages_in_flight",std::to_string(std::numeric_limits<u_int32_t>::max()))
+                                                    ("have_positions", fc::variants{})
+                                                    ("irreversible_only", irreversible_only)
+                                                    ("fetch_block", fetch_block)
+                                                    ("fetch_traces", fetch_traces)
+                                                    ("fetch_deltas", fetch_deltas)
+                                                    ("fetch_finality_data", fetch_finality_data)},
+         eosio::chain::abi_serializer::create_depth_yield_function());
+      stream.write(boost::asio::buffer(get_status_bytes));
       stream.read_message_max(0);
 
       // Each block_num can have multiple block_ids since forks are possible
@@ -129,21 +112,19 @@ int main(int argc, char* argv[]) {
          boost::beast::flat_buffer buffer;
          stream.read(buffer);
 
-         eosio::input_stream is((const char*)buffer.data().data(), buffer.data().size());
-         rapidjson::Document result_document;
-         result_document.Parse(result_type.bin_to_json(is).c_str());
+         fc::datastream<const char*> ds((const char*)buffer.data().data(), buffer.data().size());
+         const fc::variant result = abi.binary_to_variant("result", ds, eosio::chain::abi_serializer::create_depth_yield_function());
 
-         eosio::check(!result_document.HasParseError(),                                      "Failed to parse result JSON from abieos");
-         eosio::check(result_document.IsArray(),                                             "result should have been an array (variant) but it's not");
-         eosio::check(result_document.Size() == 2,                                           "result was an array but did not contain 2 items like a variant should");
-         eosio::check(std::string(result_document[0].GetString()) == "get_blocks_result_v1", "result type doesn't look like get_blocks_result_v1");
-         eosio::check(result_document[1].IsObject(),                                         "second item in result array is not an object");
-         eosio::check(result_document[1].HasMember("head"),                                  "cannot find 'head' in result");
-         eosio::check(result_document[1]["head"].IsObject(),                                 "'head' is not an object");
-         eosio::check(result_document[1]["head"].HasMember("block_num"),                     "'head' does not contain 'block_num'");
-         eosio::check(result_document[1]["head"]["block_num"].IsUint(),                      "'head.block_num' isn't a number");
-         eosio::check(result_document[1]["head"].HasMember("block_id"),                      "'head' does not contain 'block_id'");
-         eosio::check(result_document[1]["head"]["block_id"].IsString(),                     "'head.block_id' isn't a string");
+         FC_ASSERT(result.is_array(),                                                        "result should have been an array (variant) but it's not");
+         FC_ASSERT(result.size() == 2,                                                       "result was an array but did not contain 2 items like a variant should");
+         FC_ASSERT(result[(size_t)0] == "get_blocks_result_v1",                              "result type doesn't look like get_blocks_result_v1");
+         const fc::variant_object& resultobj = result[(size_t)1].get_object();
+         FC_ASSERT(resultobj.contains("head"),                                               "cannot find 'head' in result");
+         FC_ASSERT(resultobj["head"].is_object(),                                            "'head' is not an object");
+         FC_ASSERT(resultobj["head"].get_object().contains("block_num"),                     "'head' does not contain 'block_num'");
+         FC_ASSERT(resultobj["head"].get_object()["block_num"].is_integer(),                 "'head.block_num' isn't a number");
+         FC_ASSERT(resultobj["head"].get_object().contains("block_id"),                      "'head' does not contain 'block_id'");
+         FC_ASSERT(resultobj["head"].get_object()["block_id"].is_string(),                   "'head.block_id' isn't a string");
 
          // stream what was received
          if(is_first) {
@@ -152,29 +133,24 @@ int main(int argc, char* argv[]) {
          } else {
            std::cout << "," << std::endl;
          }
-         std::cout << "{ \"get_blocks_result_v1\":" << std::endl;
-
-         rapidjson::StringBuffer result_sb;
-         rapidjson::PrettyWriter<rapidjson::StringBuffer> result_writer(result_sb);
-         result_document[1].Accept(result_writer);
-         std::cout << result_sb.GetString() << std::endl << "}" << std::endl;
+         std::cout << "{ \"get_blocks_result_v1\":" << fc::json::to_pretty_string(resultobj) << std::endl << "}" << std::endl;
 
          // validate after streaming, so that invalid entry is included in the output
          uint32_t this_block_num = 0;
-         if( result_document[1].HasMember("this_block") && result_document[1]["this_block"].IsObject() ) {
-            const auto& this_block = result_document[1]["this_block"];
-            if( this_block.HasMember("block_num") && this_block["block_num"].IsUint() ) {
-               this_block_num = this_block["block_num"].GetUint();
+         if( resultobj.contains("this_block") && resultobj["this_block"].is_object() ) {
+            const fc::variant_object& this_block = resultobj["this_block"].get_object();
+            if( this_block.contains("block_num") && this_block["block_num"].is_integer() ) {
+               this_block_num = this_block["block_num"].as_uint64();
             }
             std::string this_block_id;
-            if( this_block.HasMember("block_id") && this_block["block_id"].IsString() ) {
-               this_block_id = this_block["block_id"].GetString();
+            if( this_block.contains("block_id") && this_block["block_id"].is_string() ) {
+               this_block_id = this_block["block_id"].get_string();
             }
             std::string prev_block_id;
-            if( result_document[1].HasMember("prev_block") && result_document[1]["prev_block"].IsObject() ) {
-               const auto& prev_block = result_document[1]["prev_block"];
-               if ( prev_block.HasMember("block_id") && prev_block["block_id"].IsString() ) {
-                  prev_block_id = prev_block["block_id"].GetString();
+            if( resultobj.contains("prev_block") && resultobj["prev_block"].is_object() ) {
+               const fc::variant_object& prev_block = resultobj["prev_block"].get_object();
+               if ( prev_block.contains("block_id") && prev_block["block_id"].is_string() ) {
+                  prev_block_id = prev_block["block_id"].get_string();
                }
             }
             if( !irreversible_only && !this_block_id.empty() && !prev_block_id.empty() ) {
@@ -189,8 +165,8 @@ int main(int argc, char* argv[]) {
                }
                block_ids[this_block_num].insert(this_block_id);
 
-               if( result_document[1]["last_irreversible"].HasMember("block_num") && result_document[1]["last_irreversible"]["block_num"].IsUint() ) {
-                  uint32_t lib_num = result_document[1]["last_irreversible"]["block_num"].GetUint();
+               if( resultobj["last_irreversible"].get_object().contains("block_num") && resultobj["last_irreversible"]["block_num"].is_integer() ) {
+                  uint32_t lib_num = resultobj["last_irreversible"]["block_num"].as_uint64();
                   auto i = block_ids.lower_bound(lib_num);
                   if (i != block_ids.end()) {
                      block_ids.erase(block_ids.begin(), i);

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -73,7 +73,7 @@ add_custom_command(
 file(GLOB UNIT_TESTS "*.cpp") # find all unit test suites
 add_executable( unit_test ${UNIT_TESTS} protocol_feature_digest_tests.cpp) # build unit tests as one executable
 
-target_link_libraries( unit_test eosio_chain_wrap state_history chainbase eosio_testing fc custom_appbase abieos ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( unit_test eosio_chain_wrap state_history chainbase eosio_testing fc custom_appbase ${PLATFORM_SPECIFIC_LIBS} )
 
 target_compile_options(unit_test PUBLIC -DDISABLE_EOSLIB_SERIALIZE)
 target_include_directories( unit_test PUBLIC

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 #include <contracts.hpp>
 #include <test_contracts.hpp>
+#include <eosio/state_history/abi.hpp>
 #include <eosio/state_history/create_deltas.hpp>
 #include <eosio/state_history/log_catalog.hpp>
 #include <eosio/state_history/trace_converter.hpp>
@@ -13,20 +14,12 @@
 
 #include "test_cfd_transaction.hpp"
 
-#include <eosio/stream.hpp>
-#include <eosio/ship_protocol.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/copy.hpp>
 
 using namespace eosio::chain;
 using namespace eosio::testing;
 using namespace std::literals;
-
-extern const char* const state_history_plugin_abi;
-
-bool operator==(const eosio::checksum256& lhs, const transaction_id_type& rhs) {
-   return memcmp(lhs.extract_as_byte_array().data(), rhs.data(), rhs.data_size()) == 0;
-}
 
 namespace eosio::state_history {
 
@@ -86,18 +79,20 @@ public:
       return make_pair(it != v.end(), it);
    }
 
-   template <typename A, typename B>
-   vector<A> deserialize_data(deltas_vector::iterator &it) {
-      vector<A> result;
+   variants deserialize_data(deltas_vector::iterator &it, const std::string& type, const std::string& in_variant_type) {
+      variants result;
       for(size_t i=0; i < it->rows.obj.size(); i++) {
-         eosio::input_stream stream{it->rows.obj[i].second.data(), it->rows.obj[i].second.size()};
-         result.push_back(std::get<A>(eosio::from_bin<B>(stream)));
+         fc::variant v = shipabi.binary_to_variant(in_variant_type, it->rows.obj[i].second, {});
+         BOOST_REQUIRE(v.is_array() && v.size() == 2 && v[0ul].is_string());
+         BOOST_REQUIRE_EQUAL(v[0ul].get_string(), type);
+         result.push_back(std::move(v[1ul]));
       }
       return result;
    }
 
 private:
    deltas_vector v;
+   abi_serializer shipabi = abi_serializer(json::from_string(eosio::state_history::ship_abi_without_tables()).as<abi_def>(), {});
 };
 
 using table_deltas_testers = boost::mpl::list<table_deltas_tester<legacy_tester>,
@@ -130,8 +125,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_account_creation, T, table_deltas_test
    auto &it_account = result.second;
    BOOST_REQUIRE_EQUAL(it_account->rows.obj.size(), 1u);
 
-   auto accounts = chain.template deserialize_data<eosio::ship_protocol::account_v0, eosio::ship_protocol::account>(it_account);
-   BOOST_REQUIRE_EQUAL(accounts[0].name.to_string(), "newacc");
+   const variants accounts = chain.deserialize_data(it_account, "account_v0", "account");
+   BOOST_REQUIRE_EQUAL(accounts[0]["name"].get_string(), "newacc");
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_account_metadata, T, table_deltas_testers) {
@@ -146,9 +141,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_account_metadata, T, table_deltas_test
    auto &it_account_metadata = result.second;
    BOOST_REQUIRE_EQUAL(it_account_metadata->rows.obj.size(), 1u);
 
-   auto accounts_metadata = chain.template deserialize_data<eosio::ship_protocol::account_metadata_v0, eosio::ship_protocol::account_metadata>(it_account_metadata);
-   BOOST_REQUIRE_EQUAL(accounts_metadata[0].name.to_string(), "newacc");
-   BOOST_REQUIRE_EQUAL(accounts_metadata[0].privileged, false);
+   const variants accounts_metadata = chain.deserialize_data(it_account_metadata, "account_metadata_v0", "account_metadata");
+   BOOST_REQUIRE_EQUAL(accounts_metadata[0]["name"].get_string(), "newacc");
+   BOOST_REQUIRE_EQUAL(accounts_metadata[0]["privileged"].as_bool(), false);
 }
 
 
@@ -164,12 +159,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_account_permission, T, table_deltas_te
    BOOST_REQUIRE(result.first);
    auto &it_permission = result.second;
    BOOST_REQUIRE_EQUAL(it_permission->rows.obj.size(), 2u);
-   auto accounts_permissions = chain.template deserialize_data<eosio::ship_protocol::permission_v0, eosio::ship_protocol::permission>(it_permission);
+   const variants accounts_permissions = chain.deserialize_data(it_permission, "permission_v0", "permission");
    for(size_t i = 0; i < accounts_permissions.size(); i++)
    {
       BOOST_REQUIRE_EQUAL(it_permission->rows.obj[i].first, true);
-      BOOST_REQUIRE_EQUAL(accounts_permissions[i].owner.to_string(), "newacc");
-      BOOST_REQUIRE_EQUAL(accounts_permissions[i].name.to_string(), expected_permission_names[i]);
+      BOOST_REQUIRE_EQUAL(accounts_permissions[i]["owner"].get_string(), "newacc");
+      BOOST_REQUIRE_EQUAL(accounts_permissions[i]["name"].get_string(), expected_permission_names[i]);
    }
 }
 
@@ -196,10 +191,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_account_permission_creation_and_deleti
    auto &it_permission = result.second;
    BOOST_REQUIRE_EQUAL(it_permission->rows.obj.size(), 3u);
    BOOST_REQUIRE_EQUAL(it_permission->rows.obj[2].first, true);
-   auto accounts_permissions = chain.template deserialize_data<eosio::ship_protocol::permission_v0, eosio::ship_protocol::permission>(it_permission);
-   BOOST_REQUIRE_EQUAL(accounts_permissions[2].owner.to_string(), "newacc");
-   BOOST_REQUIRE_EQUAL(accounts_permissions[2].name.to_string(), "mypermission");
-   BOOST_REQUIRE_EQUAL(accounts_permissions[2].parent.to_string(), "active");
+   variants accounts_permissions = chain.deserialize_data(it_permission, "permission_v0", "permission");
+   BOOST_REQUIRE_EQUAL(accounts_permissions[2]["owner"].get_string(), "newacc");
+   BOOST_REQUIRE_EQUAL(accounts_permissions[2]["name"].get_string(), "mypermission");
+   BOOST_REQUIRE_EQUAL(accounts_permissions[2]["parent"].get_string(), "active");
 
    chain.produce_block();
 
@@ -211,10 +206,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_account_permission_creation_and_deleti
    auto &it_permission_del = result.second;
    BOOST_REQUIRE_EQUAL(it_permission_del->rows.obj.size(), 1u);
    BOOST_REQUIRE_EQUAL(it_permission_del->rows.obj[0].first, false);
-   accounts_permissions = chain.template deserialize_data<eosio::ship_protocol::permission_v0, eosio::ship_protocol::permission>(it_permission_del);
-   BOOST_REQUIRE_EQUAL(accounts_permissions[0].owner.to_string(), "newacc");
-   BOOST_REQUIRE_EQUAL(accounts_permissions[0].name.to_string(), "mypermission");
-   BOOST_REQUIRE_EQUAL(accounts_permissions[0].parent.to_string(), "active");
+   accounts_permissions = chain.deserialize_data(it_permission_del, "permission_v0", "permission");
+   BOOST_REQUIRE_EQUAL(accounts_permissions[0]["owner"].get_string(), "newacc");
+   BOOST_REQUIRE_EQUAL(accounts_permissions[0]["name"].get_string(), "mypermission");
+   BOOST_REQUIRE_EQUAL(accounts_permissions[0]["parent"].get_string(), "active");
 }
 
 
@@ -228,7 +223,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_account_permission_modification, T, ta
          public_key_type("PUB_WA_WdCPfafVNxVMiW5ybdNs83oWjenQXvSt1F49fg9mv7qrCiRwHj5b38U3ponCFWxQTkDsMC"s), // Test for correct serialization of WA key, see issue #9087
          public_key_type("PUB_K1_12wkBET2rRgE8pahuaczxKbmv7ciehqsne57F9gtzf1PVb7Rf7o"s),
          public_key_type("PUB_R1_6FPFZqw5ahYrR9jD96yDbbDNTdKtNqRbze6oTDLntrsANgQKZu"s)};
-   const int K1_storage_type_which_value = 0;
 
    for(auto &key: keys) {
       // Modify the permission authority
@@ -240,14 +234,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_account_permission_modification, T, ta
 
       auto &it_permission = result.second;
       BOOST_REQUIRE_EQUAL(it_permission->rows.obj.size(), 1u);
-      auto accounts_permissions = chain.template deserialize_data<eosio::ship_protocol::permission_v0, eosio::ship_protocol::permission>(it_permission);
-      BOOST_REQUIRE_EQUAL(accounts_permissions[0].owner.to_string(), "newacc");
-      BOOST_REQUIRE_EQUAL(accounts_permissions[0].name.to_string(), "active");
-      BOOST_REQUIRE_EQUAL(accounts_permissions[0].auth.keys.size(), 1u);
-      if(key.which() != K1_storage_type_which_value)
-         BOOST_REQUIRE_EQUAL(eosio::public_key_to_string(accounts_permissions[0].auth.keys[0].key), key.to_string({}));
-      else
-         BOOST_REQUIRE_EQUAL(eosio::public_key_to_string(accounts_permissions[0].auth.keys[0].key), "PUB_K1_12wkBET2rRgE8pahuaczxKbmv7ciehqsne57F9gtzf1PVb7Rf7o");
+      const variants accounts_permissions = chain.deserialize_data(it_permission, "permission_v0", "permission");
+      BOOST_REQUIRE_EQUAL(accounts_permissions[0]["owner"].get_string(), "newacc");
+      BOOST_REQUIRE_EQUAL(accounts_permissions[0]["name"].get_string(), "active");
+      BOOST_REQUIRE_EQUAL(accounts_permissions[0]["auth"]["keys"].size(), 1u);
+      BOOST_REQUIRE_EQUAL(accounts_permissions[0]["auth"]["keys"][0ul]["key"].get_string(), key.to_string({}));
 
       chain.produce_block();
    }
@@ -273,10 +264,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_permission_link, T, table_deltas_teste
    BOOST_REQUIRE(result.first);
    auto &it_permission_link = result.second;
    BOOST_REQUIRE_EQUAL(it_permission_link->rows.obj.size(), 1u);
-   auto permission_links = chain.template deserialize_data<eosio::ship_protocol::permission_link_v0, eosio::ship_protocol::permission_link>(it_permission_link);
-   BOOST_REQUIRE_EQUAL(permission_links[0].account.to_string(), "newacc");
-   BOOST_REQUIRE_EQUAL(permission_links[0].message_type.to_string(), "reqauth");
-   BOOST_REQUIRE_EQUAL(permission_links[0].required_permission.to_string(), "spending");
+   const variants permission_links = chain.deserialize_data(it_permission_link, "permission_link_v0", "permission_link");
+   BOOST_REQUIRE_EQUAL(permission_links[0]["account"].get_string(), "newacc");
+   BOOST_REQUIRE_EQUAL(permission_links[0]["message_type"].get_string(), "reqauth");
+   BOOST_REQUIRE_EQUAL(permission_links[0]["required_permission"].get_string(), "spending");
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_global_property_history, T, table_deltas_testers) {
@@ -295,9 +286,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_global_property_history, T, table_delt
    BOOST_REQUIRE(result.first);
    auto &it_global_property = result.second;
    BOOST_REQUIRE_EQUAL(it_global_property->rows.obj.size(), 1u);
-   auto global_properties = chain.template deserialize_data<eosio::ship_protocol::global_property_v1, eosio::ship_protocol::global_property>(it_global_property);
-   auto configuration = std::get<eosio::ship_protocol::chain_config_v1>(global_properties[0].configuration);
-   BOOST_REQUIRE_EQUAL(configuration.max_transaction_delay, 60u);
+   const variants global_properties = chain.deserialize_data(it_global_property, "global_property_v1", "global_property");
+   BOOST_REQUIRE_EQUAL(global_properties[0]["configuration"][0ul].get_string(), "chain_config_v1");
+   BOOST_REQUIRE_EQUAL(global_properties[0]["configuration"][1ul]["max_transaction_delay"].as_uint64(), 60u);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_protocol_feature_history, T, table_deltas_testers) {
@@ -322,17 +313,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_protocol_feature_history, T, table_del
    BOOST_REQUIRE(result.first);
    auto &it_protocol_state = result.second;
    BOOST_REQUIRE_EQUAL(it_protocol_state->rows.obj.size(), 1u);
-   auto protocol_states = chain.template deserialize_data<eosio::ship_protocol::protocol_state_v0, eosio::ship_protocol::protocol_state>(it_protocol_state);
-   auto protocol_feature = std::get<eosio::ship_protocol::activated_protocol_feature_v0>(protocol_states[0].activated_protocol_features[0]);
-
-   auto digest_byte_array = protocol_feature.feature_digest.extract_as_byte_array();
-   char digest_array[digest_byte_array.size()];
-   for(size_t i=0; i < digest_byte_array.size(); i++) digest_array[i] = digest_byte_array[i];
-   eosio::chain::digest_type digest_in_delta(digest_array, digest_byte_array.size());
-
+   const variants protocol_states = chain.deserialize_data(it_protocol_state, "protocol_state_v0", "protocol_state");
+   BOOST_REQUIRE_EQUAL(protocol_states[0]["activated_protocol_features"][0ul][0ul].get_string(), "activated_protocol_feature_v0");
+   const digest_type digest_in_delta = protocol_states[0]["activated_protocol_features"][0ul][1ul]["feature_digest"].as<digest_type>();
    BOOST_REQUIRE_EQUAL(digest_in_delta, *d);
 }
-
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_contract, T, table_deltas_testers) {
    T chain;
@@ -358,31 +343,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_contract, T, table_deltas_testers) {
    BOOST_REQUIRE(result.first);
    auto &it_contract_table = result.second;
    BOOST_REQUIRE_EQUAL(it_contract_table->rows.obj.size(), 6u);
-   auto contract_tables = chain.template deserialize_data<eosio::ship_protocol::contract_table_v0, eosio::ship_protocol::contract_table>(it_contract_table);
-   BOOST_REQUIRE_EQUAL(contract_tables[0].table.to_string(), "hashobjs");
-   BOOST_REQUIRE_EQUAL(contract_tables[1].table.to_string(), "hashobjs....1");
-   BOOST_REQUIRE_EQUAL(contract_tables[2].table.to_string(), "numobjs");
-   BOOST_REQUIRE_EQUAL(contract_tables[3].table.to_string(), "numobjs.....1");
-   BOOST_REQUIRE_EQUAL(contract_tables[4].table.to_string(), "numobjs.....2");
-   BOOST_REQUIRE_EQUAL(contract_tables[5].table.to_string(), "numobjs.....3");
+   const variants contract_tables = chain.deserialize_data(it_contract_table, "contract_table_v0", "contract_table");
+   BOOST_REQUIRE_EQUAL(contract_tables[0]["table"].get_string(), "hashobjs");
+   BOOST_REQUIRE_EQUAL(contract_tables[1]["table"].get_string(), "hashobjs....1");
+   BOOST_REQUIRE_EQUAL(contract_tables[2]["table"].get_string(), "numobjs");
+   BOOST_REQUIRE_EQUAL(contract_tables[3]["table"].get_string(), "numobjs.....1");
+   BOOST_REQUIRE_EQUAL(contract_tables[4]["table"].get_string(), "numobjs.....2");
+   BOOST_REQUIRE_EQUAL(contract_tables[5]["table"].get_string(), "numobjs.....3");
 
    // Spot onto contract_row
    result = chain.find_table_delta("contract_row");
    BOOST_REQUIRE(result.first);
    auto &it_contract_row = result.second;
    BOOST_REQUIRE_EQUAL(it_contract_row->rows.obj.size(), 2u);
-   auto contract_rows = chain.template deserialize_data<eosio::ship_protocol::contract_row_v0, eosio::ship_protocol::contract_row>(it_contract_row);
-   BOOST_REQUIRE_EQUAL(contract_rows[0].table.to_string(), "hashobjs");
-   BOOST_REQUIRE_EQUAL(contract_rows[1].table.to_string(), "numobjs");
+   const variants contract_rows = chain.deserialize_data(it_contract_row, "contract_row_v0", "contract_row");
+   BOOST_REQUIRE_EQUAL(contract_rows[0]["table"].get_string(), "hashobjs");
+   BOOST_REQUIRE_EQUAL(contract_rows[1]["table"].get_string(), "numobjs");
 
    // Spot onto contract_index256
    result = chain.find_table_delta("contract_index256");
    BOOST_REQUIRE(result.first);
    auto &it_contract_index256 = result.second;
    BOOST_REQUIRE_EQUAL(it_contract_index256->rows.obj.size(), 2u);
-   auto contract_indices = chain.template deserialize_data<eosio::ship_protocol::contract_index256_v0, eosio::ship_protocol::contract_index256>(it_contract_index256);
-   BOOST_REQUIRE_EQUAL(contract_indices[0].table.to_string(), "hashobjs");
-   BOOST_REQUIRE_EQUAL(contract_indices[1].table.to_string(), "hashobjs....1");
+   const variants contract_indices = chain.deserialize_data(it_contract_index256, "contract_index256_v0", "contract_index256");
+   BOOST_REQUIRE_EQUAL(contract_indices[0]["table"].get_string(), "hashobjs");
+   BOOST_REQUIRE_EQUAL(contract_indices[1]["table"].get_string(), "hashobjs....1");
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_resources_history, T, table_deltas_testers) {
@@ -527,7 +512,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_resources_history, T, table_deltas_tes
       BOOST_REQUIRE(result.first);
       auto &it_contract_row = result.second;
       BOOST_REQUIRE_EQUAL(it_contract_row->rows.obj.size(), 8u);
-      auto contract_rows = chain.template deserialize_data<eosio::ship_protocol::contract_row_v0, eosio::ship_protocol::contract_row>(it_contract_row);
+      variants contract_rows = chain.deserialize_data(it_contract_row, "contract_row_v0", "contract_row");
 
       std::multiset<std::string> expected_contract_row_table_names {"abihash", "abihash", "hashobjs", "hashobjs", "hashobjs", "numobjs", "numobjs", "numobjs"};
 
@@ -535,8 +520,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_resources_history, T, table_deltas_tes
       std::multiset<std::string> result_contract_row_table_names;
       std::multiset<uint64_t> result_contract_row_table_primary_keys;
       for(auto &contract_row : contract_rows) {
-         result_contract_row_table_names.insert(contract_row.table.to_string());
-         result_contract_row_table_primary_keys.insert(contract_row.primary_key);
+         result_contract_row_table_names.insert(contract_row["table"].get_string());
+         result_contract_row_table_primary_keys.insert(contract_row["primary_key"].as_uint64());
       }
       BOOST_REQUIRE(expected_contract_row_table_names == result_contract_row_table_names);
       BOOST_REQUIRE(expected_contract_row_table_primary_keys == result_contract_row_table_primary_keys);
@@ -552,22 +537,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_deltas_resources_history, T, table_deltas_tes
       result = chain.find_table_delta("contract_row");
       BOOST_REQUIRE(result.first);
       BOOST_REQUIRE_EQUAL(it_contract_row->rows.obj.size(), 2u);
-      contract_rows = chain.template deserialize_data<eosio::ship_protocol::contract_row_v0, eosio::ship_protocol::contract_row>(it_contract_row);
+      contract_rows = chain.deserialize_data(it_contract_row, "contract_row_v0", "contract_row");
 
       for(size_t i=0; i < contract_rows.size(); i++) {
          BOOST_REQUIRE_EQUAL(it_contract_row->rows.obj[i].first, 0);
-         BOOST_REQUIRE_EQUAL(contract_rows[i].table.to_string(), "numobjs");
+         BOOST_REQUIRE_EQUAL(contract_rows[i]["table"].get_string(), "numobjs");
       }
 
       result = chain.find_table_delta("contract_index_double");
       BOOST_REQUIRE(result.first);
       auto &it_contract_index_double = result.second;
       BOOST_REQUIRE_EQUAL(it_contract_index_double->rows.obj.size(), 2u);
-      auto contract_index_double_elems = chain.template deserialize_data<eosio::ship_protocol::contract_index_double_v0, eosio::ship_protocol::contract_index_double>(it_contract_index_double);
+      const variants contract_index_double_elems = chain.deserialize_data(it_contract_index_double, "contract_index_double_v0", "contract_index_double");
 
       for(size_t i=0; i < contract_index_double_elems.size(); i++) {
          BOOST_REQUIRE_EQUAL(it_contract_index_double->rows.obj[i].first, 0);
-         BOOST_REQUIRE_EQUAL(contract_index_double_elems[i].table.to_string(), "numobjs.....2");
+         BOOST_REQUIRE_EQUAL(contract_index_double_elems[i]["table"].get_string(), "numobjs.....2");
       }
 
    }
@@ -662,16 +647,14 @@ static std::vector<char> get_decompressed_entry(eosio::state_history::log_catalo
    return bytes;
 }
 
-static std::vector<eosio::ship_protocol::transaction_trace> get_traces(eosio::state_history::log_catalog& log,
-                                                                       block_num_type            block_num) {
-   auto                                                          entry = get_decompressed_entry(log, block_num);
-   std::vector<eosio::ship_protocol::transaction_trace>          traces;
+static variants get_traces(eosio::state_history::log_catalog& log, block_num_type            block_num) {
+   auto     entry = get_decompressed_entry(log, block_num);
 
    if (entry.size()) {
-      eosio::input_stream traces_bin{ entry.data(), entry.data() + entry.size() };
-      BOOST_REQUIRE_NO_THROW(from_bin(traces, traces_bin));
+      abi_serializer shipabi = abi_serializer(json::from_string(eosio::state_history::ship_abi_without_tables()).as<abi_def>(), {});
+      return shipabi.binary_to_variant("transaction_trace[]", entry, {}).get_array();
    }
-   return traces;
+   return variants();
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_splitted_log, T, state_history_testers) {
@@ -848,7 +831,7 @@ bool test_fork(uint32_t stride, uint32_t max_retained_files) {
 
    auto traces = get_traces(chain1.traces_log, b->block_num());
    bool trace_found = std::find_if(traces.begin(), traces.end(), [create_account_trace_id](const auto& v) {
-                         return std::get<eosio::ship_protocol::transaction_trace_v0>(v).id == create_account_trace_id;
+                         return v[1ul]["id"].template as<digest_type>() == create_account_trace_id;
                       }) != traces.end();
 
    return trace_found;

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -21,6 +21,8 @@ using namespace eosio::chain;
 using namespace eosio::testing;
 using namespace std::literals;
 
+static const abi_serializer::yield_function_t null_yield_function{};
+
 namespace eosio::state_history {
 
 template <typename ST>
@@ -82,7 +84,7 @@ public:
    variants deserialize_data(deltas_vector::iterator &it, const std::string& type, const std::string& in_variant_type) {
       variants result;
       for(size_t i=0; i < it->rows.obj.size(); i++) {
-         fc::variant v = shipabi.binary_to_variant(in_variant_type, it->rows.obj[i].second, {});
+         fc::variant v = shipabi.binary_to_variant(in_variant_type, it->rows.obj[i].second, null_yield_function);
          BOOST_REQUIRE(v.is_array() && v.size() == 2 && v[0ul].is_string());
          BOOST_REQUIRE_EQUAL(v[0ul].get_string(), type);
          result.push_back(std::move(v[1ul]));
@@ -92,7 +94,7 @@ public:
 
 private:
    deltas_vector v;
-   abi_serializer shipabi = abi_serializer(json::from_string(eosio::state_history::ship_abi_without_tables()).as<abi_def>(), {});
+   abi_serializer shipabi = abi_serializer(json::from_string(eosio::state_history::ship_abi_without_tables()).as<abi_def>(), null_yield_function);
 };
 
 using table_deltas_testers = boost::mpl::list<table_deltas_tester<legacy_tester>,
@@ -651,8 +653,8 @@ static variants get_traces(eosio::state_history::log_catalog& log, block_num_typ
    auto     entry = get_decompressed_entry(log, block_num);
 
    if (entry.size()) {
-      abi_serializer shipabi = abi_serializer(json::from_string(eosio::state_history::ship_abi_without_tables()).as<abi_def>(), {});
-      return shipabi.binary_to_variant("transaction_trace[]", entry, {}).get_array();
+      abi_serializer shipabi = abi_serializer(json::from_string(eosio::state_history::ship_abi_without_tables()).as<abi_def>(), null_yield_function);
+      return shipabi.binary_to_variant("transaction_trace[]", entry, null_yield_function).get_array();
    }
    return variants();
 }


### PR DESCRIPTION
Removes abieos usage (and the submodule entirely); uses spring's abi_serializer instead.