### PR TITLE
SC: Support new sync_call entry point function signature which returns an int64_t

### DIFF
--- a/libraries/chain/include/eosio/chain/host_context.hpp
+++ b/libraries/chain/include/eosio/chain/host_context.hpp
@@ -565,7 +565,13 @@ public:
 
    /// Sync call methods:
 
-   // sync calls can be initiated from actions or other sync calls
+   enum class call_error_code : int64_t {
+      sync_call_not_supported_by_receiver = -1, // receiver contract does not have sync_call entry point
+      unsupported_data_version            = -2, // version in the data header is not supported
+      called_function_not_found           = -3, // called function is not found in the receiver contract
+      empty_receiver                      = -4  // receiver contract code is empty
+   };
+   // Negative status indicates failure, positive or 0 is the size of return value of the called function
    int64_t execute_sync_call(name receiver, uint64_t flags, std::span<const char> data);
    uint32_t get_call_return_value(std::span<char> memory) const;
 

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -83,7 +83,7 @@ namespace eosio { namespace chain {
          void current_lib(const uint32_t lib);
 
          //Calls apply/sync_call
-         void execute(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, host_context& context);
+         int64_t execute(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, host_context& context);
 
          //Returns true if the code is cached
          bool is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const;

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -148,7 +148,7 @@ struct eosvmoc_tier {
       }
 #endif
 
-      void execute( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, host_context& context ) {
+      int64_t execute( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, host_context& context ) {
          bool attempt_tierup = false;
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
          attempt_tierup = eosvmoc && (eosvmoc_tierup == wasm_interface::vm_oc_enable::oc_all || context.should_use_eos_vm_oc());

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/executor.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/executor.hpp
@@ -26,7 +26,7 @@ class executor {
       executor(const code_cache_base& cc);
       ~executor();
 
-      void execute(const code_descriptor& code, memory& mem, host_context& context);
+      int64_t execute(const code_descriptor& code, memory& mem, host_context& context);
 
    private:
       uint8_t* code_mapping;

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -12,7 +12,7 @@ class host_context;
 
 class wasm_instantiated_module_interface {
    public:
-      virtual void execute(host_context& context) = 0;
+      virtual int64_t execute(host_context& context) = 0;
       virtual ~wasm_instantiated_module_interface();
 };
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -108,8 +108,8 @@ namespace eosio { namespace chain {
       my->current_lib(lib);
    }
 
-   void wasm_interface::execute( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, host_context& context ) {
-      my->execute( code_hash, vm_type, vm_version, context );
+   int64_t wasm_interface::execute( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, host_context& context ) {
+      return my->execute( code_hash, vm_type, vm_version, context );
    }
 
    bool wasm_interface::is_code_cached(const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) const {

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -27,7 +27,7 @@ class eosvmoc_instantiated_module : public wasm_instantiated_module_interface {
 
       bool is_main_thread() { return _main_thread_id == std::this_thread::get_id(); };
 
-      void execute(host_context& context) override {
+      int64_t execute(host_context& context) override {
          eosio::chain::eosvmoc::code_cache_sync::mode m;
          m.whitelisted = context.is_eos_vm_oc_whitelisted();
          m.write_window = context.control.is_write_window();
@@ -41,12 +41,12 @@ class eosvmoc_instantiated_module : public wasm_instantiated_module_interface {
                _eosvmoc_runtime.release_call_exec(exec);
                _eosvmoc_runtime.release_call_mem(context.sync_call_depth, mem);
             });
-            exec->execute(*cd, *mem, context);
+            return exec->execute(*cd, *mem, context);
          } else if ( is_main_thread() ) {  // action on main thread
-            _eosvmoc_runtime.exec.execute(*cd, _eosvmoc_runtime.mem, context);
+            return _eosvmoc_runtime.exec.execute(*cd, _eosvmoc_runtime.mem, context);
          }
          else {  // action on read only thread
-            _eosvmoc_runtime.exec_thread_local->execute(*cd, *_eosvmoc_runtime.mem_thread_local, context);
+            return _eosvmoc_runtime.exec_thread_local->execute(*cd, *_eosvmoc_runtime.mem_thread_local, context);
          }
       }
 

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -70,7 +70,7 @@ static bool module_has_valid_sync_call(module& mod) {
    const uint32_t i = mod.get_exported_function("sync_call");
    if (i < std::numeric_limits<uint32_t>::max()) {
       const vm::func_type& function_type = mod.get_function_type(i);
-      if (function_type == vm::host_function{{vm::i64, vm::i64, vm::i32}, {}}) {
+      if (function_type == vm::host_function{{vm::i64, vm::i64, vm::i32}, {vm::i64}}) {
          supported = true;
       }
    }
@@ -175,16 +175,16 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          _runtime(runtime),
          _instantiated_module(std::move(mod)) {}
 
-      void  execute(host_context& context) override {
+      int64_t execute(host_context& context) override {
          if (context.is_action()) {
-            apply(static_cast<apply_context&>(context));
+            return apply(static_cast<apply_context&>(context));
          } else {
-            do_sync_call(static_cast<sync_call_context&>(context));
+            return do_sync_call(static_cast<sync_call_context&>(context));
          }
       }
 
    private:
-      void do_sync_call(sync_call_context& context) {
+      int64_t do_sync_call(sync_call_context& context) {
          backend_t                                bkend;
          typename eos_vm_runtime<Impl>::context_t exec_ctx;
          vm::wasm_allocator*                      wasm_alloc = context.control.acquire_sync_call_wasm_allocator();
@@ -196,20 +196,20 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
 
          apply_options opts = get_apply_options(context);
 
-         auto fn = [&]() {
+         auto fn = [&]() -> int64_t {
             eosio::chain::webassembly::interface iface(context);
             bkend.initialize(&iface, opts);
-            bkend.call(
-                iface, "env", "sync_call",
-                context.sender.to_uint64_t(),
-                context.receiver.to_uint64_t(),
-                static_cast<uint32_t>(context.data.size()));
+            return bkend.call_with_return(
+               iface, "env", "sync_call",
+               context.sender.to_uint64_t(),
+               context.receiver.to_uint64_t(),
+               static_cast<uint32_t>(context.data.size()))->to_i64();
          };
 
-         exe(context, bkend, exec_ctx, *wasm_alloc, fn, true);
+         return exe(context, bkend, exec_ctx, *wasm_alloc, fn, true);
       }
 
-      void apply(apply_context& context) {
+      int64_t apply(apply_context& context) {
          auto& bkend      = _runtime->_bkend;
          auto& exec_ctx   = _runtime->_exec_ctx;
          auto& wasm_alloc = context.control.get_wasm_allocator();
@@ -226,9 +226,11 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          };
 
          exe(context, bkend, exec_ctx, wasm_alloc, fn, false);
+         return 0;  // status of `apply` is not used
       }
 
-      void exe(host_context& context, backend_t& bkend, eos_vm_runtime<Impl>::context_t& exec_ctx, vm::wasm_allocator& wasm_alloc, std::function<void()> fn, bool multi_expr_callbacks_allowed) {
+      template<typename F>
+      auto exe(host_context& context, backend_t& bkend, eos_vm_runtime<Impl>::context_t& exec_ctx, vm::wasm_allocator& wasm_alloc, F&& fn, bool multi_expr_callbacks_allowed) {
          // set up backend to share the compiled mod in the instantiated
          // module of the contract
          bkend.share(*_instantiated_module);
@@ -242,15 +244,29 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
          // set wasm allocator per apply data
          bkend.set_wasm_allocator(&wasm_alloc);
 
+         using return_type = std::invoke_result_t<F>;
+         static_assert(std::is_void_v<return_type> || std::is_same_v<return_type, std::int64_t>,
+                       "return type of F must be either void or int64_t");  // Protect future misuse
          try {
             checktime_watchdog wd(context.trx_context.transaction_timer, multi_expr_callbacks_allowed);
-            bkend.timed_run(std::move(wd), std::move(fn));
+
+            if constexpr (std::is_void_v<return_type>) {
+               bkend.timed_run(std::move(wd), std::move(fn));
+            } else {
+               return bkend.timed_run(std::move(wd), std::move(fn));
+            }
          } catch(eosio::vm::timeout_exception&) {
             context.trx_context.checktime();
          } catch(eosio::vm::wasm_memory_exception& e) {
             FC_THROW_EXCEPTION(wasm_execution_error, "access violation: ${d}", ("d", e.detail()));
          } catch(eosio::vm::exception& e) {
             FC_THROW_EXCEPTION(wasm_execution_error, "eos-vm system failure: ${d}", ("d", e.detail()));
+         }
+
+         // This is to get around `no return` compile warning.
+         // `exe()` is a private method and we know the return type is either void or int64_t
+         if constexpr (std::is_same_v<return_type, std::int64_t>) {
+            return 0l;
          }
       }
 
@@ -276,7 +292,7 @@ class eos_vm_profiling_module : public wasm_instantiated_module_interface {
          _original_code(code, code + code_size) {}
 
 
-      void execute(host_context& context) override {
+      int64_t execute(host_context& context) override {
          _instantiated_module->set_wasm_allocator(&context.control.get_wasm_allocator());
          apply_options opts;
          if(context.control.is_builtin_activated(builtin_protocol_feature_t::configurable_wasm_limits)) {
@@ -304,6 +320,7 @@ class eos_vm_profiling_module : public wasm_instantiated_module_interface {
          } catch(eosio::vm::exception& e) {
             FC_THROW_EXCEPTION(wasm_execution_error, "eos-vm system failure");
          }
+         return 0;
       }
 
       profile_data* start(apply_context& context) {

--- a/unittests/sync_call_tests.cpp
+++ b/unittests/sync_call_tests.cpp
@@ -74,8 +74,9 @@ static const char sync_call_in_same_account_wast[] = R"=====(
    )
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $callee) 
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -129,8 +130,9 @@ static const char callee_wast[] = R"=====(
    )
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $callee) 
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -187,8 +189,9 @@ static const char callee1_wast[] = R"=====(
    )
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $callee) 
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -209,8 +212,9 @@ static const char callee2_wast[] = R"=====(
    )
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $callee) 
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -265,7 +269,8 @@ static const char seq_callee1_wast[] = R"=====(
    (export "memory" (memory $0))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)(result i64)
+      (i64.const 0))
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
@@ -280,8 +285,9 @@ static const char seq_callee2_wast[] = R"=====(
    (export "memory" (memory $0))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $assert (i32.const 0) (i32.const 0))
+      (i64.const 0)
    )
 
    ;; not used but needed for set_code validation
@@ -351,8 +357,9 @@ static const char loop_callee_wast[] = R"=====(
    (func $callee)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $callee)
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -419,8 +426,9 @@ static const char different_actions_callee1_wast[] = R"=====(
    (export "memory" (memory $0))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $assert (i32.const 0) (i32.const 0))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -438,8 +446,9 @@ static const char different_actions_callee2_wast[] = R"=====(
    (export "memory" (memory $0))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $assert (i32.const 0) (i32.const 0))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -502,8 +511,9 @@ static const char recursive_caller_wast[] = R"=====(
 
    ;; called recursively from callee
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $doit (i32.const 0)) ;; argument 0 to request doit to exit
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -524,8 +534,8 @@ static const char recursive_callee_wast[] = R"=====(
 
    ;; called from caller and calls caller again
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
-      (drop (call $call (get_global $caller) (i64.const 0)(i32.const 0)(i32.const 8)))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
+      (call $call (get_global $caller) (i64.const 0)(i32.const 0)(i32.const 8))
    )
 
    (export "apply" (func $apply))
@@ -619,7 +629,7 @@ static const char basic_params_return_value_callee_wast[] = R"=====(
 
    ;; use get_call_data and set_call_return_value to get argument and store return value
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $get_call_data (i32.const 0)(get_local $data_size)))
 
       i32.const 16      ;; address to store return value
@@ -629,6 +639,7 @@ static const char basic_params_return_value_callee_wast[] = R"=====(
       i32.store         ;; save the return value at address 16
 
       (call $set_call_return_value (i32.const 16)(i32.const 4)) ;; store the return value on host
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -673,7 +684,7 @@ static const char get_call_data_less_memory_wast[] = R"=====(
    (export "memory" (memory $0))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $get_call_data (i32.const 0)(i32.const 0)) ;; destination memory size is 0
       (i32.const 8)  ;; caller passes in 8 bytes. get_call_data should always return 8
       i32.ne
@@ -687,6 +698,7 @@ static const char get_call_data_less_memory_wast[] = R"=====(
       if             ;; assert if get_call_data did not return 8
          (call $assert (i32.const 0) (i32.const 0))
       end
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -733,13 +745,14 @@ static const char no_parameters_callee_wast[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $get_call_data (i32.const 160)(i32.const 100)) ;; store call data in memory[160], with size 100
       (i32.const 0)  ;; caller did not pass in data. get_call_data should return 0
       i32.ne
       if             ;; assert if get_call_data did not return 0
          (call $assert (i32.const 0) (i32.const 0))
       end
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -784,7 +797,8 @@ static const char no_return_value_caller_wast[] = R"=====(
 static const char no_return_value_callee_wast[] = R"=====(
 (module
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
+      (i64.const 0))
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64))
@@ -807,7 +821,8 @@ static const char zero_return_value_size_callee_wast[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
+      (i64.const 0))
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
@@ -857,9 +872,10 @@ static const char return_value_before_eosio_exit_callee_wast[] = R"=====(
    (import "env" "set_call_return_value" (func $set_call_return_value (param i32 i32)))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $set_call_return_value (i32.const 0)(i32.const 4)) ;; store the return value 1000 (length is 4) before calling eosio_exit
       (call $eosio_exit (i32.const 0))  ;; 0 is the exit code
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -920,8 +936,9 @@ static const char set_call_return_value_invalid_size_wast[] = R"=====(
    (export "memory" (memory $0))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $set_call_return_value (i32.const 16)(i32.const 524289)) ;; max allowed return value size is 512 KB (524288)
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1149,7 +1166,8 @@ static const char valid_flags_wast[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
+      (i64.const 0))
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
@@ -1173,7 +1191,8 @@ static const char invalid_flags_wast1[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
+      (i64.const 0))
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
@@ -1199,7 +1218,8 @@ static const char invalid_flags_wast2[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32))
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
+      (i64.const 0))
 
    (export "apply" (func $apply))
    (func $apply (param $receiver i64) (param $account i64) (param $action_name i64)
@@ -1244,7 +1264,7 @@ static const char direct_recursive_wast[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (local $n i32)
 
       (drop (call $get_call_data (i32.const 0)(get_local $data_size))) ;; read function parameter into address 0
@@ -1266,6 +1286,7 @@ static const char direct_recursive_wast[] = R"=====(
                         (i32.const 4)          ;; size
          )) ;; recursive call to itself with `n - 1 `
       end
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1303,7 +1324,7 @@ static const char indirect_recursive_caller_wast[] = R"=====(
    (global $callee i64 (i64.const 4729647295212027904)) ;; "callee"_n uint64_t value
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (local $n i32)
 
       (drop (call $get_call_data (i32.const 4)(get_local $data_size))) ;; read function parameter into memory[4]
@@ -1319,6 +1340,7 @@ static const char indirect_recursive_caller_wast[] = R"=====(
                (i32.const 4)          ;; size
          )
       ) ;; recursive call to to the sender with `n`
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1337,7 +1359,7 @@ static const char indirect_recursive_callee_wast[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (local $n i32)
 
       (drop (call $get_call_data (i32.const 0)(get_local $data_size))) ;; read function parameter into address 0
@@ -1360,6 +1382,7 @@ static const char indirect_recursive_callee_wast[] = R"=====(
                   (i32.const 4)          ;; size
          )) ;; recursive call to itself with `n - 1 `
       end
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1512,11 +1535,12 @@ static const char constrains_enforcement_callee_wast[] = R"=====(
    )
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $get_call_data (i32.const 0)(get_local $data_size)))  ;; read the argument: index
       i32.const 0       ;; address of index (stored by get_call_data)
       i32.load          ;; load index
       call $callee
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1603,8 +1627,9 @@ static const char privilege_call_wast[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $get_wasm_parameters_packed (i32.const 0) (i32.const 0) (i32.const 0))) ;; get_wasm_parameters_packed requires privilege
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1892,11 +1917,12 @@ static const char read_only_general_callee_wast[] = R"=====(
    )
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $get_call_data (i32.const 0)(get_local $data_size)))  ;; read the argument: index
       i32.const 0       ;; address of index (stored by get_call_data)
       i32.load          ;; load index
       call $callee
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1955,8 +1981,9 @@ static const char read_only_pass_along_callee_wast[] = R"=====(
    (global $callee1 i64 (i64.const 4729647295748898816)) ;; "calllee1"_n uint64 value
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $call (get_global $callee1) (i64.const 0)(i32.const 0)(i32.const 1)))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1973,8 +2000,9 @@ static const char read_only_pass_along_callee1_wast[] = R"=====(
    (global $callee2 i64 (i64.const 4729647296285769728))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $call (get_global $callee2) (i64.const 0)(i32.const 0)(i32.const 1)))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -1989,8 +2017,9 @@ static const char read_only_pass_along_callee2_wast[] = R"=====(
    (import "env" "db_store_i64" (func $db_store_i64 (param i64 i64 i64 i64 i32 i32) (result i32)))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $db_store_i64 (i64.const 0)(i64.const 0)(i64.const 0)(i64.const 0)(i32.const 0)(i32.const 0)))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2146,10 +2175,11 @@ static const char basic_trace_callee_wast[] = R"=====(
    (memory (export "memory") 1)
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $get_call_data (i32.const 0)(get_local $data_size)))  ;; read parameter into memory[0]
 
       (call $set_call_return_value (i32.const 0)(get_local $data_size)) ;; returns the value of the parameter
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2222,10 +2252,11 @@ static const char trace_callee1_wast[] = R"=====(
    (global $callee11 i64 (i64.const 4729647295765676032)) ;; "calllee11"_n uint64 value
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $prints_l (i32.const 0)(i32.const 12))
       (drop (call $call (get_global $callee11) (i64.const 0)(i32.const 0)(i32.const 8)))
       (call $set_call_return_value (i32.const 0)(i32.const 12)) ;; size of "I am callee1" 12
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2244,9 +2275,10 @@ static const char trace_callee11_wast[] = R"=====(
    (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64)))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $prints_l (i32.const 0)(i32.const 13))
       (call $set_call_return_value (i32.const 0)(i32.const 13)) ;; size of "I am callee11" 13
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2265,9 +2297,10 @@ static const char trace_callee2_wast[] = R"=====(
    (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64)))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $prints_l (i32.const 0)(i32.const 12))
       (call $set_call_return_value (i32.const 0)(i32.const 12)) ;; size of "I am callee2" 12
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2383,8 +2416,9 @@ static const char trace_except_callee1_wast[] = R"=====(
    (global $callee11 i64 (i64.const 4729647295765676032)) ;; "calllee11"_n uint64 value
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (drop (call $call (get_global $callee11) (i64.const 0)(i32.const 0)(i32.const 8)))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2401,8 +2435,9 @@ static const char trace_except_callee11_wast[] = R"=====(
    (import "env" "call" (func $call (param i64 i64 i32 i32) (result i64)))
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $assert (i32.const 0) (i32.const 0))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2519,10 +2554,11 @@ static const char console_callee1_wast[] = R"=====(
    (global $callee11 i64 (i64.const 4729647295765676032)) ;; "calllee11"_n uint64 value
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $prints_l (i32.const 0)(i32.const 26))
       (drop (call $call (get_global $callee11) (i64.const 0)(i32.const 0)(i32.const 0)))
       (call $prints_l (i32.const 26)(i32.const 23))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2541,8 +2577,9 @@ static const char console_callee11_wast[] = R"=====(
    (import "env" "prints_l" (func $prints_l (param i32 i32)))  ;; prints a string
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $prints_l (i32.const 0)(i32.const 16))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2560,8 +2597,9 @@ static const char console_callee2_wast[] = R"=====(
    (import "env" "prints_l" (func $prints_l (param i32 i32)))  ;; prints a string
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $prints_l (i32.const 0)(i32.const 15))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))
@@ -2644,8 +2682,9 @@ static const char no_prints_before_synccall_callee_wast[] = R"=====(
    (import "env" "prints_l" (func $prints_l (param i32 i32)))  ;; prints a string
 
    (export "sync_call" (func $sync_call))
-   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32)
+   (func $sync_call (param $sender i64) (param $receiver i64) (param $data_size i32) (result i64)
       (call $prints_l (i32.const 0)(i32.const 12))
+      (i64.const 0)
    )
 
    (export "apply" (func $apply))


### PR DESCRIPTION
`sync_call()` entry point needs to return an `int64_t` to indicate the status of its execution:
* `0`: success
* `-2`:  `version` field in the data header is not supported
* `-3`:  called function is not found in the receiver contract

This PR builds all the plumbing to pass the execution status from WASM execution all the way to host function `call`.

This is required by CDT data validation work.

Resolves https://github.com/AntelopeIO/spring/issues/1523