### PR TITLE
[1.2.0-rc2 -> main] P2P: Gossip BP peer enhancements

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3412,8 +3412,10 @@ struct controller_impl {
    } /// start_block
 
    void update_peer_keys() {
-      // if syncing or replaying old blocks don't bother updating peer keys
-      if (!peer_keys_db.is_active() || fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
+      if (!peer_keys_db.is_active())
+         return;
+      // if syncing or replaying old blocks don't bother updating peer keys.
+      if (fc::time_point::now() - chain_head.timestamp() > fc::minutes(5))
          return;
 
       try {
@@ -5877,7 +5879,7 @@ chain_id_type controller::get_chain_id()const {
    return my->chain_id;
 }
 
-void controller::set_peer_keys_retrieval_active(peer_name_set_t configured_bp_peers) {
+void controller::set_peer_keys_retrieval_active(name_set_t configured_bp_peers) {
    my->peer_keys_db.set_active(std::move(configured_bp_peers));
 }
 
@@ -5886,7 +5888,7 @@ std::optional<peer_info_t> controller::get_peer_info(name n) const {
 }
 
 bool controller::configured_peer_keys_updated() {
-   return my->peer_keys_db.configured_peer_keys_updated();
+   return my->peer_keys_db.is_active() && my->peer_keys_db.configured_peer_keys_updated();
 }
 
 getpeerkeys_res_t controller::get_top_producer_keys() {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -430,7 +430,7 @@ namespace eosio::chain {
 
          chain_id_type get_chain_id()const;
 
-         void set_peer_keys_retrieval_active(peer_name_set_t configured_bp_peers);
+         void set_peer_keys_retrieval_active(name_set_t configured_bp_peers);
          std::optional<peer_info_t> get_peer_info(name n) const;  // thread safe
          bool configured_peer_keys_updated(); // thread safe
          // used for testing, only call with an active pending block from main thread

--- a/libraries/chain/include/eosio/chain/peer_keys_db.hpp
+++ b/libraries/chain/include/eosio/chain/peer_keys_db.hpp
@@ -27,7 +27,7 @@ struct peer_info_t {
 };
 
 using peer_key_map_t = boost::unordered_flat_map<name, peer_info_t, std::hash<name>>;
-using peer_name_set_t = flat_set<name>;
+using name_set_t = flat_set<name>;
 
 /**
  * This class caches the on-chain public keys that BP use to sign the `gossip_bp_peers`
@@ -39,7 +39,7 @@ public:
    peer_keys_db_t() = default;
 
    // called on startup with configured bp peers of the node
-   void set_active(peer_name_set_t configured_bp_peers) {
+   void set_active(name_set_t configured_bp_peers) {
       _configured_bp_peers = std::move(configured_bp_peers);
       _active = true;
    }
@@ -64,7 +64,7 @@ public:
 private:
    bool               _active = false;       // if not active (the default), no update occurs
    block_num_type     _last_block_num = 0;
-   peer_name_set_t    _configured_bp_peers;  // no updates occurs
+   name_set_t         _configured_bp_peers;  // no updates occurs
    std::atomic<bool>  _configured_bp_peers_updated{false};
 
    mutable fc::mutex  _m;

--- a/libraries/chain/peer_keys_db.cpp
+++ b/libraries/chain/peer_keys_db.cpp
@@ -17,11 +17,12 @@ bool peer_keys_db_t::configured_peer_keys_updated() {
 
 void peer_keys_db_t::update_peer_keys(block_num_type block_num, const getpeerkeys_res_t& v) {
    assert(_active);
-   _last_block_num = block_num;
 
    if (v.empty())
       return;
    
+   _last_block_num = block_num;
+
    // create hash_map of current top selected producers (according to "getpeerkeys"_n in system contracts)
    // ----------------------------------------------------------------------------------------------------
    peer_key_map_t current;

--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -63,7 +63,9 @@ void net_api_plugin::plugin_startup() {
             INVOKE_R_R(net_mgr, status, std::string), 201),
        CALL_WITH_400(net, net_ro, net_mgr, connections,
             INVOKE_R_V(net_mgr, connections), 201),
-   } );
+       CALL_WITH_400(net, net_ro, net_mgr, bp_gossip_peers,
+            INVOKE_R_V(net_mgr, bp_gossip_peers), 201),
+  } );
 }
 
 void net_api_plugin::plugin_initialize(const variables_map& options) {

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -21,54 +21,73 @@ class bp_connection_manager {
  public:
 #endif
 
-   static constexpr size_t max_bp_peers_per_producer = 4;
+   static constexpr size_t           max_bp_gossip_peers_per_producer = 8;
+   static constexpr fc::microseconds bp_gossip_peer_expiration = fc::hours(1);
+   static constexpr fc::microseconds my_bp_gossip_peer_expiration = fc::minutes(30); // resend my bp_peer info every 30 minutes
+   static constexpr fc::microseconds bp_gossip_peer_expiration_variance = bp_gossip_peer_expiration + fc::minutes(15);
+
    gossip_bp_index_t      gossip_bps;
+
+   struct bp_gossip_endpoint_t {
+      std::string server_endpoint;      // externally known inbound endpoint host:port
+      std::string outbound_ip_address;  // externally known outbound IP address
+
+      auto operator<=>(const bp_gossip_endpoint_t& rhs) const = default;
+      bool operator==(const bp_gossip_endpoint_t& rhs) const = default;
+   };
 
    // the following members are thread-safe, only modified during plugin startup
    struct config_t {
-      flat_map<account_name, net_utils::endpoint>   bp_peer_addresses;
-      flat_map<net_utils::endpoint, account_name>   bp_peer_accounts;
-      peer_name_set_t                               my_bp_accounts;       // block producer --producer-name
-      peer_name_set_t                               my_bp_peer_accounts;  // peer key account --p2p-producer-peer
+      // p2p-auto-bp-peer
+      flat_map<account_name, net_utils::endpoint>   auto_bp_addresses;      // --p2p-auto-bp-peer account->endpoint
+      flat_map<net_utils::endpoint, account_name>   auto_bp_accounts;       // --p2p-auto-bp-peer endpoint->account
+      // p2p-bp-gossip-endpoint, producer account -> [inbound_endpoint,outbound_ip_address] for bp gossip
+      std::unordered_map<account_name, std::vector<bp_gossip_endpoint_t>>  my_bp_gossip_accounts;
    } config; // thread safe only because modified at plugin startup currently
 
    // the following members are only accessed from main thread
-   peer_name_set_t        pending_bps;
+   name_set_t             pending_bps;
    uint32_t               pending_schedule_version = 0;
    uint32_t               active_schedule_version  = 0;
 
    fc::mutex                     mtx;
    gossip_buffer_initial_factory initial_gossip_msg_factory GUARDED_BY(mtx);
-   peer_name_set_t               active_bps GUARDED_BY(mtx);
-   peer_name_set_t               active_schedule GUARDED_BY(mtx);
+   name_set_t                    active_bps GUARDED_BY(mtx);
+   name_set_t                    active_schedule GUARDED_BY(mtx);
 
    Derived*       self() { return static_cast<Derived*>(this); }
    const Derived* self() const { return static_cast<const Derived*>(this); }
 
    template <template <typename...> typename Container, typename... Rest>
+   requires std::is_same_v<typename Container<account_name, Rest...>::value_type, account_name>
    static std::string to_string(const Container<account_name, Rest...>& peers) {
       return boost::algorithm::join(peers | boost::adaptors::transformed([](auto& p) { return p.to_string(); }), ",");
    }
+   template <template <typename...> typename Container, typename... Rest>
+   requires std::is_same_v<typename Container<std::string, Rest...>::value_type, std::string>
+   static std::string to_string(const Container<std::string, Rest...>& peers) {
+      return boost::algorithm::join(peers, ",");
+   }
 
    // Only called from main thread
-   peer_name_set_t active_bp_accounts(const std::vector<chain::producer_authority>& schedule) const {
+   name_set_t active_bp_accounts(const std::vector<chain::producer_authority>& schedule) const {
       fc::lock_guard g(gossip_bps.mtx);
       const auto& prod_idx = gossip_bps.index.get<by_producer>();
-      peer_name_set_t result;
+      name_set_t result;
       for (const auto& auth : schedule) {
-         if (config.bp_peer_addresses.contains(auth.producer_name) || prod_idx.contains(auth.producer_name))
+         if (config.auto_bp_addresses.contains(auth.producer_name) || prod_idx.contains(auth.producer_name))
             result.insert(auth.producer_name);
       }
       return result;
    }
 
    // called from net threads
-   peer_name_set_t active_bp_accounts(const peer_name_set_t& active_schedule) const REQUIRES(mtx) {
+   name_set_t active_bp_accounts(const name_set_t& active_schedule) const REQUIRES(mtx) {
       fc::lock_guard g(gossip_bps.mtx);
       const auto& prod_idx = gossip_bps.index.get<by_producer>();
-      peer_name_set_t result;
+      name_set_t result;
       for (const auto& a : active_schedule) {
-         if (config.bp_peer_addresses.contains(a) || prod_idx.contains(a))
+         if (config.auto_bp_addresses.contains(a) || prod_idx.contains(a))
             result.insert(a);
       }
       return result;
@@ -81,52 +100,55 @@ class bp_connection_manager {
    }
 
    // for testing
-   peer_name_set_t get_active_bps() {
+   name_set_t get_active_bps() {
       fc::lock_guard g(mtx);
       return active_bps;
    }
    // for testing
-   void set_active_bps(peer_name_set_t bps) {
+   void set_active_bps(name_set_t bps) {
       fc::lock_guard g(mtx);
       active_bps = std::move(bps);
    }
 
 public:
-   bool auto_bp_peering_enabled() const { return !config.bp_peer_addresses.empty() || !config.my_bp_peer_accounts.empty(); }
-   bool bp_gossip_enabled() const { return !config.my_bp_peer_accounts.empty(); }
-   peer_name_set_t configured_bp_peer_accounts() const { return config.my_bp_peer_accounts; }
+   // the following accessors are thread-safe
+   // return true if bp gossip enabled (node has a configured producer peer account)
+   bool bp_gossip_enabled() const { return !config.my_bp_gossip_accounts.empty(); }
+   // return true if auto bp peering of manually configured bp peers is configured or if bp gossip enabled
+   bool auto_bp_peering_enabled() const { return !config.auto_bp_addresses.empty() || bp_gossip_enabled(); }
+   name_set_t my_bp_gossip_accounts() const {
+      name_set_t result;
+      for (const auto& a : config.my_bp_gossip_accounts)
+         result.insert(a.first);
+      return result;
+   }
    bool bp_gossip_initialized() { return !!get_gossip_bp_initial_send_buffer(); }
 
-   // Only called at plugin startup
-   void set_producer_accounts(const std::set<account_name>& accounts) {
-      config.my_bp_accounts.insert(accounts.begin(), accounts.end());
-   }
-
-   // thread safe, my_bp_accounts only modified during plugin startup
-   bool is_producer(account_name account) const {
-      return config.my_bp_accounts.contains(account);
-   }
-
-   // Only called at plugin startup
+   // Only called at plugin startup.
+   // set manually configured [producer_account,endpoint] to use as proposer schedule changes.
+   // These are not gossiped.
    void set_configured_bp_peers(const std::vector<std::string>& peers) {
+      assert(!peers.empty());
       for (const auto& entry : peers) {
+         std::string aname;
          try {
             auto comma_pos = entry.find(',');
             EOS_ASSERT(comma_pos != std::string::npos, chain::plugin_config_exception,
-                       "p2p-auto-bp-peer must consist of an account name and server address separated by a comma");
-            auto         addr = entry.substr(comma_pos + 1);
-            account_name account(entry.substr(0, comma_pos));
+                       "p2p-auto-bp-peer ${e} must consist of an account name and server address separated by a comma", ("e", entry));
+            auto addr = entry.substr(comma_pos + 1);
+            aname = entry.substr(0, comma_pos);
+            account_name account(aname);
             const auto& [host, port, type] = net_utils::split_host_port_type(addr);
             EOS_ASSERT( !host.empty() && !port.empty(), chain::plugin_config_exception,
                         "Invalid p2p-auto-bp-peer ${p}, syntax host:port:[trx|blk]", ("p", addr));
             net_utils::endpoint e{host, port};
 
             fc_dlog(self()->get_logger(), "Setting p2p-auto-bp-peer ${a} -> ${d}", ("a", account)("d", addr));
-            config.bp_peer_accounts[e]        = account;
-            config.bp_peer_addresses[account] = std::move(e);
+            config.auto_bp_accounts[e]        = account;
+            config.auto_bp_addresses[account] = std::move(e);
          } catch (chain::name_type_exception&) {
             EOS_ASSERT(false, chain::plugin_config_exception,
-                       "the account ${a} supplied by --p2p-auto-bp-peer option is invalid", ("a", entry));
+                       "The account ${a} supplied by --p2p-auto-bp-peer option is invalid", ("a", aname));
          }
       }
    }
@@ -136,50 +158,109 @@ public:
    void for_each_bp_peer_address(T&& fun) const {
       fc::lock_guard g(gossip_bps.mtx);
       for (const auto& bp_peer : gossip_bps.index) {
-         fun(bp_peer.server_address);
+         fun(bp_peer.server_endpoint);
       }
    }
 
    // Only called at plugin startup
-   void set_bp_producer_peers(const std::vector<std::string>& peers) {
-      for (const auto& entry : peers) {
+   // The configured p2p-bp-gossip-endpoint [producer_account,inbound_server_endpoint,outbound_ip_address] for bp gossip
+   void set_bp_producer_peers(const std::vector<std::string>& bp_gossip_endpoints) {
+      assert(!bp_gossip_endpoints.empty());
+      for (const auto& entry : bp_gossip_endpoints) {
+         std::string aname;
          try {
-            config.my_bp_peer_accounts.emplace(chain::name(entry));
+            auto comma_pos = entry.find(',');
+            EOS_ASSERT(comma_pos != std::string::npos, chain::plugin_config_exception,
+                       "p2p-bp-gossip-endpoint ${e} must consist of bp-account-name,inbound-server-endpoint,outbound-ip-address separated by commas", ("e", entry));
+            aname = entry.substr(0, comma_pos);
+            account_name account(aname);
+            auto rest = entry.substr(comma_pos + 1);
+            comma_pos = rest.find(',');
+            EOS_ASSERT(comma_pos != std::string::npos, chain::plugin_config_exception,
+                       "p2p-bp-gossip-endpoint ${e} must consist of bp-account-name,inbound-server-endpoint,outbound-ip-address separated by commas, second comma is missing", ("e", entry));
+            auto inbound_server_endpoint = rest.substr(0, comma_pos);
+            const auto& [host, port, type] = net_utils::split_host_port_type(inbound_server_endpoint);
+            EOS_ASSERT( !host.empty() && !port.empty(), chain::plugin_config_exception,
+                        "Invalid p2p-bp-gossip-endpoint inbound server endpoint ${p}, syntax host:port", ("p", inbound_server_endpoint));
+            auto outbound_ip_address = rest.substr(comma_pos + 1);
+            EOS_ASSERT( outbound_ip_address.length() <= net_utils::max_p2p_address_length, chain::plugin_config_exception,
+                        "p2p-bp-gossip-endpoint outbound-ip-address ${a} too long, must be less than ${m}",
+                        ("a", outbound_ip_address)("m", net_utils::max_p2p_address_length) );
+            auto is_valid_ip_address = [](const std::string& ip_str) {
+               try {
+                  boost::asio::ip::address::from_string(ip_str);
+               } catch ( ... ) {
+                  return false;
+               }
+               return true;
+            };
+            EOS_ASSERT( is_valid_ip_address(outbound_ip_address), chain::plugin_config_exception,
+                        "Invalid p2p-bp-gossip-endpoint outbound ip address ${p}, syntax ip-address", ("p", outbound_ip_address));
+
+            fc_dlog(self()->get_logger(), "Setting p2p-bp-gossip-endpoint ${a} -> ${i},${o}", ("a", account)("i", inbound_server_endpoint)("o", outbound_ip_address));
+            EOS_ASSERT(std::ranges::find_if(config.my_bp_gossip_accounts[account],
+                                            [&](const auto& e) { return e.server_endpoint == inbound_server_endpoint; }) == config.my_bp_gossip_accounts[account].end(),
+                       chain::plugin_config_exception, "Duplicate p2p-bp-gossip-endpoint for: ${a}, inbound server endpoint: ${i}",
+                       ("a", account)("i", inbound_server_endpoint));
+            config.my_bp_gossip_accounts[account].emplace_back(inbound_server_endpoint, outbound_ip_address);
+            EOS_ASSERT(config.my_bp_gossip_accounts[account].size() <= max_bp_gossip_peers_per_producer, chain::plugin_config_exception,
+                       "Too many p2p-bp-gossip-endpoint for ${a}, max ${m}", ("a", account)("m", max_bp_gossip_peers_per_producer));
          } catch (chain::name_type_exception&) {
             EOS_ASSERT(false, chain::plugin_config_exception,
-                       "the producer ${p} supplied by --p2p-producer-peer option is invalid", ("p", entry));
+                       "The account ${a} supplied by --p2p-bp-gossip-endpoint option is invalid", ("a", aname));
          }
       }
    }
 
+   // thread-safe
    // Called when configured bp peer key changes
-   void update_bp_producer_peers(const chain::controller& cc, const std::string& server_address) {
-      assert(!config.my_bp_peer_accounts.empty());
+   void update_bp_producer_peers() {
+      assert(!config.my_bp_gossip_accounts.empty());
       fc::lock_guard gm(mtx);
       fc::lock_guard g(gossip_bps.mtx);
+      bool initial_updated = false;
       // normally only one bp peer account except in testing scenarios or test chains
-      for (const auto& e : config.my_bp_peer_accounts) { // my_bp_peer_accounts not modified after plugin startup
-         std::optional<peer_info_t> peer_info = cc.get_peer_info(e);
+      const controller& cc = self()->chain_plug->chain();
+      block_timestamp_type expire = self()->head_block_time.load() + bp_gossip_peer_expiration;
+      fc_dlog(self()->get_logger(), "Updating BP gossip_bp_peers_message with expiration ${e}", ("e", expire));
+      for (const auto& my_bp_account : config.my_bp_gossip_accounts) { // my_bp_gossip_accounts not modified after plugin startup
+         const auto& bp_account = my_bp_account.first;
+         std::optional<peer_info_t> peer_info = cc.get_peer_info(bp_account);
          if (peer_info && peer_info->key) {
-            // update initial so always an active one
-            gossip_bp_peers_message::bp_peer signed_empty{.producer_name = e}; // .server_address not set for initial message
-            signed_empty.sig = self()->sign_compact(*peer_info->key, signed_empty.digest());
-            EOS_ASSERT(signed_empty.sig != signature_type{}, chain::plugin_config_exception,
-                       "Unable to sign empty gossip bp peer, private key not found for ${k}", ("k", peer_info->key->to_string({})));
-            initial_gossip_msg_factory.set_initial_send_buffer(signed_empty);
-            // update gossip_bps
-            auto& prod_idx = gossip_bps.index.get<by_producer>();
-            gossip_bp_peers_message::bp_peer peer{.producer_name = e, .server_address = server_address};
-            peer.sig = self()->sign_compact(*peer_info->key, peer.digest());
-            EOS_ASSERT(peer.sig != signature_type{}, chain::plugin_config_exception,
-                       "Unable to sign bp peer ${p}, private key not found for ${k}", ("p", peer.producer_name)("k", peer_info->key->to_string({})));
-            if (auto i = prod_idx.find(boost::make_tuple(e, boost::cref(server_address))); i != prod_idx.end()) {
-               gossip_bps.index.modify(i, [&peer](auto& v) {
-                  v.sig = peer.sig;
-               });
-            } else {
-               gossip_bps.index.emplace(peer);
+            for (const auto& le : my_bp_account.second) {
+               fc_dlog(self()->get_logger(), "Updating BP gossip_bp_peers_message for ${a} address ${s}", ("a", bp_account)("s", le.server_endpoint));
+                  if (!initial_updated) {
+                     // update initial so always an active one
+                     gossip_bp_peers_message::signed_bp_peer signed_empty{{.producer_name = bp_account}}; // .server_endpoint not set for initial message
+                     signed_empty.sig = self()->sign_compact(*peer_info->key, signed_empty.digest());
+                     EOS_ASSERT(signed_empty.sig != signature_type{}, chain::plugin_config_exception,
+                                "Unable to sign empty gossip bp peer of ${a}, private key not found for ${k}", ("a", bp_account)("k", peer_info->key->to_string({})));
+                     initial_gossip_msg_factory.set_initial_send_buffer(signed_empty);
+                     initial_updated = true;
+                  }
+                  // update gossip_bps
+                  auto& prod_idx = gossip_bps.index.get<by_producer>();
+                  gossip_bp_peers_message::signed_bp_peer peer{
+                     { .producer_name = bp_account,
+                       .server_endpoint = le.server_endpoint,
+                       .outbound_ip_address = le.outbound_ip_address,
+                       .expiration = expire }
+                  };
+                  peer.sig = self()->sign_compact(*peer_info->key, peer.digest());
+                  EOS_ASSERT(peer.sig != signature_type{}, chain::plugin_config_exception,
+                             "Unable to sign bp peer ${p}, private key not found for ${k}", ("p", peer.producer_name)("k", peer_info->key->to_string({})));
+                  if (auto i = prod_idx.find(boost::make_tuple(bp_account, boost::cref(le.server_endpoint))); i != prod_idx.end()) {
+                     gossip_bps.index.modify(i, [&peer](auto& v) {
+                        v.outbound_ip_address = peer.outbound_ip_address;
+                        v.expiration = peer.expiration;
+                        v.sig = peer.sig;
+                     });
+                  } else {
+                     gossip_bps.index.emplace(peer);
+                  }
             }
+         } else {
+            fc_wlog(self()->get_logger(), "On-chain peer-key not found for configured BP ${a}", ("a", bp_account));
          }
       }
    }
@@ -192,7 +273,7 @@ public:
       std::string type;
       std::tie(e.host, e.port, type) = eosio::net_utils::split_host_port_type(conn->log_p2p_address);
 
-      if (config.bp_peer_accounts.count(e)) {
+      if (config.auto_bp_accounts.contains(e)) {
          conn->bp_connection = Connection::bp_connection_type::bp_config;
       }
    }
@@ -238,7 +319,7 @@ public:
       if (msg.peers.empty())
          return false;
       // initial case, no server_addresses to validate
-      bool initial_msg = msg.peers.size() == 1 && msg.peers[0].server_address.empty();
+      bool initial_msg = msg.peers.size() == 1 && msg.peers[0].server_endpoint.empty();
       if (!initial_msg) {
          // validate structure and data of msg
          auto valid_address = [](const std::string& addr) -> bool {
@@ -250,14 +331,14 @@ public:
          for (const auto& peer : msg.peers) {
             if (peer.producer_name.empty())
                return false; // invalid bp_peer data
-            if (!valid_address(peer.server_address))
+            if (!valid_address(peer.server_endpoint))
                return false; // invalid address
             if (prev != nullptr) {
                if (prev->producer_name == peer.producer_name) {
                   ++num_per_producer;
-                  if (num_per_producer > max_bp_peers_per_producer)
+                  if (num_per_producer > max_bp_gossip_peers_per_producer)
                      return false; // more than allowed per producer
-                  if (prev->server_address == peer.server_address)
+                  if (prev->server_endpoint == peer.server_endpoint)
                      return false; // duplicate entries not allowed
                } else if (prev->producer_name > peer.producer_name) {
                   return false; // required to be sorted
@@ -271,7 +352,7 @@ public:
 
       const controller& cc = self()->chain_plug->chain();
       bool invalid_message = false;
-      auto is_peer_key_valid = [&](const gossip_bp_peers_message::bp_peer& peer) -> bool {
+      auto is_peer_key_valid = [&](const gossip_bp_peers_message::signed_bp_peer& peer) -> bool {
          try {
             if (peer.sig.is_webauthn()) {
                fc_dlog(self()->get_logger(), "Peer ${p} signature is webauthn, not allowed.", ("p", peer.producer_name));
@@ -300,13 +381,22 @@ public:
          return true;
       };
 
+      const auto head_block_time = self()->head_block_time.load();
+      const block_timestamp_type latest_acceptable_expiration_time = head_block_time + bp_gossip_peer_expiration_variance;
+      auto is_expiration_valid = [&](const gossip_bp_peers_message::signed_bp_peer& peer) -> bool {
+         if (initial_msg)
+            return true; // initial message has no expiration
+         return peer.expiration > head_block_time && peer.expiration < latest_acceptable_expiration_time;
+      };
+
       fc::lock_guard g(gossip_bps.mtx);
       auto& sig_idx = gossip_bps.index.get<by_sig>();
       for (auto i = msg.peers.begin(); i != msg.peers.end() && !invalid_message;) {
          const auto& peer = *i;
          bool have_sig = sig_idx.contains(peer.sig); // we already have it, already verified
-         if (!have_sig && !is_peer_key_valid(peer)) {
+         if (!have_sig && (!is_peer_key_valid(peer) || !is_expiration_valid(peer))) {
             // peer key may have changed or been removed on-chain, do not consider that a fatal error, just remove it
+            // may be expired, do not consider that fatal, just remove it
             i = msg.peers.erase(i);
          } else {
             ++i;
@@ -326,17 +416,29 @@ public:
       auto& idx = gossip_bps.index.get<by_producer>();
       bool diff = false;
       for (const auto& peer : msg.peers) {
-         if (auto i = idx.find(boost::make_tuple(peer.producer_name, boost::cref(peer.server_address))); i != idx.end()) {
-            if (i->sig != peer.sig) { // signature has changed, producer_name and server_address has not changed
+         if (auto i = idx.find(boost::make_tuple(peer.producer_name, boost::cref(peer.server_endpoint))); i != idx.end()) {
+            if (i->sig != peer.sig && peer.expiration >= i->expiration) { // signature has changed, producer_name and server_endpoint has not changed
                gossip_bps.index.modify(i, [&peer](auto& m) {
-                  m.sig = peer.sig; // update the signature, producer_name and server_address has not changed
+                  m.outbound_ip_address = peer.outbound_ip_address;
+                  m.expiration = peer.expiration;
+                  m.sig = peer.sig;
                });
                diff = true;
             }
          } else {
-            if (idx.count(peer.producer_name) >= max_bp_peers_per_producer) {
-               // only allow max_bp_peers_per_producer, choose one to remove
-               gossip_bps.index.erase(idx.find(peer.producer_name));
+            auto r = idx.equal_range(peer.producer_name);
+            if (std::distance(r.first, r.second) >= max_bp_gossip_peers_per_producer) {
+               // remove entry with min expiration
+               auto min_expiration_itr = r.first;
+               auto min_expiration = min_expiration_itr->expiration;
+               ++r.first;
+               for (; r.first != r.second; ++r.first) {
+                  if (r.first->expiration < min_expiration) {
+                     min_expiration = r.first->expiration;
+                     min_expiration_itr = r.first;
+                  }
+               }
+               gossip_bps.index.erase(min_expiration_itr);
             }
             gossip_bps.index.insert(peer);
             diff = true;
@@ -345,19 +447,44 @@ public:
       return diff;
    }
 
-   flat_set<std::string> find_gossip_bp_addresses(const peer_name_set_t& accounts, const char* desc) const {
+   // thread-safe
+   // return true if my bp accounts will expire "soon"
+   bool expire_gossip_bp_peers() {
+      if (!bp_gossip_enabled())
+         return false;
+
+      auto head_block_time = self()->head_block_time.load();
+
+      fc::lock_guard g(gossip_bps.mtx);
+      auto& idx = gossip_bps.index.get<by_expiry>();
+      auto ex_lo = idx.lower_bound(block_timestamp_type{});
+      auto ex_up = idx.upper_bound(head_block_time);
+      idx.erase(ex_lo, ex_up);
+      if (ex_up != idx.end()) {
+         ex_lo = ex_up;
+         ex_up = idx.upper_bound(head_block_time + my_bp_gossip_peer_expiration);
+         auto my_bp_account_will_expire = std::ranges::any_of(ex_lo, ex_up, [&](const auto& i) {
+            return config.my_bp_gossip_accounts.contains(i.producer_name);
+         });
+         return my_bp_account_will_expire;
+      }
+
+      return false;
+   }
+
+   flat_set<std::string> find_gossip_bp_addresses(const name_set_t& accounts, const char* desc) const {
       flat_set<std::string> addresses;
       fc::lock_guard g(gossip_bps.mtx);
       const auto& prod_idx = gossip_bps.index.get<by_producer>();
       for (const auto& account : accounts) {
-         if (auto i = config.bp_peer_addresses.find(account); i != config.bp_peer_addresses.end()) {
+         if (auto i = config.auto_bp_addresses.find(account); i != config.auto_bp_addresses.end()) {
             fc_dlog(self()->get_logger(), "${d} manual bp peer ${p}", ("d", desc)("p", i->second));
             addresses.insert(i->second.address());
          }
          auto r = prod_idx.equal_range(account);
          for (auto i = r.first; i != r.second; ++i) {
-            fc_dlog(self()->get_logger(), "${d} gossip bp peer ${p}", ("d", desc)("p", i->server_address));
-            addresses.insert(i->server_address);
+            fc_dlog(self()->get_logger(), "${d} gossip bp peer ${p}", ("d", desc)("p", i->server_endpoint));
+            addresses.insert(i->server_endpoint);
          }
       }
       return addresses;
@@ -371,7 +498,10 @@ public:
       {
          fc::lock_guard gm(mtx);
          active_bps = active_bp_accounts(active_schedule);
+         fc_dlog(self()->get_logger(), "active_bps: ${a}", ("a", to_string(active_bps)));
+
          addresses = find_gossip_bp_addresses(active_bps, "connect");
+         fc_dlog(self()->get_logger(), "active addresses: ${a}", ("a", to_string(addresses)));
       }
 
       for (const auto& add : addresses) {
@@ -432,14 +562,14 @@ public:
 
          fc_dlog(self()->get_logger(), "active_bps: ${a}", ("a", to_string(active_bps)));
 
-         peer_name_set_t peers_to_stay;
+         name_set_t peers_to_stay;
          std::set_union(active_bps.begin(), active_bps.end(), pending_bps.begin(), pending_bps.end(),
                         std::inserter(peers_to_stay, peers_to_stay.begin()));
          gm.unlock();
 
          fc_dlog(self()->get_logger(), "peers_to_stay: ${p}", ("p", to_string(peers_to_stay)));
 
-         peer_name_set_t peers_to_drop;
+         name_set_t peers_to_drop;
          std::set_difference(old_bps.begin(), old_bps.end(), peers_to_stay.begin(), peers_to_stay.end(),
                              std::inserter(peers_to_drop, peers_to_drop.end()));
          fc_dlog(self()->get_logger(), "peers to drop: ${p}", ("p", to_string(peers_to_drop)));
@@ -451,6 +581,22 @@ public:
 
          active_schedule_version = schedule.version;
       }
+   }
+
+   // RPC called from http threads
+   vector<gossip_bp_peers_message::bp_peer> bp_gossip_peers() const {
+      fc::lock_guard g(gossip_bps.mtx);
+      vector<gossip_bp_peers_message::bp_peer> peers;
+      for (const auto& p : gossip_bps.index) {
+         // no need to include sig
+         peers.emplace_back(
+            p.producer_name,
+            p.server_endpoint,
+            p.outbound_ip_address,
+            p.expiration
+         );
+      }
+      return peers;
    }
 };
 } // namespace eosio::auto_bp_peering

--- a/plugins/net_plugin/include/eosio/net_plugin/buffer_factory.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/buffer_factory.hpp
@@ -156,7 +156,7 @@ namespace eosio {
          const uint32_t which_size = fc::raw::pack_size( unsigned_int( which ) );
          // content size
          size_t s = fc::raw::pack_size( unsigned_int((uint32_t)gossip_bp_peers.index.size()) ); // match vector pack
-         for (const auto& peer : gossip_bp_peers.index.get<by_producer>()) {
+         for (const gossip_bp_peers_message::signed_bp_peer& peer : gossip_bp_peers.index.get<by_producer>()) {
             s += fc::raw::pack_size( peer );
          }
          const uint32_t payload_size = which_size + s;
@@ -169,7 +169,7 @@ namespace eosio {
          ds.write( header, message_header_size );
          fc::raw::pack( ds, unsigned_int( which ) );
          fc::raw::pack( ds, unsigned_int((uint32_t)gossip_bp_peers.index.size()) );
-         for (const auto& peer : gossip_bp_peers.index.get<by_producer>()) {
+         for (const gossip_bp_peers_message::signed_bp_peer& peer : gossip_bp_peers.index.get<by_producer>()) {
             fc::raw::pack( ds, peer );
          }
 
@@ -180,7 +180,7 @@ namespace eosio {
    struct gossip_buffer_initial_factory : public buffer_factory {
 
       // called on startup
-      void set_initial_send_buffer(const gossip_bp_peers_message::bp_peer& signed_empty) {
+      void set_initial_send_buffer(const gossip_bp_peers_message::signed_bp_peer& signed_empty) {
          send_buffer = create_initial_send_buffer(signed_empty);
       }
 
@@ -191,7 +191,7 @@ namespace eosio {
 
    private:
 
-      static send_buffer_type create_initial_send_buffer(const gossip_bp_peers_message::bp_peer& signed_empty) {
+      static send_buffer_type create_initial_send_buffer(const gossip_bp_peers_message::signed_bp_peer& signed_empty) {
          constexpr uint32_t which = to_index(msg_type_t::gossip_bp_peers_message);
 
          // match net_message static_variant pack

--- a/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
@@ -11,20 +11,25 @@ namespace eosio {
 
 struct gossip_bp_index_t {
    using gossip_bps_index_container_t = boost::multi_index_container<
-      gossip_bp_peers_message::bp_peer,
+      gossip_bp_peers_message::signed_bp_peer,
       indexed_by<
          ordered_unique<
             tag<struct by_producer>,
-            composite_key< gossip_bp_peers_message::bp_peer,
+            composite_key< gossip_bp_peers_message::signed_bp_peer,
                member<gossip_bp_peers_message::bp_peer, name, &gossip_bp_peers_message::bp_peer::producer_name>,
-               member<gossip_bp_peers_message::bp_peer, std::string, &gossip_bp_peers_message::bp_peer::server_address>
+               member<gossip_bp_peers_message::bp_peer, std::string, &gossip_bp_peers_message::bp_peer::server_endpoint>
             >,
             composite_key_compare< std::less<>, std::less<> >
          >,
+         ordered_non_unique<
+            tag< struct by_expiry >,
+            member< gossip_bp_peers_message::bp_peer, block_timestamp_type, &gossip_bp_peers_message::bp_peer::expiration >
+         >,
          ordered_unique<
             tag< struct by_sig >,
-            member< gossip_bp_peers_message::bp_peer, chain::signature_type, &gossip_bp_peers_message::bp_peer::sig > >
+            member< gossip_bp_peers_message::signed_bp_peer, chain::signature_type, &gossip_bp_peers_message::signed_bp_peer::sig >
          >
+      >
       >;
 
    alignas(hardware_destructive_interference_sz)

--- a/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_plugin.hpp
@@ -41,6 +41,7 @@ namespace eosio {
         string                            disconnect( const string& endpoint );
         std::optional<connection_status>  status( const string& endpoint )const;
         vector<connection_status>         connections()const;
+        vector<gossip_bp_peers_message::bp_peer> bp_gossip_peers()const;
 
         struct p2p_per_connection_metrics {
             struct connection_metric {

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -238,7 +238,7 @@ namespace eosio {
    constexpr auto     def_max_clients = 25; // 0 for unlimited clients
    constexpr auto     def_max_nodes_per_host = 1;
    constexpr auto     def_conn_retry_wait = 30;
-   constexpr auto     def_txn_expire_wait = std::chrono::seconds(3);
+   constexpr auto     def_expire_timer_wait = std::chrono::seconds(3);
    constexpr auto     def_resp_expected_wait = std::chrono::seconds(5);
    constexpr auto     def_sync_fetch_span = 1000;
    constexpr auto     def_keepalive_interval = 10000;
@@ -370,7 +370,7 @@ namespace eosio {
             };
       possible_connections                  allowed_connections{None};
 
-      boost::asio::steady_timer::duration   txn_exp_period{0};
+      boost::asio::steady_timer::duration   expire_timer_period{0};
       boost::asio::steady_timer::duration   resp_expected_period{0};
       std::chrono::milliseconds             keepalive_interval{std::chrono::milliseconds{def_keepalive_interval}};
 
@@ -402,6 +402,9 @@ namespace eosio {
 
       boost::asio::deadline_timer           accept_error_timer{thread_pool.get_executor()};
 
+
+      alignas(hardware_destructive_interference_sz)
+      std::atomic<fc::time_point>           head_block_time;
 
       struct chain_info_t {
          block_id_type fork_db_root_id;
@@ -490,7 +493,7 @@ namespace eosio {
 
       fc::logger& get_logger() const { return logger; }
 
-      void create_session(tcp::socket&& socket, const string listen_address, size_t limit);
+      void create_session(tcp::socket&& socket, string listen_address, size_t limit);
 
       std::string empty{};
    }; //net_plugin_impl
@@ -823,6 +826,7 @@ namespace eosio {
       string                  log_remote_endpoint_port;
       string                  local_endpoint_ip;
       string                  local_endpoint_port;
+      string                  short_agent_name;
       // kept in sync with last_handshake_recv.fork_db_root_num, only accessed from connection strand
       uint32_t                peer_fork_db_root_num = 0;
 
@@ -843,7 +847,9 @@ namespace eosio {
       std::atomic<uint16_t>   protocol_version = 0;
       uint16_t                net_version = net_version_max;
       std::atomic<uint16_t>   consecutive_immediate_connection_close = 0;
-      enum class bp_connection_type { non_bp, bp_config, bp_gossip };
+      // bp_config = p2p-auto-bp-peer, bp_gossip = validated gossip connection,
+      // bp_gossip_validating = only used when connection received before peer keys available
+      enum class bp_connection_type { non_bp, bp_config, bp_gossip, bp_gossip_validating };
       std::atomic<bp_connection_type> bp_connection = bp_connection_type::non_bp;
       block_status_monitor    block_status_monitor_;
       std::atomic<time_point> last_vote_received;
@@ -910,9 +916,8 @@ namespace eosio {
 
       void send_gossip_bp_peers_initial_message();
       void send_gossip_bp_peers_message();
-      void send_gossip_bp_peers_message_to_bp_peers();
    public:
-      static void send_gossip_bp_peers_initial_message_to_peers();
+      static void send_gossip_bp_peers_message_to_bp_peers();
 
       bool populate_handshake( handshake_message& hello ) const;
 
@@ -1034,6 +1039,7 @@ namespace eosio {
             ( "_port", log_remote_endpoint_port )
             ( "_lip", local_endpoint_ip )
             ( "_lport", local_endpoint_port )
+            ( "_agent", short_agent_name )
             ( "_nver", protocol_version.load() );
          return mvo;
       }
@@ -1443,6 +1449,7 @@ namespace eosio {
       last_vote_received = time_point{};
       consecutive_blocks_nacks = 0;
       last_block_nack = block_id_type{};
+      bp_connection = bp_connection_type::non_bp;
 
       uint32_t head_num = my_impl->get_chain_head_num();
       if (last_received_block_num >= head_num) {
@@ -2652,7 +2659,7 @@ namespace eosio {
          if (cp->protocol_version >= proto_block_nack && !my_impl->p2p_disable_block_nack) {
             if (cp->consecutive_blocks_nacks > connection::consecutive_block_nacks_threshold) {
                // only send block_notice if we didn't produce the block, otherwise broadcast the block below
-               if (!my_impl->is_producer(b->producer)) {
+               if (!my_impl->producer_plug->producer_accounts().contains(b->producer)) {
                   const auto& send_buffer = block_notice_buff_factory.get_send_buffer( block_notice_message{b->previous, id} );
                   boost::asio::post(cp->strand, [cp, send_buffer, bnum]() {
                      cp->latest_blk_time = std::chrono::steady_clock::now();
@@ -2764,7 +2771,7 @@ namespace eosio {
       return p2p_addresses.size() > 0 ? *p2p_addresses.begin() : empty;
    }
 
-   void net_plugin_impl::create_session(tcp::socket&& socket, const string listen_address, size_t limit) {
+   void net_plugin_impl::create_session(tcp::socket&& socket, string listen_address, size_t limit) {
       boost::system::error_code rec;
       const auto&               rend = socket.remote_endpoint(rec);
       if (rec) {
@@ -3164,15 +3171,17 @@ namespace eosio {
    void net_plugin_impl::update_chain_info() {
       controller& cc = chain_plug->chain();
       uint32_t fork_db_root_num = 0, head_num = 0, fork_db_head_num = 0;
+      auto head = cc.head();
       {
          fc::lock_guard g( chain_info_mtx );
          chain_info.fork_db_root_id = cc.fork_db_root().id();
          chain_info.fork_db_root_num = fork_db_root_num = block_header::num_from_id(chain_info.fork_db_root_id);
-         chain_info.head_id = cc.head().id();
+         chain_info.head_id = head.id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
          chain_info.fork_db_head_id = cc.fork_db_head().id();
          chain_info.fork_db_head_num = fork_db_head_num = block_header::num_from_id(chain_info.fork_db_head_id);
       }
+      head_block_time = head.block_time();
       fc_dlog( logger, "updating chain info froot ${fr} head ${h} fhead ${f}", ("fr", fork_db_root_num)("h", head_num)("f", fork_db_head_num) );
    }
 
@@ -3180,15 +3189,17 @@ namespace eosio {
    void net_plugin_impl::update_chain_info(const block_id_type& fork_db_root_id) {
       controller& cc = chain_plug->chain();
       uint32_t fork_db_root_num = 0, head_num = 0, fork_db_head_num = 0;
+      auto head = cc.head();
       {
          fc::lock_guard g( chain_info_mtx );
          chain_info.fork_db_root_id = fork_db_root_id;
          chain_info.fork_db_root_num = fork_db_root_num = block_header::num_from_id(fork_db_root_id);
-         chain_info.head_id = cc.head().id();
+         chain_info.head_id = head.id();
          chain_info.head_num = head_num = block_header::num_from_id(chain_info.head_id);
          chain_info.fork_db_head_id = cc.fork_db_head().id();
          chain_info.fork_db_head_num = fork_db_head_num = block_header::num_from_id(chain_info.fork_db_head_id);
       }
+      head_block_time = head.block_time();
       fc_dlog( logger, "updating chain info froot ${fr} head ${h} fhead ${f}", ("fr", fork_db_root_num)("h", head_num)("f", fork_db_head_num) );
    }
 
@@ -3282,6 +3293,7 @@ namespace eosio {
             return;
          }
 
+         short_agent_name = msg.agent.substr( msg.agent.size() > 1 && msg.agent[0] == '"' ? 1 : 0, 15);
          log_p2p_address = msg.p2p_address;
          fc::unique_lock g_conn( conn_mtx );
          p2p_address = msg.p2p_address;
@@ -3737,9 +3749,7 @@ namespace eosio {
    digest_type gossip_bp_peers_message::bp_peer::digest() const {
       digest_type::encoder enc;
       fc::raw::pack(enc, my_impl->chain_id);
-      fc::raw::pack(enc, producer_name);
-      fc::raw::pack(enc, server_address);
-
+      fc::raw::pack(enc, *this);
       return enc.result();
    }
 
@@ -3749,11 +3759,12 @@ namespace eosio {
          return;
 
       if (!my_impl->bp_gossip_initialized()) {
+         bp_connection = bp_connection_type::bp_gossip_validating;
          peer_dlog(this, "received gossip_bp_peers_message before bp gossip initialized");
          return;
       }
 
-      const bool first_msg = msg.peers.size() == 1 && msg.peers[0].server_address.empty();
+      const bool first_msg = msg.peers.size() == 1 && msg.peers[0].server_endpoint.empty();
       if (!my_impl->validate_gossip_bp_peers_message(msg)) {
          peer_wlog( this, "bad gossip_bp_peers_message, closing");
          no_retry = go_away_reason::fatal_other;
@@ -3786,25 +3797,13 @@ namespace eosio {
    void connection::send_gossip_bp_peers_initial_message() {
       if (protocol_version < proto_gossip_bp_peers || !my_impl->bp_gossip_enabled())
          return;
+      peer_dlog(this, "sending initial gossip_bp_peers_message");
       const auto& sb = my_impl->get_gossip_bp_initial_send_buffer();
-      if (sb)
+      if (sb) {
          enqueue_buffer(msg_type_t::gossip_bp_peers_message, {}, queued_buffer::queue_t::general, sb, go_away_reason::no_reason);
-   }
-
-   // thread safe, called from main thread
-   void connection::send_gossip_bp_peers_initial_message_to_peers() {
-      assert(my_impl->bp_gossip_enabled());
-      const send_buffer_type& sb = my_impl->get_gossip_bp_initial_send_buffer();
-      if (!sb)
-         return;
-      my_impl->connections.for_each_connection([sb](const connection_ptr& c) {
-         gossip_buffer_factory factory;
-         if (c->bp_connection != bp_connection_type::bp_gossip && c->socket_is_open()) {
-            boost::asio::post(c->strand, [sb, c]() {
-               c->enqueue_buffer(msg_type_t::gossip_bp_peers_message, {}, queued_buffer::queue_t::general, sb, go_away_reason::no_reason);
-            });
-         }
-      });
+      } else {
+         peer_ilog(this, "no initial gossip_bp_peers_message to send");
+      }
    }
 
    // called from connection strand
@@ -3812,19 +3811,26 @@ namespace eosio {
       assert(my_impl->bp_gossip_enabled());
       gossip_buffer_factory factory;
       const send_buffer_type& sb = my_impl->get_gossip_bp_send_buffer(factory);
+      peer_dlog(this, "sending gossip_bp_peers_message");
       enqueue_buffer(msg_type_t::gossip_bp_peers_message, {}, queued_buffer::queue_t::general, sb, go_away_reason::no_reason);
    }
 
-   // called from connection strand, thread safe
    void connection::send_gossip_bp_peers_message_to_bp_peers() {
       assert(my_impl->bp_gossip_enabled());
-      my_impl->connections.for_each_connection([this](const connection_ptr& c) {
+      my_impl->connections.for_each_connection([](const connection_ptr& c) {
          gossip_buffer_factory factory;
-         if (this != c.get() && c->bp_connection == bp_connection_type::bp_gossip && c->socket_is_open()) {
-            const send_buffer_type& sb = my_impl->get_gossip_bp_send_buffer(factory);
-            boost::asio::post(c->strand, [sb, c]() {
-               c->enqueue_buffer(msg_type_t::gossip_bp_peers_message, {}, queued_buffer::queue_t::general, sb, go_away_reason::no_reason);
-            });
+         if (c->protocol_version >= proto_gossip_bp_peers && c->socket_is_open()) {
+            if (c->bp_connection == bp_connection_type::bp_gossip) {
+               const send_buffer_type& sb = my_impl->get_gossip_bp_send_buffer(factory);
+               boost::asio::post(c->strand, [sb, c]() {
+                  peer_dlog(c, "sending gossip_bp_peers_message");
+                  c->enqueue_buffer(msg_type_t::gossip_bp_peers_message, {}, queued_buffer::queue_t::general, sb, go_away_reason::no_reason);
+               });
+            } else if (c->bp_connection == bp_connection_type::bp_config || c->bp_connection == bp_connection_type::bp_gossip_validating) {
+               boost::asio::post(c->strand, [c]() {
+                  c->send_gossip_bp_peers_initial_message();
+               });
+            }
          }
       });
    }
@@ -3951,7 +3957,7 @@ namespace eosio {
    // thread safe
    void net_plugin_impl::start_expire_timer() {
       fc::lock_guard g( expire_timer_mtx );
-      expire_timer.expires_from_now( txn_exp_period);
+      expire_timer.expires_from_now( expire_timer_period);
       expire_timer.async_wait( [my = shared_from_this()]( boost::system::error_code ec ) {
          if( !ec ) {
             my->expire();
@@ -3990,7 +3996,11 @@ namespace eosio {
       uint32_t fork_db_root_num = get_fork_db_root_num();
       dispatcher.expire_blocks( fork_db_root_num );
       dispatcher.expire_txns();
-      fc_dlog( logger, "expire_txns ${n}us", ("n", time_point::now() - now) );
+      if (expire_gossip_bp_peers()) {
+         update_bp_producer_peers();
+         connection::send_gossip_bp_peers_message_to_bp_peers();
+      }
+      fc_dlog( logger, "expire run time ${n}us", ("n", time_point::now() - now) );
 
       start_expire_timer();
    }
@@ -4023,6 +4033,20 @@ namespace eosio {
          on_pending_schedule(*pending_producers);
       }
       on_active_schedule(chain_plug->chain().active_producers());
+
+      // update peer public keys from chainbase db
+      chain::controller& cc = chain_plug->chain();
+      if (cc.configured_peer_keys_updated()) {
+         boost::asio::post(thread_pool.get_executor(), [this]() {
+            try {
+               update_bp_producer_peers();
+               my_impl->connect_to_active_bp_peers();
+               connection::send_gossip_bp_peers_message_to_bp_peers();
+            } catch (fc::exception& e) {
+               fc_elog( logger, "Unable to update bp producer peers, error: ${e}", ("e", e.to_detail_string()));
+            }
+         });
+      }
    }
 
    // called from application thread
@@ -4037,16 +4061,6 @@ namespace eosio {
             const fc::microseconds age(fc::time_point::now() - block->timestamp);
             sync_master->sync_recv_block(connection_ptr{}, id, block->block_num(), age);
          });
-      }
-
-      // update peer public keys from chainbase db
-      if (cc.configured_peer_keys_updated()) {
-         try {
-            update_bp_producer_peers(cc, get_first_p2p_address());
-            connection::send_gossip_bp_peers_initial_message_to_peers();
-         } catch (fc::exception& e) {
-            fc_elog( logger, "Unable to update bp producer peers, error: ${e}", ("e", e.to_detail_string()));
-         }
       }
    }
 
@@ -4264,10 +4278,11 @@ namespace eosio {
            " Transactions and blocks outside sync mode are not throttled."
            " The optional 'trx' and 'blk' indicates to peers that only transactions 'trx' or blocks 'blk' should be sent."
            " Examples:\n"
-           "   192.168.0.100:9876:1MiB/s\n"
-           "   node.eos.io:9876:trx:1512KB/s\n"
-           "   node.eos.io:9876:0.5GB/s\n"
-           "   [2001:db8:85a3:8d3:1319:8a2e:370:7348]:9876:250KB/s")
+           "   192.168.0.100:9875\n"
+           "   192.168.0.101:9876:1MiB/s\n"
+           "   node.eos.io:9877:trx:1512KB/s\n"
+           "   node.eos.io:9879:0.5GB/s\n"
+           "   [2001:db8:85a3:8d3:1319:8a2e:370:7348]:9879:250KB/s")
          ( "p2p-server-address", bpo::value< vector<string> >(),
            "An externally accessible host:port for identifying this node. Defaults to p2p-listen-endpoint."
            " May be used as many times as p2p-listen-endpoint."
@@ -4285,15 +4300,24 @@ namespace eosio {
          ( "p2p-disable-block-nack", bpo::value<bool>()->default_value(false),
             "Disable block notice and block nack. All blocks received will be broadcast to all peers unless already received.")
          ( "p2p-auto-bp-peer", bpo::value< vector<string> >()->composing(),
-           "The account and public p2p endpoint of a block producer node to automatically connect to when it is in producer schedule proximity\n."
-           "  Syntax: account,host:port\n"
-           "  Example,\n"
-           "    eosproducer1,p2p.eos.io:9876\n"
-           "    eosproducer2,p2p.trx.eos.io:9876:trx\n"
-           "    eosproducer3,p2p.blk.eos.io:9876:blk\n")
-         ("p2p-producer-peer", boost::program_options::value<vector<string>>()->composing()->multitoken(),
-           "Producer peer name of this node used to retrieve peer key from on-chain peerkeys table. Private key of peer key should be configured via signature-provider.")
-         ( "agent-name", bpo::value<string>()->default_value("EOS Test Agent"), "The name supplied to identify this node amongst the peers.")
+           "The account and public p2p endpoint of a block producer node to automatically connect to when it is in producer schedule. Not gossipped.\n"
+           "  Syntax: bp_account,host:port\n"
+           "  Example:\n"
+           "    producer1,p2p.prod.io:9876\n"
+           "    producer2,p2p.trx.myprod.io:9876:trx\n"
+           "    producer3,p2p.blk.example.io:9876:blk\n")
+         ("p2p-bp-gossip-endpoint", boost::program_options::value<vector<string>>()->composing()->multitoken(),
+           "The BP account, inbound connection endpoint, outbound connection IP address. "
+           "The BP account is the producer name. Used to retrieve peer-key from on-chain peerkeys table registered on-chain via regpeerkey action. "
+           "The inbound connection endpoint is typically the listen endpoint of this node. "
+           "The outbound connection IP address is typically the IP address of this node. Peer will use this value to allow access through firewall. "
+           "Private key of peer-key should be configured via signature-provider.\n"
+           " Syntax: bp_account,inbound_endpoint,outbound_ip_address\n"
+           " Example:\n"
+           "   myprod,myhostname.com:9876,198.51.100.1\n"
+           "   myprod,myhostname2.com:9876,[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"
+           )
+         ( "agent-name", bpo::value<string>()->default_value("Vault Agent"), "The name supplied to identify this node amongst the peers.")
          ( "allowed-connection", bpo::value<vector<string>>()->multitoken()->default_value({"any"}, "any"), "Can be 'any' or 'producers' or 'specified' or 'none'. If 'specified', peer-key must be specified at least once. If only 'producers', peer-key is not required. 'producers' and 'specified' may be combined.")
          ( "peer-key", bpo::value<vector<string>>()->composing()->multitoken(), "Optional public key of peer allowed to connect.  May be used multiple times.")
          ( "peer-private-key", bpo::value<vector<string>>()->composing()->multitoken(),
@@ -4321,6 +4345,7 @@ namespace eosio {
            "   _port  \tremote port number of peer\n\n"
            "   _lip   \tlocal IP address connected to peer\n\n"
            "   _lport \tlocal port number connected to peer\n\n"
+           "   _agent \tfirst 15 characters of agent-name of peer\n\n"
            "   _nver  \tp2p protocol version\n\n")
          ( "p2p-keepalive-interval-ms", bpo::value<int>()->default_value(def_keepalive_interval), "peer heartbeat keepalive message interval in milliseconds")
 
@@ -4341,7 +4366,7 @@ namespace eosio {
 
          peer_log_format = options.at( "peer-log-format" ).as<string>();
 
-         txn_exp_period = def_txn_expire_wait;
+         expire_timer_period = def_expire_timer_wait;
          p2p_dedup_cache_expire_time_us = fc::seconds( options.at( "p2p-dedup-cache-expire-time-sec" ).as<uint32_t>() );
          resp_expected_period = def_resp_expected_wait;
          max_nodes_per_host = options.at( "p2p-max-nodes-per-host" ).as<int>();
@@ -4370,7 +4395,7 @@ namespace eosio {
 
          if( options.count( "p2p-listen-endpoint" )) {
             auto p2ps =  options.at("p2p-listen-endpoint").as<vector<string>>();
-            if (!p2ps.front().empty()) {
+            if (!p2ps.front().empty()) { // "" for p2p-listen-endpoint means to not listen
                p2p_addresses = p2ps;
                auto addr_count = p2p_addresses.size();
                std::sort(p2p_addresses.begin(), p2p_addresses.end());
@@ -4432,10 +4457,10 @@ namespace eosio {
             });
          }
 
-         if ( options.count("p2p-producer-peer") ) {
+         if ( options.count( "p2p-bp-gossip-endpoint" ) ) {
+            set_bp_producer_peers(options.at( "p2p-bp-gossip-endpoint" ).as<vector<string>>());
             EOS_ASSERT(options.count("signature-provider"), chain::plugin_config_exception,
-                       "signature-provider of associated key required for p2p-producer-peer");
-            set_bp_producer_peers(options.at("p2p-producer-peer").as<vector<string>>());
+                       "signature-provider of associated key required for p2p-bp-gossip-endpoint");
          }
 
          if( options.count( "allowed-connection" )) {
@@ -4487,7 +4512,7 @@ namespace eosio {
       fc_ilog( logger, "my node_id is ${id}", ("id", node_id ));
 
       producer_plug = app().find_plugin<producer_plugin>();
-      set_producer_accounts(producer_plug->producer_accounts());
+      assert(producer_plug);
 
       thread_pool.start( thread_pool_size, []( const fc::exception& e ) {
          elog("Exception in net thread, exiting: ${e}", ("e", e.to_detail_string()));
@@ -4506,14 +4531,15 @@ namespace eosio {
 
       std::vector<string> listen_addresses = p2p_addresses;
 
-      EOS_ASSERT( p2p_addresses.size() == p2p_server_addresses.size(), chain::plugin_config_exception, "" );
+      assert( p2p_addresses.size() == p2p_server_addresses.size() );
       std::transform(p2p_addresses.begin(), p2p_addresses.end(), p2p_server_addresses.begin(), 
                      p2p_addresses.begin(), [](const string& p2p_address, const string& p2p_server_address) {
-         auto [host, port] = fc::split_host_port(p2p_address);
-         
          if( !p2p_server_address.empty() ) {
             return p2p_server_address;
-         } else if( host.empty() || host == "0.0.0.0" || host == "[::]") {
+         }
+
+         const auto& [host, port, type] = net_utils::split_host_port_type(p2p_address);
+         if( host.empty() || host == "0.0.0.0" || host == "[::]") {
             boost::system::error_code ec;
             auto hostname = host_name( ec );
             if( ec.value() != boost::system::errc::success ) {
@@ -4522,7 +4548,7 @@ namespace eosio {
                                     "Unable to retrieve host_name. ${msg}", ("msg", ec.message()));
 
             }
-            return hostname + ":" + port;
+            return hostname + ":" + port + (type.empty() ? "" : ":" + type);
          }
          return p2p_address;
       });
@@ -4552,7 +4578,9 @@ namespace eosio {
          cc.voted_block().connect( broadcast_vote );
 
          if (bp_gossip_enabled()) {
-            cc.set_peer_keys_retrieval_active(configured_bp_peer_accounts());
+            cc.set_peer_keys_retrieval_active(my_bp_gossip_accounts());
+            // Can't update bp producer peer messages here because update_peer_keys requires a read-only trx which
+            // requires a speculative block to run in. Wait for the first on block.
          }
       }
 
@@ -4576,7 +4604,7 @@ namespace eosio {
                   [this, addr = p2p_addr, block_sync_rate_limit = block_sync_rate_limit](tcp::socket&& socket) {
                      fc_dlog( logger, "start listening on ${addr} with peer sync throttle ${limit}",
                               ("addr", addr)("limit", block_sync_rate_limit));
-                     create_session(std::move(socket), addr, block_sync_rate_limit);
+                     create_session(std::move(socket), std::move(addr), block_sync_rate_limit);
                   });
          } catch (const fc::exception& e) {
             fc_elog(logger, "net_plugin::plugin_startup failed to listen on ${a}, ${w}",
@@ -4634,6 +4662,10 @@ namespace eosio {
    /// RPC API
    vector<connection_status> net_plugin::connections()const {
       return my->connections.connection_statuses();
+   }
+
+   vector<gossip_bp_peers_message::bp_peer> net_plugin::bp_gossip_peers()const {
+      return my->bp_gossip_peers();
    }
 
    constexpr uint16_t net_plugin_impl::to_protocol_version(uint16_t v) {

--- a/plugins/net_plugin/tests/auto_bp_peering_unittest.cpp
+++ b/plugins/net_plugin/tests/auto_bp_peering_unittest.cpp
@@ -84,18 +84,18 @@ BOOST_AUTO_TEST_CASE(test_set_bp_peers) {
          "producer3,127.0.0.1:8890"s,
          "producer4,127.0.0.1:8891"s
    });
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer1"_n], endpoint("127.0.0.1", "8888"));
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer2"_n], endpoint("127.0.0.1", "8889"));
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer3"_n], endpoint("127.0.0.1", "8890"));
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_addresses["producer4"_n], endpoint("127.0.0.1", "8891"));
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_addresses["producer1"_n], endpoint("127.0.0.1", "8888"));
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_addresses["producer2"_n], endpoint("127.0.0.1", "8889"));
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_addresses["producer3"_n], endpoint("127.0.0.1", "8890"));
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_addresses["producer4"_n], endpoint("127.0.0.1", "8891"));
 
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_accounts[endpoint("127.0.0.1", "8888")], "producer1"_n);
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_accounts[endpoint("127.0.0.1", "8889")], "producer2"_n);
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_accounts[endpoint("127.0.0.1", "8890")], "producer3"_n);
-   BOOST_CHECK_EQUAL(plugin.config.bp_peer_accounts[endpoint("127.0.0.1", "8891")], "producer4"_n);
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_accounts[endpoint("127.0.0.1", "8888")], "producer1"_n);
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_accounts[endpoint("127.0.0.1", "8889")], "producer2"_n);
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_accounts[endpoint("127.0.0.1", "8890")], "producer3"_n);
+   BOOST_CHECK_EQUAL(plugin.config.auto_bp_accounts[endpoint("127.0.0.1", "8891")], "producer4"_n);
 }
 
-bool operator==(const eosio::chain::peer_name_set_t& a, const eosio::chain::peer_name_set_t& b) {
+bool operator==(const eosio::chain::name_set_t& a, const eosio::chain::name_set_t& b) {
    return std::equal(a.begin(), a.end(), b.begin(), b.end());
 }
 
@@ -104,7 +104,7 @@ bool operator==(const std::vector<std::string>& a, const std::vector<std::string
 }
 
 namespace boost::container {
-std::ostream& boost_test_print_type(std::ostream& os, const eosio::chain::peer_name_set_t& accounts) {
+std::ostream& boost_test_print_type(std::ostream& os, const eosio::chain::name_set_t& accounts) {
    os << "{";
    const char* sep = "";
    for (auto e : accounts) {
@@ -148,7 +148,7 @@ const eosio::chain::producer_authority_schedule test_schedule2{
      { "prodd"_n, {} }, { "prodh"_n, {} }, { "prodl"_n, {} } }
 };
 
-const eosio::chain::peer_name_set_t producers_minus_prodkt{
+const eosio::chain::name_set_t producers_minus_prodkt{
    "proda"_n, "prodb"_n, "prodc"_n, "prodd"_n, "prode"_n, "prodf"_n,
    "prodg"_n, "prodh"_n, "prodi"_n, "prodj"_n,
    // "prodk"_n, not part of the peer addresses
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    plugin.on_pending_schedule(test_schedule1);
 
    BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{}));
-   BOOST_TEST(plugin.pending_bps == (eosio::chain::peer_name_set_t{ "prodj"_n, "prodm"_n }));
+   BOOST_TEST(plugin.pending_bps == (eosio::chain::name_set_t{ "prodj"_n, "prodm"_n }));
    BOOST_CHECK_EQUAL(plugin.pending_schedule_version, 0u);
 
    // when it is in sync and on_pending_schedule is called
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{}));
 
    plugin.on_pending_schedule(reset_schedule1);
-   BOOST_TEST(plugin.pending_bps == eosio::chain::peer_name_set_t{});
+   BOOST_TEST(plugin.pending_bps == eosio::chain::name_set_t{});
 }
 
 BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
    plugin.on_active_schedule(test_schedule1);
 
    BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{}));
-   BOOST_TEST(plugin.get_active_bps() == (eosio::chain::peer_name_set_t{ "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n }));
+   BOOST_TEST(plugin.get_active_bps() == (eosio::chain::name_set_t{ "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n }));
    BOOST_CHECK_EQUAL(plugin.active_schedule_version, 0u);
 
    // when it is in sync and on_active_schedule is called

--- a/tests/auto_bp_gossip_peering_test.py
+++ b/tests/auto_bp_gossip_peering_test.py
@@ -9,8 +9,8 @@ from TestHarness import Cluster, TestHelper, Utils, WalletMgr, createAccountKeys
 # auto_bp_gossip_peering_test
 #
 # This test sets up  a cluster with 21 producers nodeos, each nodeos is configured with only one producer and only
-# connects to the bios node. Moreover, each producer nodeos is also configured with a p2p-producer-peer so that each
-# one can automatically establish p2p connections to other bps. Test verifies connections are established when
+# connects to the bios node. Moreover, each producer nodeos is also configured with a p2p-bp-gossip-endpoint so that
+# each one can automatically establish p2p connections to other bps. Test verifies connections are established when
 # producer schedule is active.
 #
 ###############################################################
@@ -115,19 +115,22 @@ try:
         Utils.Print("Wait for last regpeerkey to be final on ", nodeId)
         cluster.getNode(nodeId).waitForTransFinalization(trans['transaction_id'])
 
-    # relaunch with p2p-producer-peer
+    # relaunch with p2p-bp-gossip-endpoint
     for nodeId in range(0, producerNodes):
-        Utils.Print(f"Relaunch node {nodeId} with p2p-producer-peer")
+        Utils.Print(f"Relaunch node {nodeId} with p2p-bp-gossip-endpoint")
         node = cluster.getNode(nodeId)
         node.kill(signal.SIGTERM)
         producer_name = "defproducer" + chr(ord('a') + nodeId)
-        if not node.relaunch(chainArg=" --enable-stale-production --p2p-producer-peer " + producer_name):
+        server_address = getHostName(nodeId)
+        if not node.relaunch(chainArg=f" --enable-stale-production --p2p-bp-gossip-endpoint {producer_name},{server_address},127.0.0.1"):
             errorExit(f"Failed to relaunch node {nodeId}")
 
     # give time for messages to be gossiped around
+    cluster.getNode(producerNodes-1).waitForHeadToAdvance(blocksToAdvance=60)
+    blockNum = cluster.getNode(0).getBlockNum()
     for nodeId in range(0, producerNodes):
-        Utils.Print("Wait for defproducert on node ", nodeId)
-        cluster.getNode(nodeId).waitForHeadToAdvance(5)
+        Utils.Print(f"Wait for block ${blockNum} on node ", nodeId)
+        cluster.getNode(nodeId).waitForBlock(blockNum)
 
     # retrieve the producer stable producer schedule
     scheduled_producers = []
@@ -141,6 +144,8 @@ try:
         # retrieve the connections in each node and check if each connects to the other bps in the schedule
         connections = cluster.nodes[nodeId].processUrllibRequest("net", "connections")
         if Utils.Debug: Utils.Print(f"v1/net/connections: {connections}")
+        bp_peers = cluster.nodes[nodeId].processUrllibRequest("net", "bp_gossip_peers")
+        if Utils.Debug: Utils.Print(f"v1/net/bp_gossip_peers: {bp_peers}")
         peers = []
         for conn in connections["payload"]:
             if conn["is_socket_open"] is False:
@@ -166,6 +171,16 @@ try:
             Utils.Print(f"ERROR: expect {name} has connections to {scheduled_producers}, got connections to {peers}")
             connection_failure = True
             break
+        num_peers_found = 0
+        for p in bp_peers["payload"]:
+            if p["producer_name"] not in peers:
+                Utils.Print(f"ERROR: expect bp peer {p} in peer list")
+                connection_failure = True
+                break
+            else:
+                num_peers_found += 1
+
+        assert(num_peers_found == len(peers))
 
     testSuccessful = not connection_failure
 


### PR DESCRIPTION
Merges `release/1.2` into `main` including #1503  

- Add new `p2p-bp-gossip-endpoint <producer account>,<advertised inbound connection endpoint>,<outbound connection IP address>`
    - Where `<producer account>` is the previous `p2p-producer-peer`. The BP producer account used for producing and used for registering an on-chain producer peer key.
    - Where `<advertised inbound connection endpoint>` is an externally reachable IP address or domain name with port.
    - Where `<outbound connection IP address>` is the IP address this node will connection from. This is provided so that BPs using a firewall can add this entry to allow connection. Required and must be a valid IP address.
    - Only communicated over bp gossip messages, not sent to non-bp-gossip peers.
    - `p2p-bp-gossip-endpoint` can be specified more than once if multiple endpoints for a node should be gossiped or if in a test network more than one BP peer key is handled by the nodeos.
    - `<producer account>`, `<advertised inbound connection endpoint>` combination must be unique. 8 unique bp gossip entries are allowed across all BP nodes for a specific producer account.
    - Examples for producer `defproda`:
      -  `p2p-bp-gossip-endpoint = defproda,p2p.proddomain.com:9876,173.194.219.100`
      -  `p2p-bp-gossip-endpoint = defproda,p2p.proddomain2.com:9875,173.194.219.99`

- Add `expiration` to `gossip_bp_peers_message::bp_peer`
  - Part of the signed data
  - Used to time-out a `bp_peer` entry
  - Hard code expiration time to be 1hr.
  - Use head-block time + expiration time.
  - Configured `p2p-bp-gossip-endpoint` will send out an updated signed `bp_peer` entry every 1/2 of expiration time (30 minutes) which will be gossiped to all its bp gossip peers.
  - Error if expiration greater than 1.25 hr of current block time.
  - Error if expiration less than current block time.
  - Remove bp_peer entries when they expire
  - If more than 8 `bp_peer` entries received from single producer than Error.
  - Update existing expiration of bp_peers that match same [`producer_name`,`server_endpoint`.]

- Increase from 4 to 8 allowed `bp_peer` entries per producer.
  - Duplicate connections will naturally be de-dupped by peer.

- Add API `/v1/net/bp_gossip_peers` which will return the current set of known bp gossip peers.
  - Include all information in `gossip_bp_peers_message::bp_peer`
  - Can be queried to retrieve data for firewall

- Add `agent-name` as an option of `peer-log-format` so it can be included in every peer log statement if desired.
 
- Update p2p help with valid examples.

```
  --p2p-bp-gossip-endpoint arg          The BP account, inbound connection
                                        endpoint, outbound connection IP
                                        address. The BP account is the producer
                                        peer name to retrieve peer-key from
                                        on-chain peerkeys table registered
                                        on-chain via regpeerkey action. The
                                        inbound connection endpoint is
                                        typically the listen endpoint of this
                                        node. The outbound connection IP
                                        address is typically the IP address of
                                        this node. Peer will use this value to
                                        allow access through firewall. Private
                                        key of peer-key should be configured
                                        via signature-provider.
                                         Syntax: bp_account,inbound_endpoint,ou
                                        tbound_ip_address
                                         Example:
                                           myprod,myhostname.com:9876,198.51.10
                                        0.1
                                           myprod,myhostname2.com:9876,[2001:0d
                                        b8:85a3:0000:0000:8a2e:0370:7334]
```

Resolves #1496