### PR TITLE
allow `hash()` to take multiple arguments similar to `pack()`

### DIFF
--- a/libraries/chain/include/eosio/chain/action.hpp
+++ b/libraries/chain/include/eosio/chain/action.hpp
@@ -96,20 +96,8 @@ namespace eosio { namespace chain {
    };
 
    inline digest_type generate_action_digest(const action& act, const vector<char>& action_output) {
-      std::array<digest_type,2> hashes;
       const action_base& base = act;
-
-      fc::sha256::encoder enc;
-      fc::raw::pack(enc, base);
-      hashes[0] = enc.result();
-
-      enc.reset();
-      fc::raw::pack(enc, act.data, action_output);
-      hashes[1] = enc.result();
-
-      enc.reset();
-      fc::raw::pack(enc, hashes);
-      return enc.result();
+      return fc::sha256::hash(fc::sha256::hash(base), fc::sha256::hash(act.data, action_output));
    }
 
 } } /// namespace eosio::chain

--- a/libraries/libfc/include/fc/crypto/hash_concepts.hpp
+++ b/libraries/libfc/include/fc/crypto/hash_concepts.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+#include <cstdint>
+
+namespace fc {
+
+template<typename Arg0>
+concept FirstArgDecaysToCharPtr =
+    std::is_same_v<std::decay_t<Arg0>, char*> ||
+    std::is_same_v<std::decay_t<Arg0>, const char*>;
+
+template<typename Arg1>
+concept SecondArgIsConvertibleToUint32 =
+    std::is_convertible_v<std::decay_t<Arg1>, uint32_t>;
+
+/* Used on template<typename... T> hash_type hash(const T&... t); to prevent calls such as
+ * std::vector<char> foo;
+ * hash(foo.data(), foo.size())
+ * calling the variadic hash instead of the existing hash(const char* d, uint32_t dlen)
+ */
+template<typename... T>
+concept NotTwoArgsCharUint32 =
+    sizeof...(T) != 2 ||
+    !FirstArgDecaysToCharPtr<std::tuple_element_t<0, std::tuple<T...>>> ||
+    !SecondArgIsConvertibleToUint32<std::tuple_element_t<1, std::tuple<T...>>>;
+
+}

--- a/libraries/libfc/include/fc/crypto/ripemd160.hpp
+++ b/libraries/libfc/include/fc/crypto/ripemd160.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <fc/fwd.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw.hpp>
 #include <fc/reflect/typename.hpp>
 
@@ -26,6 +27,7 @@ class ripemd160
     static ripemd160 hash( const std::string& );
 
     template<typename... T>
+    requires NotTwoArgsCharUint32<T...>
     static ripemd160 hash( const T&... t )
     { 
       ripemd160::encoder e; 

--- a/libraries/libfc/include/fc/crypto/ripemd160.hpp
+++ b/libraries/libfc/include/fc/crypto/ripemd160.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <fc/fwd.hpp>
-#include <fc/io/raw_fwd.hpp>
+#include <fc/io/raw.hpp>
 #include <fc/reflect/typename.hpp>
 
 namespace fc{
@@ -25,11 +25,11 @@ class ripemd160
     static ripemd160 hash( const char* d, uint32_t dlen );
     static ripemd160 hash( const std::string& );
 
-    template<typename T>
-    static ripemd160 hash( const T& t ) 
+    template<typename... T>
+    static ripemd160 hash( const T&... t )
     { 
       ripemd160::encoder e; 
-      fc::raw::pack(e,t);
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha1.hpp
+++ b/libraries/libfc/include/fc/crypto/sha1.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
+#include <fc/io/raw.hpp>
 
 namespace fc{
 
@@ -20,11 +21,11 @@ class sha1
     static sha1 hash( const char* d, uint32_t dlen );
     static sha1 hash( const std::string& );
 
-    template<typename T>
-    static sha1 hash( const T& t ) 
+    template<typename... T>
+    static sha1 hash( const T&... t )
     { 
       sha1::encoder e; 
-      e << t; 
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha1.hpp
+++ b/libraries/libfc/include/fc/crypto/sha1.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw.hpp>
 
 namespace fc{
@@ -22,6 +23,7 @@ class sha1
     static sha1 hash( const std::string& );
 
     template<typename... T>
+    requires NotTwoArgsCharUint32<T...>
     static sha1 hash( const T&... t )
     { 
       sha1::encoder e; 

--- a/libraries/libfc/include/fc/crypto/sha224.hpp
+++ b/libraries/libfc/include/fc/crypto/sha224.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <unordered_map>
 #include <fc/fwd.hpp>
-#include <fc/io/raw_fwd.hpp>
+#include <fc/io/raw.hpp>
 #include <fc/string.hpp>
 
 namespace fc
@@ -23,11 +23,11 @@ class sha224
     static sha224 hash( const char* d, uint32_t dlen );
     static sha224 hash( const std::string& );
 
-    template<typename T>
-    static sha224 hash( const T& t ) 
+    template<typename... T>
+    static sha224 hash( const T&... t )
     { 
       sha224::encoder e; 
-      fc::raw::pack(e,t);
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha224.hpp
+++ b/libraries/libfc/include/fc/crypto/sha224.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <unordered_map>
 #include <fc/fwd.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw.hpp>
 #include <fc/string.hpp>
 
@@ -24,6 +25,7 @@ class sha224
     static sha224 hash( const std::string& );
 
     template<typename... T>
+    requires NotTwoArgsCharUint32<T...>
     static sha224 hash( const T&... t )
     { 
       sha224::encoder e; 

--- a/libraries/libfc/include/fc/crypto/sha256.hpp
+++ b/libraries/libfc/include/fc/crypto/sha256.hpp
@@ -4,7 +4,7 @@
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
-#include <fc/io/raw_fwd.hpp>
+#include <fc/io/raw.hpp>
 #include <boost/functional/hash.hpp>
 
 namespace fc
@@ -36,11 +36,11 @@ class sha256
     static sha256 hash( const std::string& );
     static sha256 hash( const sha256& );
 
-    template<typename T>
-    static sha256 hash( const T& t ) 
+    template<typename... T>
+    static sha256 hash( const T&... t )
     { 
       sha256::encoder e; 
-      fc::raw::pack(e,t);
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha256.hpp
+++ b/libraries/libfc/include/fc/crypto/sha256.hpp
@@ -4,13 +4,14 @@
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw.hpp>
 #include <boost/functional/hash.hpp>
 
 namespace fc
 {
 
-class sha256 
+class sha256
 {
   public:
     sha256();
@@ -37,6 +38,7 @@ class sha256
     static sha256 hash( const sha256& );
 
     template<typename... T>
+    requires NotTwoArgsCharUint32<T...>
     static sha256 hash( const T&... t )
     { 
       sha256::encoder e; 

--- a/libraries/libfc/include/fc/crypto/sha3.hpp
+++ b/libraries/libfc/include/fc/crypto/sha3.hpp
@@ -2,7 +2,7 @@
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
-#include <fc/io/raw_fwd.hpp>
+#include <fc/io/raw.hpp>
 #include <boost/functional/hash.hpp>
 
 namespace fc
@@ -32,12 +32,23 @@ public:
 	static sha3 hash(const std::string& s, bool is_nist=true) { return hash(s.c_str(), s.size(), is_nist); }
 	static sha3 hash(const sha3& s, bool is_nist=true) { return hash(s.data(), sizeof(s._hash), is_nist); }
 
-	template <typename T>
-	static sha3 hash(const T &t, bool is_nist=true)
+	struct keccak {};
+	struct nist {};
+
+	template<typename... T>
+	static sha3 hash( keccak, const T&... t )
 	{
 		sha3::encoder e;
-		fc::raw::pack(e, t);
-		return e.result(is_nist);
+		fc::raw::pack(e,t...);
+		return e.result(false);
+	}
+
+	template<typename... T>
+	static sha3 hash( nist, const T&... t )
+	{
+		sha3::encoder e;
+		fc::raw::pack(e,t...);
+		return e.result(true);
 	}
 
 	class encoder

--- a/libraries/libfc/include/fc/crypto/sha512.hpp
+++ b/libraries/libfc/include/fc/crypto/sha512.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
+#include <fc/io/raw.hpp>
 
 namespace fc
 {
@@ -21,11 +22,11 @@ class sha512
     static sha512 hash( const char* d, uint32_t dlen );
     static sha512 hash( const std::string& );
 
-    template<typename T>
-    static sha512 hash( const T& t ) 
+    template<typename... T>
+    static sha512 hash( const T&... t )
     { 
       sha512::encoder e; 
-      e << t; 
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha512.hpp
+++ b/libraries/libfc/include/fc/crypto/sha512.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw.hpp>
 
 namespace fc
@@ -23,6 +24,7 @@ class sha512
     static sha512 hash( const std::string& );
 
     template<typename... T>
+    requires NotTwoArgsCharUint32<T...>
     static sha512 hash( const T&... t )
     { 
       sha512::encoder e; 

--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -176,6 +176,7 @@ namespace fc {
     } FC_RETHROW_EXCEPTIONS( warn, "fc::array<${type},${length}>", ("type",fc::get_typename<T>::name())("length",N) ) }
 
     template<typename Stream, typename T, size_t N>
+    requires (!std::is_same_v<std::remove_cv_t<T>, char>)
     inline void pack( Stream& s, T (&v)[N]) {
       fc::raw::pack( s, unsigned_int((uint32_t)N) );
       for (uint64_t i = 0; i < N; ++i)
@@ -183,6 +184,7 @@ namespace fc {
     }
 
     template<typename Stream, typename T, size_t N>
+    requires (!std::is_same_v<std::remove_cv_t<T>, char>)
     inline void unpack( Stream& s, T (&v)[N])
     { try {
       unsigned_int size; fc::raw::unpack( s, size );


### PR DESCRIPTION
This change allows passing `hash()` multiple arguments to concatenate together similar to how `pack()` already does. This can allow some more concise usage of `hash()` without resorting to `make_tuple/pair()` and remembering to avoid the trap of needing to use `cref` along with `make_tuple/pair()` to avoid copies.

I updated `generate_action_digest()` as a good demonstration of the improved conciseness. Of course there are other locations we could potentially change too.

Unfortunately there were a few gnarly quirks that came out of adding just this "simple" variadic template that I will describe below. If it is too gnarly (i.e. too risky) we can explore other approaches that aren't so invasive. For example I have a different branch https://github.com/AntelopeIO/spring/compare/main...vardigest that just creates a new variadic `digest()` call so as not to conflict with any existing `hash()` usages at all.