### PR TITLE
[2.0.0-dev] Add a rethrow() to fc::exception to preserve exception type

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1308,7 +1308,7 @@ struct controller_impl {
          if( trace->except_ptr )
             std::rethrow_exception(trace->except_ptr);
          if( trace->except)
-            throw *trace->except;
+            trace->except->rethrow();
          getpeerkeys_res_t res;
          if (!trace->action_traces.empty()) {
             const auto& act_trace = trace->action_traces[0];
@@ -3376,7 +3376,7 @@ struct controller_impl {
             if( onblock_trace->except ) {
                if (onblock_trace->except->code() == interrupt_exception::code_value) {
                   ilog("Interrupt of onblock ${bn}", ("bn", chain_head.block_num() + 1));
-                  throw *onblock_trace->except;
+                  onblock_trace->except->rethrow();
                }
                wlog("onblock ${block_num} is REJECTING: ${entire_trace}",
                     ("block_num", chain_head.block_num() + 1)("entire_trace", onblock_trace));
@@ -3896,7 +3896,7 @@ struct controller_impl {
                   } else {
                      edump((*trace));
                   }
-                  throw *trace->except;
+                  trace->except->rethrow();
                }
 
                EOS_ASSERT(trx_receipts.size() > 0, block_validate_exception,

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -139,8 +139,9 @@
        :BASE(c){} \
        TYPE():BASE(CODE, BOOST_PP_STRINGIZE(TYPE), WHAT){}\
        \
-       virtual std::shared_ptr<fc::exception> dynamic_copy_exception()const\
+       std::shared_ptr<fc::exception> dynamic_copy_exception()const override\
        { return std::make_shared<TYPE>( *this ); } \
+       void rethrow() const override { throw *this; } \
        std::optional<uint64_t> error_code; \
    };
 

--- a/libraries/libfc/include/fc/exception/exception.hpp
+++ b/libraries/libfc/include/fc/exception/exception.hpp
@@ -117,6 +117,7 @@ namespace fc
           *  @endcode
           */
           virtual std::shared_ptr<exception> dynamic_copy_exception()const;
+          virtual void rethrow() const { throw *this; }
 
          friend void to_variant( const exception& e, variant& v );
          friend void from_variant( const variant& e, exception& ll );
@@ -156,7 +157,7 @@ namespace fc
 
        std::exception_ptr get_inner_exception()const;
 
-       virtual std::shared_ptr<exception>   dynamic_copy_exception()const;
+       std::shared_ptr<exception>   dynamic_copy_exception()const override;
       private:
        std::exception_ptr _inner;
    };
@@ -180,7 +181,8 @@ namespace fc
 
        static std_exception_wrapper from_current_exception(const std::exception& e);
 
-       virtual std::shared_ptr<exception>   dynamic_copy_exception()const;
+       std::shared_ptr<exception>   dynamic_copy_exception()const override;
+       void rethrow() const override { throw *this; }
       private:
        std::exception_ptr _inner;
    };
@@ -225,8 +227,9 @@ namespace fc
        :BASE(c){} \
        TYPE():BASE(CODE, BOOST_PP_STRINGIZE(TYPE), WHAT){}\
        \
-       virtual std::shared_ptr<fc::exception> dynamic_copy_exception()const\
+       std::shared_ptr<fc::exception> dynamic_copy_exception()const override\
        { return std::make_shared<TYPE>( *this ); } \
+       void rethrow() const override { throw *this; } \
    };
 
   #define FC_DECLARE_EXCEPTION( TYPE, CODE, WHAT ) \

--- a/libraries/libfc/src/network/http/http_client.cpp
+++ b/libraries/libfc/src/network/http/http_client.cpp
@@ -320,7 +320,7 @@ public:
          }
 
          if (excp) {
-            throw *excp;
+            excp->rethrow();
          } else {
             FC_THROW("Request failed with 500 response, but response was not parseable");
          }

--- a/libraries/libfc/test/CMakeLists.txt
+++ b/libraries/libfc/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable( test_fc
         variant_estimated_size/test_variant_estimated_size.cpp
         test_base64.cpp
         test_escape_str.cpp
+        test_exception.cpp
         test_bls.cpp
         test_ordered_diff.cpp
         main.cpp

--- a/libraries/libfc/test/test_exception.cpp
+++ b/libraries/libfc/test/test_exception.cpp
@@ -1,0 +1,33 @@
+#include <boost/test/unit_test.hpp>
+
+#include <fc/exception/exception.hpp>
+
+BOOST_AUTO_TEST_SUITE(exception)
+
+BOOST_AUTO_TEST_CASE(rethrow) try {
+   fc::exception_ptr exp;
+   try {
+      try {
+         FC_ASSERT(false, "test ${i}", ("i", 42));
+      } FC_RETHROW_EXCEPTIONS(info, "extra stuff")
+   } catch (fc::exception& e) {
+      exp = e.dynamic_copy_exception();
+   }
+
+   BOOST_TEST(exp->to_detail_string().find("test 42") != std::string::npos);
+   BOOST_TEST(exp->to_detail_string().find("extra stuff") != std::string::npos);
+
+   try {
+      exp->rethrow();
+   } catch (fc::assert_exception& e) {
+      // success
+   } catch (fc::exception& e) {
+      BOOST_FAIL("should be: assert_exception");
+   } catch (...) {
+      BOOST_FAIL("should be: assert_exception");
+   }
+
+} FC_LOG_AND_RETHROW();
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -491,8 +491,7 @@ namespace eosio::testing {
          for( auto itr = unapplied_transactions.begin(); itr != unapplied_transactions.end();  ) {
             auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true, 0 );
             if(!no_throw && trace->except) {
-               // this always throws an fc::exception, since the original exception is copied into an fc::exception
-               throw *trace->except;
+               trace->except->rethrow();
             }
             itr = unapplied_transactions.erase( itr );
             res.unapplied_transaction_traces.emplace_back( std::move(trace) );
@@ -503,8 +502,7 @@ namespace eosio::testing {
             for( const auto& trx : scheduled_trxs ) {
                auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
                if( !no_throw && trace->except ) {
-                  // this always throws an fc::exception, since the original exception is copied into an fc::exception
-                  throw *trace->except;
+                  trace->except->rethrow();
                }
             }
          }
@@ -737,7 +735,7 @@ namespace eosio::testing {
       auto fut = transaction_metadata::start_recover_keys( ptrx, control->get_thread_pool(), control->get_chain_id(), time_limit, transaction_metadata::trx_type::input );
       auto r = control->push_transaction( fut.get(), deadline, fc::microseconds::maximum(), billed_cpu_time_us, billed_cpu_time_us > 0, 0 );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except ) throw *r->except;
+      if( r->except ) r->except->rethrow();
       return r;
    } FC_RETHROW_EXCEPTIONS( warn, "transaction_header: ${header}", ("header", transaction_header(trx.get_transaction()) )) }
 
@@ -764,7 +762,7 @@ namespace eosio::testing {
       auto r = control->push_transaction( fut.get(), deadline, fc::microseconds::maximum(), billed_cpu_time_us, billed_cpu_time_us > 0, 0 );
       if (no_throw) return r;
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except)  throw *r->except;
+      if( r->except)  r->except->rethrow();
       return r;
    } FC_RETHROW_EXCEPTIONS( warn, "transaction_header: ${header}, billed_cpu_time_us: ${billed}",
                             ("header", transaction_header(trx) ) ("billed", billed_cpu_time_us))

--- a/plugins/http_plugin/include/eosio/http_plugin/macros.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/macros.hpp
@@ -13,7 +13,7 @@
            (const chain::next_function_variant<call_result>& result) mutable {                                  \
               if (std::holds_alternative<fc::exception_ptr>(result)) {                                          \
                  try {                                                                                          \
-                    throw *std::get<fc::exception_ptr>(result);                                                 \
+                    std::get<fc::exception_ptr>(result)->rethrow();                                             \
                  } catch (...) {                                                                                \
                     http_plugin::handle_exception(#api_name, #call_name, body, cb);                             \
                  }                                                                                              \
@@ -28,7 +28,7 @@
                     chain::t_or_exception<call_result> result = http_fwd();                                     \
                     if (std::holds_alternative<fc::exception_ptr>(result)) {                                    \
                        try {                                                                                    \
-                          throw *std::get<fc::exception_ptr>(result);                                           \
+                          std::get<fc::exception_ptr>(result)->rethrow();                                       \
                        } catch (...) {                                                                          \
                           http_plugin::handle_exception(#api_name, #call_name, body, cb);                       \
                        }                                                                                        \
@@ -65,7 +65,7 @@
                    chain::t_or_exception<call_result> result = http_fwd();                                      \
                    if (std::holds_alternative<fc::exception_ptr>(result)) {                                     \
                       try {                                                                                     \
-                         throw *std::get<fc::exception_ptr>(result);                                            \
+                         std::get<fc::exception_ptr>(result)->rethrow();                                        \
                       } catch (...) {                                                                           \
                          http_plugin::handle_exception(#api_name, #call_name, body, cb);                        \
                       }                                                                                         \

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -40,7 +40,7 @@ using namespace eosio;
       auto next = [cb=std::move(cb), body=std::move(body)](const chain::next_function_variant<call_result>& result){ \
          if (std::holds_alternative<fc::exception_ptr>(result)) {\
             try {\
-               throw *std::get<fc::exception_ptr>(result);\
+               std::get<fc::exception_ptr>(result)->rethrow();\
             } catch (...) {\
                http_plugin::handle_exception(#api_name, #call_name, body, cb);\
             }\

--- a/tests/chain_test_utils.hpp
+++ b/tests/chain_test_utils.hpp
@@ -91,13 +91,13 @@ inline auto push_input_trx(appbase::scoped_app& app, eosio::chain::controller& c
            [trx_promise](const next_function_variant<transaction_trace_ptr>& result) {
               if( std::holds_alternative<fc::exception_ptr>( result ) ) {
                  try {
-                    throw *std::get<fc::exception_ptr>(result);
+                    std::get<fc::exception_ptr>(result)->rethrow();
                  } catch(...) {
                     trx_promise->set_exception(std::current_exception());
                  }
               } else if ( std::get<chain::transaction_trace_ptr>( result )->except ) {
                  try {
-                    throw *std::get<chain::transaction_trace_ptr>(result)->except;
+                    std::get<chain::transaction_trace_ptr>(result)->except->rethrow();
                  } catch(...) {
                     trx_promise->set_exception(std::current_exception());
                  }

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1005,7 +1005,7 @@ void transaction_tests(T& chain) {
       auto fut = transaction_metadata::start_recover_keys( std::move( ptrx ), chain.control->get_thread_pool(), chain.get_chain_id(), time_limit, transaction_metadata::trx_type::input );
       auto r = chain.control->push_transaction( fut.get(), fc::time_point::maximum(), fc::microseconds::maximum(), T::DEFAULT_BILLED_CPU_TIME_US, true, 0 );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except) throw *r->except;
+      if( r->except) r->except->rethrow();
       tx_trace = r;
       chain.produce_block();
       BOOST_CHECK(tx_trace->action_traces.front().console == sha_expect);

--- a/unittests/test_utils.hpp
+++ b/unittests/test_utils.hpp
@@ -96,7 +96,7 @@ void push_trx(Tester& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cpu
    auto res = test.control->push_transaction( fut.get(), fc::time_point::now() + fc::milliseconds(max_block_cpu_ms),
                                               fc::milliseconds(max_cpu_usage_ms), billed_cpu_time_us, explicit_bill, 0 );
    if( res->except_ptr ) std::rethrow_exception( res->except_ptr );
-   if( res->except ) throw *res->except;
+   if( res->except ) res->except->rethrow();
 };
 
 static constexpr unsigned int DJBH(const char* cp) {

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -2000,7 +2000,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( billed_cpu_test, T, testers ) try {
                      uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time, uint32_t subjective_cpu_bill_us ) {
       auto r = chain.control->push_transaction( trx, deadline, fc::microseconds::maximum(), billed_cpu_time_us, explicit_billed_cpu_time, subjective_cpu_bill_us );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except ) throw *r->except;
+      if( r->except ) r->except->rethrow();
       return r;
    };
 


### PR DESCRIPTION
I ran into the issue again where fc exception type is lost. In the past that has led to comments like:
```cpp
   // this always throws an fc::exception, since the original exception is copied into an fc::exception
   throw *trace->except;
```

The comment is a bit misleading. The original exception was not copied into an `fc::exception` it was `dynamic_copy_exception` which does preserve the type into the `shared_ptr<exception>`. It is not until the actual throw that the object is copied/sliced into an fc::exception. 

The previous use would lead to confusion around catching `fc::exception`.
```
   try {
      // call something that does something like:  throw *trace->except;
      // note that  throw *trace->except; slices the object
   } catch (fc::assert_exception& e) {
     // expect to catch an assert exception, but the type of the exception was lost.
   } catch (fc::exception& e) {
     // this gets hit instead, the type is lost
   }
```
