### PR TITLE
[1.2.0-rc2] P2P: Versioned signed type for gossip_bp_peers_message::signed_bp_peer

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -384,10 +384,12 @@ public:
 
       fc::lock_guard g(gossip_bps.mtx);
       auto& sig_idx = gossip_bps.index.get<by_sig>();
-      for (auto i = msg.peers.begin(); i != msg.peers.end() && !invalid_message;) {
+      for (auto i = msg.peers.begin(); i != msg.peers.end();) {
          const auto& peer = *i;
          bool have_sig = sig_idx.contains(peer.sig); // we already have it, already verified
          if (!have_sig && (!is_peer_key_valid(peer) || !is_expiration_valid(peer))) {
+            if (invalid_message)
+               return false;
             // peer key may have changed or been removed on-chain, do not consider that a fatal error, just remove it
             // may be expired, do not consider that fatal, just remove it
             i = msg.peers.erase(i);
@@ -395,9 +397,6 @@ public:
             ++i;
          }
       }
-
-      if (invalid_message)
-         return false;
 
       return true; // empty is checked by caller
    }

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -173,7 +173,7 @@ public:
                        "p2p-bp-gossip-endpoint ${e} must consist of bp-account-name,inbound-server-endpoint,outbound-ip-address separated by commas, second comma is missing", ("e", entry));
             auto inbound_server_endpoint = rest.substr(0, comma_pos);
             const auto& [host, port, type] = net_utils::split_host_port_type(inbound_server_endpoint);
-            EOS_ASSERT( !host.empty() && !port.empty(), chain::plugin_config_exception,
+            EOS_ASSERT( !host.empty() && !port.empty() && type.empty(), chain::plugin_config_exception,
                         "Invalid p2p-bp-gossip-endpoint inbound server endpoint ${p}, syntax host:port", ("p", inbound_server_endpoint));
             auto outbound_ip_address = rest.substr(comma_pos + 1);
             EOS_ASSERT( outbound_ip_address.length() <= net_utils::max_p2p_address_length, chain::plugin_config_exception,
@@ -310,7 +310,7 @@ public:
          // validate structure and data of msg
          auto valid_endpoint = [](const std::string& addr) -> bool {
             const auto& [host, port, type] = net_utils::split_host_port_type(addr);
-            return !host.empty() && !port.empty();
+            return !host.empty() && !port.empty() && type.empty();
          };
          try {
             const gossip_bp_peers_message::signed_bp_peer* prev = nullptr;

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -403,9 +403,10 @@ public:
       for (const auto& peer : msg.peers) {
          if (auto i = idx.find(std::make_tuple(peer.producer_name, std::cref(peer.server_endpoint()))); i != idx.end()) {
             if (i->sig != peer.sig && peer.expiration() >= i->expiration()) { // signature has changed, producer_name and server_endpoint has not changed
+               assert(peer.cached_bp_peer_info); // unpacked in validate_gossip_bp_peers_message()
                gossip_bps.index.modify(i, [&peer](auto& m) {
                   m.bp_peer_info = peer.bp_peer_info;
-                  m.cached_bp_peer_info = fc::raw::unpack<gossip_bp_peers_message::bp_peer_info_v1>(peer.bp_peer_info);
+                  m.cached_bp_peer_info = peer.cached_bp_peer_info;
                   m.sig = peer.sig;
                });
                diff = true;

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <eosio/net_plugin/net_plugin.hpp>
 #include <eosio/net_plugin/gossip_bps_index.hpp>
 #include <eosio/net_plugin/net_utils.hpp>
 #include <eosio/net_plugin/buffer_factory.hpp>
@@ -130,9 +131,9 @@ public:
    // Only called at plugin startup.
    // set manually configured [producer_account,endpoint] to use as proposer schedule changes.
    // These are not gossiped.
-   void set_configured_bp_peers(const std::vector<std::string>& peers) {
-      assert(!peers.empty());
-      for (const auto& entry : peers) {
+   void set_configured_bp_peers(const std::vector<std::string>& peers_with_producers, const std::vector<std::string>& peers) {
+      assert(!peers_with_producers.empty());
+      for (const auto& entry : peers_with_producers) {
          std::string aname;
          try {
             auto comma_pos = entry.find(',');
@@ -145,7 +146,8 @@ public:
             EOS_ASSERT( !host.empty() && !port.empty(), chain::plugin_config_exception,
                         "Invalid p2p-auto-bp-peer ${p}, syntax host:port:[trx|blk]", ("p", addr));
             net_utils::endpoint e{host, port};
-
+            EOS_ASSERT(std::find(peers.begin(), peers.end(), addr) == peers.end(), chain::plugin_config_exception,
+                       "\"${a}\" should only appear in either p2p-peer-address or p2p-auto-bp-peer option, not both.", ("a",addr));
             fc_dlog(self()->get_logger(), "Setting p2p-auto-bp-peer ${a} -> ${d}", ("a", account)("d", addr));
             config.bp_peer_accounts[e]        = account;
             config.bp_peer_addresses[account] = std::move(e);
@@ -153,15 +155,6 @@ public:
             EOS_ASSERT(false, chain::plugin_config_exception,
                        "The account ${a} supplied by --p2p-auto-bp-peer option is invalid", ("a", aname));
          }
-      }
-   }
-
-   // Only called at plugin startup
-   template <typename T>
-   void for_each_bp_peer_address(T&& fun) const {
-      fc::lock_guard g(gossip_bps.mtx);
-      for (const auto& bp_peer : gossip_bps.index) {
-         fun(bp_peer.server_endpoint);
       }
    }
 
@@ -237,19 +230,16 @@ public:
                }
                // update gossip_bps
                auto& prod_idx = gossip_bps.index.get<by_producer>();
-               gossip_bp_peers_message::signed_bp_peer peer{
-                  { .producer_name = my_bp_account,
-                    .server_endpoint = le.server_endpoint,
-                    .outbound_ip_address = le.outbound_ip_address,
-                    .expiration = expire }
-               };
+               gossip_bp_peers_message::signed_bp_peer peer{ {.producer_name = my_bp_account} };
+               peer.cached_bp_peer_info.emplace(le.server_endpoint, le.outbound_ip_address, expire);
+               peer.bp_peer_info = fc::raw::pack<gossip_bp_peers_message::bp_peer_info_v1>(*peer.cached_bp_peer_info);
                peer.sig = self()->sign_compact(*peer_info->key, peer.digest());
                EOS_ASSERT(peer.sig != signature_type{}, chain::plugin_config_exception,
                           "Unable to sign bp peer ${p}, private key not found for ${k}", ("p", peer.producer_name)("k", peer_info->key->to_string({})));
-               if (auto i = prod_idx.find(boost::make_tuple(my_bp_account, boost::cref(le.server_endpoint))); i != prod_idx.end()) {
+               if (auto i = prod_idx.find(std::make_tuple(my_bp_account, std::cref(le.server_endpoint))); i != prod_idx.end()) {
                   gossip_bps.index.modify(i, [&peer](auto& v) {
-                     v.outbound_ip_address = peer.outbound_ip_address;
-                     v.expiration = peer.expiration;
+                     v.bp_peer_info = peer.bp_peer_info;
+                     v.cached_bp_peer_info = peer.cached_bp_peer_info;
                      v.sig = peer.sig;
                   });
                } else {
@@ -316,34 +306,41 @@ public:
       if (msg.peers.empty())
          return false;
       // initial case, no server_addresses to validate
-      bool initial_msg = msg.peers.size() == 1 && msg.peers[0].server_endpoint.empty();
+      bool initial_msg = msg.peers.size() == 1 && msg.peers[0].bp_peer_info.empty();
       if (!initial_msg) {
          // validate structure and data of msg
-         auto valid_address = [](const std::string& addr) -> bool {
+         auto valid_endpoint = [](const std::string& addr) -> bool {
             const auto& [host, port, type] = net_utils::split_host_port_type(addr);
             return !host.empty() && !port.empty();
          };
-         const gossip_bp_peers_message::bp_peer* prev = nullptr;
-         size_t num_per_producer = 0;
-         for (const auto& peer : msg.peers) {
-            if (peer.producer_name.empty())
-               return false; // invalid bp_peer data
-            if (!valid_address(peer.server_endpoint))
-               return false; // invalid address
-            if (prev != nullptr) {
-               if (prev->producer_name == peer.producer_name) {
-                  ++num_per_producer;
-                  if (num_per_producer > max_bp_peers_per_producer)
-                     return false; // more than allowed per producer
-                  if (prev->server_endpoint == peer.server_endpoint)
-                     return false; // duplicate entries not allowed
-               } else if (prev->producer_name > peer.producer_name) {
-                  return false; // required to be sorted
-               } else {
-                  num_per_producer = 0;
+         try {
+            const gossip_bp_peers_message::signed_bp_peer* prev = nullptr;
+            size_t num_per_producer = 0;
+            for (auto& peer : msg.peers) {
+               if (peer.producer_name.empty())
+                  return false; // invalid bp_peer data
+               assert(!peer.cached_bp_peer_info);
+               peer.cached_bp_peer_info = fc::raw::unpack<gossip_bp_peers_message::bp_peer_info_v1>(peer.bp_peer_info);
+               if (!valid_endpoint(peer.server_endpoint()))
+                  return false; // invalid address
+               if (prev != nullptr) {
+                  if (prev->producer_name == peer.producer_name) {
+                     ++num_per_producer;
+                     if (num_per_producer > max_bp_peers_per_producer)
+                        return false; // more than allowed per producer
+                     if (prev->server_endpoint() == peer.server_endpoint())
+                        return false; // duplicate entries not allowed
+                  } else if (prev->producer_name > peer.producer_name) {
+                     return false; // required to be sorted
+                  } else {
+                     num_per_producer = 0;
+                  }
                }
+               prev = &peer;
             }
-            prev = &peer;
+         } catch ( fc::exception& e ) {
+            fc_dlog(self()->get_logger(), "Exception unpacking gossip_bp_peers_message::signed_bp_peer, error: ${e}", ("e", e.to_detail_string()));
+            return false;
          }
       }
 
@@ -383,7 +380,7 @@ public:
       auto is_expiration_valid = [&](const gossip_bp_peers_message::signed_bp_peer& peer) -> bool {
          if (initial_msg)
             return true; // initial message has no expiration
-         return peer.expiration > head_block_time && peer.expiration < expire;
+         return peer.expiration() > head_block_time && peer.expiration() < expire;
       };
 
       fc::lock_guard g(gossip_bps.mtx);
@@ -403,7 +400,7 @@ public:
       if (invalid_message)
          return false;
 
-      return true;
+      return true; // empty is checked by caller
    }
 
    // thread-safe
@@ -413,11 +410,11 @@ public:
       auto& idx = gossip_bps.index.get<by_producer>();
       bool diff = false;
       for (const auto& peer : msg.peers) {
-         if (auto i = idx.find(boost::make_tuple(peer.producer_name, boost::cref(peer.server_endpoint))); i != idx.end()) {
-            if (i->sig != peer.sig && peer.expiration >= i->expiration) { // signature has changed, producer_name and server_endpoint has not changed
+         if (auto i = idx.find(std::make_tuple(peer.producer_name, std::cref(peer.server_endpoint()))); i != idx.end()) {
+            if (i->sig != peer.sig && peer.expiration() >= i->expiration()) { // signature has changed, producer_name and server_endpoint has not changed
                gossip_bps.index.modify(i, [&peer](auto& m) {
-                  m.outbound_ip_address = peer.outbound_ip_address;
-                  m.expiration = peer.expiration;
+                  m.bp_peer_info = peer.bp_peer_info;
+                  m.cached_bp_peer_info = fc::raw::unpack<gossip_bp_peers_message::bp_peer_info_v1>(peer.bp_peer_info);
                   m.sig = peer.sig;
                });
                diff = true;
@@ -427,11 +424,11 @@ public:
             if (std::distance(r.first, r.second) >= max_bp_peers_per_producer) {
                // remove entry with min expiration
                auto min_expiration_itr = r.first;
-               auto min_expiration = min_expiration_itr->expiration;
+               auto min_expiration = min_expiration_itr->expiration();
                ++r.first;
                for (; r.first != r.second; ++r.first) {
-                  if (r.first->expiration < min_expiration) {
-                     min_expiration = r.first->expiration;
+                  if (r.first->expiration() < min_expiration) {
+                     min_expiration = r.first->expiration();
                      min_expiration_itr = r.first;
                   }
                }
@@ -480,8 +477,8 @@ public:
          }
          auto r = prod_idx.equal_range(account);
          for (auto i = r.first; i != r.second; ++i) {
-            fc_dlog(self()->get_logger(), "${d} gossip bp peer ${p}", ("d", desc)("p", i->server_endpoint));
-            addresses.insert(i->server_endpoint);
+            fc_dlog(self()->get_logger(), "${d} gossip bp peer ${p}", ("d", desc)("p", i->server_endpoint()));
+            addresses.insert(i->server_endpoint());
          }
       }
       return addresses;
@@ -581,16 +578,16 @@ public:
    }
 
    // RPC called from http threads
-   vector<gossip_bp_peers_message::bp_peer> bp_gossip_peers() const {
+   vector<gossip_peer> bp_gossip_peers() const {
       fc::lock_guard g(gossip_bps.mtx);
-      vector<gossip_bp_peers_message::bp_peer> peers;
+      vector<gossip_peer> peers;
       for (const auto& p : gossip_bps.index) {
          // no need to include sig
-         peers.push_back(gossip_bp_peers_message::bp_peer{
+         peers.push_back(gossip_peer{
             p.producer_name,
-            p.server_endpoint,
-            p.outbound_ip_address,
-            p.expiration
+            p.server_endpoint(),
+            p.outbound_ip_address(),
+            p.expiration()
          });
       }
       return peers;

--- a/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
@@ -17,13 +17,13 @@ struct gossip_bp_index_t {
             tag<struct by_producer>,
             composite_key< gossip_bp_peers_message::signed_bp_peer,
                member<gossip_bp_peers_message::bp_peer, name, &gossip_bp_peers_message::bp_peer::producer_name>,
-               member<gossip_bp_peers_message::bp_peer, std::string, &gossip_bp_peers_message::bp_peer::server_endpoint>
+               const_mem_fun<gossip_bp_peers_message::signed_bp_peer, const std::string&, &gossip_bp_peers_message::signed_bp_peer::server_endpoint>
             >,
             composite_key_compare< std::less<>, std::less<> >
          >,
          ordered_non_unique<
             tag< struct by_expiry >,
-            member< gossip_bp_peers_message::bp_peer, block_timestamp_type, &gossip_bp_peers_message::bp_peer::expiration >
+            const_mem_fun<gossip_bp_peers_message::signed_bp_peer, block_timestamp_type, &gossip_bp_peers_message::signed_bp_peer::expiration>
          >,
          ordered_unique<
             tag< struct by_sig >,

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -23,6 +23,13 @@ namespace eosio {
       handshake_message last_handshake;
    };
 
+   struct gossip_peer {
+      eosio::name               producer_name;
+      std::string               server_endpoint;      // externally available address to connect to
+      std::string               outbound_ip_address;  // outbound ip address for firewall
+      block_timestamp_type      expiration;           // head block to remove bp_peer
+   };
+
    class net_plugin : public appbase::plugin<net_plugin>
    {
       public:
@@ -41,7 +48,7 @@ namespace eosio {
         string                            disconnect( const string& endpoint );
         std::optional<connection_status>  status( const string& endpoint )const;
         vector<connection_status>         connections()const;
-        vector<gossip_bp_peers_message::bp_peer> bp_gossip_peers()const;
+        vector<gossip_peer>               bp_gossip_peers()const;
 
         struct p2p_per_connection_metrics {
             struct connection_metric {
@@ -108,3 +115,4 @@ namespace eosio {
 FC_REFLECT( eosio::connection_status, (peer)(remote_ip)(remote_port)(connecting)(syncing)
                                       (is_bp_peer)(is_bp_gossip_peer)(is_socket_open)(is_blocks_only)(is_transactions_only)
                                       (last_vote_received)(last_handshake) )
+FC_REFLECT( eosio::gossip_peer, (producer_name)(server_endpoint)(outbound_ip_address)(expiration) )

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -148,7 +148,7 @@ namespace eosio {
          eosio::name               producer_name;
          std::vector<char>         bp_peer_info;         // serialized bp_peer_info
 
-         digest_type digest() const;
+         digest_type digest(const chain_id_type& chain_id) const;
       };
       struct signed_bp_peer : bp_peer {
          signature_type  sig; // signature over bp_peer

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -137,22 +137,27 @@ namespace eosio {
    };
 
    struct gossip_bp_peers_message {
+      struct bp_peer_info_v1 {
+         std::string               server_endpoint;      // externally available address to connect to
+         std::string               outbound_ip_address;  // outbound ip address for firewall
+         block_timestamp_type      expiration;           // head block to remove bp_peer
+      };
+      // bp_peer_info_v2 can derive from bp_peer_info_v1, so old peers can still unpack bp_peer_info_v1 from bp_peer::bp_peer_info
       struct bp_peer {
+         unsigned_int              version = 1;
          eosio::name               producer_name;
-         std::string               server_endpoint;         // externally available address to connect to
-         std::string               outbound_ip_address;     // empty if equal to server_endpoint ip address
-         block_timestamp_type      expiration;              // head block to remove bp_peer
+         std::vector<char>         bp_peer_info;         // serialized bp_peer_info
 
          digest_type digest() const;
-
-         bool operator==(const bp_peer&) const = default;
-         bool operator<(const bp_peer& rhs) const {
-            // [producer_name, server_endpoint] is unique
-            return std::tie(producer_name, server_endpoint) < std::tie(rhs.producer_name, rhs.server_endpoint);
-         }
       };
       struct signed_bp_peer : bp_peer {
-         signature_type            sig;
+         signature_type  sig; // signature over bp_peer
+
+         std::optional<bp_peer_info_v1> cached_bp_peer_info; // not serialized
+
+         const std::string& server_endpoint() const     { assert(cached_bp_peer_info); return cached_bp_peer_info->server_endpoint; }
+         const std::string& outbound_ip_address() const { assert(cached_bp_peer_info); return cached_bp_peer_info->outbound_ip_address; }
+         block_timestamp_type expiration() const        { assert(cached_bp_peer_info); return cached_bp_peer_info->expiration; }
       };
 
       std::vector<signed_bp_peer> peers;
@@ -220,7 +225,8 @@ FC_REFLECT( eosio::request_message, (req_trx)(req_blocks) )
 FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
 FC_REFLECT( eosio::block_nack_message, (id) )
 FC_REFLECT( eosio::block_notice_message, (previous)(id) )
-FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(server_endpoint)(outbound_ip_address)(expiration) )
+FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer_info_v1, (server_endpoint)(outbound_ip_address)(expiration) )
+FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(bp_peer_info) )
 FC_REFLECT_DERIVED(eosio::gossip_bp_peers_message::signed_bp_peer, (eosio::gossip_bp_peers_message::bp_peer), (sig) )
 FC_REFLECT( eosio::gossip_bp_peers_message, (peers) )
 

--- a/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/protocol.hpp
@@ -226,7 +226,7 @@ FC_REFLECT( eosio::sync_request_message, (start_block)(end_block) )
 FC_REFLECT( eosio::block_nack_message, (id) )
 FC_REFLECT( eosio::block_notice_message, (previous)(id) )
 FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer_info_v1, (server_endpoint)(outbound_ip_address)(expiration) )
-FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (producer_name)(bp_peer_info) )
+FC_REFLECT( eosio::gossip_bp_peers_message::bp_peer, (version)(producer_name)(bp_peer_info) )
 FC_REFLECT_DERIVED(eosio::gossip_bp_peers_message::signed_bp_peer, (eosio::gossip_bp_peers_message::bp_peer), (sig) )
 FC_REFLECT( eosio::gossip_bp_peers_message, (peers) )
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3764,7 +3764,7 @@ namespace eosio {
          return;
       }
 
-      const bool first_msg = msg.peers.size() == 1 && msg.peers[0].server_endpoint.empty();
+      const bool first_msg = msg.peers.size() == 1 && msg.peers[0].bp_peer_info.empty();
       if (!my_impl->validate_gossip_bp_peers_message(msg)) {
          peer_wlog( this, "bad gossip_bp_peers_message, closing");
          no_retry = go_away_reason::fatal_other;
@@ -4449,12 +4449,8 @@ namespace eosio {
                         "agent-name too long, must be less than ${m}", ("m", net_utils::max_handshake_str_length) );
          }
 
-         if ( options.count( "p2p-auto-bp-peer")) {
-            set_configured_bp_peers(options.at( "p2p-auto-bp-peer" ).as<vector<string>>());
-            for_each_bp_peer_address([&peers](const auto& addr) {
-               EOS_ASSERT(std::find(peers.begin(), peers.end(), addr) == peers.end(), chain::plugin_config_exception,
-                          "\"${a}\" should only appear in either p2p-peer-address or p2p-auto-bp-peer option, not both.", ("a",addr));
-            });
+         if (options.count( "p2p-auto-bp-peer")) {
+            set_configured_bp_peers(options.at( "p2p-auto-bp-peer" ).as<vector<string>>(), peers);
          }
 
          if ( options.count( "p2p-bp-gossip-endpoint" ) ) {
@@ -4664,7 +4660,7 @@ namespace eosio {
       return my->connections.connection_statuses();
    }
 
-   vector<gossip_bp_peers_message::bp_peer> net_plugin::bp_gossip_peers()const {
+   vector<gossip_peer> net_plugin::bp_gossip_peers()const {
       return my->bp_gossip_peers();
    }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3746,9 +3746,9 @@ namespace eosio {
       }
    }
 
-   digest_type gossip_bp_peers_message::bp_peer::digest() const {
+   digest_type gossip_bp_peers_message::bp_peer::digest(const chain_id_type& chain_id) const {
       digest_type::encoder enc;
-      fc::raw::pack(enc, my_impl->chain_id);
+      fc::raw::pack(enc, chain_id);
       fc::raw::pack(enc, *this);
       return enc.result();
    }

--- a/plugins/net_plugin/tests/auto_bp_peering_unittest.cpp
+++ b/plugins/net_plugin/tests/auto_bp_peering_unittest.cpp
@@ -56,7 +56,7 @@ struct mock_net_plugin : eosio::auto_bp_peering::bp_connection_manager<mock_net_
                      // prodk is intentionally skipped
                      "prodl,127.0.0.1:8012"s, "prodm,127.0.0.1:8013"s, "prodn,127.0.0.1:8014"s, "prodo,127.0.0.1:8015"s,
                      "prodp,127.0.0.1:8016"s, "prodq,127.0.0.1:8017"s, "prodr,127.0.0.1:8018"s, "prods,127.0.0.1:8019"s,
-                     "prodt,127.0.0.1:8020"s, "produ,127.0.0.1:8021"s });
+                     "prodt,127.0.0.1:8020"s, "produ,127.0.0.1:8021"s }, {});
    }
 
    fc::logger get_logger() const { return fc::logger::get(DEFAULT_LOGGER); }
@@ -75,15 +75,15 @@ const std::vector<std::string> peer_addresses{
 BOOST_AUTO_TEST_CASE(test_set_bp_peers) {
 
    mock_net_plugin plugin;
-   BOOST_CHECK_THROW(plugin.set_configured_bp_peers({ "producer17,127.0.0.1:8888"s }), eosio::chain::plugin_config_exception);
-   BOOST_CHECK_THROW(plugin.set_configured_bp_peers({ "producer1"s }), eosio::chain::plugin_config_exception);
+   BOOST_CHECK_THROW(plugin.set_configured_bp_peers({ "producer17,127.0.0.1:8888"s }, {}), eosio::chain::plugin_config_exception);
+   BOOST_CHECK_THROW(plugin.set_configured_bp_peers({ "producer1"s }, {}), eosio::chain::plugin_config_exception);
 
    plugin.set_configured_bp_peers({
          "producer1,127.0.0.1:8888:blk"s,
          "producer2,127.0.0.1:8889:trx"s,
          "producer3,127.0.0.1:8890"s,
          "producer4,127.0.0.1:8891"s
-   });
+   }, {});
    BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer1"_n], endpoint("127.0.0.1", "8888"));
    BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer2"_n], endpoint("127.0.0.1", "8889"));
    BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer3"_n], endpoint("127.0.0.1", "8890"));


### PR DESCRIPTION
Use a versioned signed type for `gossip_bp_peers_message::signed_bp_peer`. This will allow for future additions to the `signed_bp_peer` while maintaining backward compatibility with future signed data.

See #1495 for more details.

Resolves #1495 