### PR TITLE
[1.2.0-rc3 -> main] Test: Relax hard thread test

### DIFF
--- a/libraries/custom_appbase/tests/custom_appbase_tests.cpp
+++ b/libraries/custom_appbase/tests/custom_appbase_tests.cpp
@@ -575,11 +575,8 @@ BOOST_AUTO_TEST_CASE( execute_many_from_read_only_and_read_exclusive_queues ) {
    const auto run_on_3 = std::count_if(rslts.cbegin(), rslts.cend(), [&](const auto& v){ return v == read_thread3_id; });
    const auto run_on_main = std::count_if(rslts.cbegin(), rslts.cend(), [&](const auto& v){ return v == app->executor().get_main_thread_id(); });
 
+   // We expect at least one task to run on every thread including main, but nothing guarantees that, just verify they all ran
    BOOST_REQUIRE_EQUAL(run_on_1+run_on_2+run_on_3+run_on_main, num_expected);
-   BOOST_CHECK(run_on_1 > 0);
-   BOOST_CHECK(run_on_2 > 0);
-   BOOST_CHECK(run_on_3 > 0);
-   BOOST_CHECK(run_on_main > 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Do not require every thread to run a task in test. In practice sometimes a thread doesn't actually run a task. There is nothing that would guarantee every thread runs at least one task, so don't require it.

Merges `release/1.2` into `main` including #1530

Resolves #1502 