### PR TITLE
[2.0.0-dev] Generate new snapshot on fork

### DIFF
--- a/libraries/chain/include/eosio/chain/pending_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/pending_snapshot.hpp
@@ -54,15 +54,15 @@ public:
       std::error_code ec;
       if(!valid) {
          fs::remove(fs::path(pending_path), ec);
-         ilog("Snapshot created at block id ${id} invalidated because block was forked out", ("id", block_id));
+         ilog("Snapshot created at block ${bn} id ${id} invalidated because block was forked out", ("bn", block_num)("id", block_id));
          EOS_THROW(chain::snapshot_finalization_exception,
-                   "Snapshotted block was forked out of the chain.  ID: ${id}", ("id", block_id));
+                   "Snapshot block ${bn} was forked out of the chain. ID: ${id}", ("bn", block_num)("id", block_id));
       }
 
       fs::rename(fs::path(pending_path), fs::path(final_path), ec);
       EOS_ASSERT(!ec, chain::snapshot_finalization_exception,
-                 "Unable to finalize valid snapshot of block number ${bn}: [code: ${ec}] ${message}",
-                 ("bn", block_num)("ec", ec.value())("message", ec.message()));
+                 "Unable to finalize valid snapshot of block ${bn} ${id} : [code: ${ec}] ${message}",
+                 ("bn", block_num)("id", block_id)("ec", ec.value())("message", ec.message()));
 
       ilog("Snapshot created at block ${bn} available at ${fn}", ("bn", block_num)("fn", final_path));
 

--- a/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
@@ -29,6 +29,9 @@ namespace fs = std::filesystem;
 
 class snapshot_scheduler {
 public:
+   template<typename T>
+   using next_function = eosio::chain::next_function<T>;
+
    struct snapshot_information {
       chain::block_id_type head_block_id;
       uint32_t head_block_num;
@@ -62,14 +65,12 @@ public:
 
    struct snapshot_schedule_information : public snapshot_request_id_information, public snapshot_request_information {
       std::vector<snapshot_information> pending_snapshots;
+      next_function<snapshot_information> next; // not serialized
    };
 
    struct get_snapshot_requests_result {
       std::vector<snapshot_schedule_information> snapshot_requests;
    };
-
-   template<typename T>
-   using next_function = eosio::chain::next_function<T>;
 
    struct by_height;
 
@@ -191,7 +192,7 @@ public:
    void on_irreversible_block(const signed_block_ptr& lib, const block_id_type& block_id, const chain::controller& chain);
 
    // snapshot scheduler handlers
-   snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri);
+   snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri, next_function<snapshot_information> next);
    snapshot_schedule_result unschedule_snapshot(uint32_t sri);
    get_snapshot_requests_result get_snapshot_requests();
 
@@ -205,10 +206,10 @@ public:
    void add_pending_snapshot_info(const snapshot_information& si);
 
    // execute snapshot
-   void execute_snapshot(uint32_t srid, chain::controller& chain);
+   void execute_snapshot(uint32_t srid, chain::controller& chain, next_function<snapshot_information> next);
 
    // former producer_plugin snapshot fn
-   void create_snapshot(next_function<snapshot_information> next, chain::controller& chain, std::function<void(void)> predicate);
+   void create_snapshot(next_function<snapshot_information> next, chain::controller& chain);
 };
 
 

--- a/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot_scheduler.hpp
@@ -194,6 +194,7 @@ public:
    // snapshot scheduler handlers
    snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri, next_function<snapshot_information> next);
    snapshot_schedule_result unschedule_snapshot(uint32_t sri);
+   void unschedule_snapshot_requests(block_num_type lib_height);
    get_snapshot_requests_result get_snapshot_requests();
 
    // initialize with storage

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -210,9 +210,7 @@ void snapshot_scheduler::create_snapshot(next_function<snapshot_information> nex
    // determine if this snapshot is already in-flight
    auto& pending_by_id = _pending_snapshot_index.get<by_id>();
    auto existing = pending_by_id.find(head_id);
-   if(existing != pending_by_id.end()) {
-      // if a snapshot at this block is already pending, ignore
-   } else {
+   if(existing == pending_by_id.end()) { // if a snapshot at this block is already pending, ignore
       const auto& pending_path = pending_snapshot<snapshot_information>::get_pending_path(head_id, _snapshots_dir);
 
       try {

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -42,8 +42,7 @@ void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, cons
 
       try {
          next(pending->finalize(block_id, chain));
-      }
-      CATCH_AND_CALL(next);
+      } FC_LOG_AND_DROP();
 
       snapshots_by_height.erase(snapshots_by_height.begin());
    }
@@ -226,7 +225,7 @@ void snapshot_scheduler::create_snapshot(next_function<snapshot_information> nex
                     "Unable to promote temp snapshot ${t} to pending ${p} for block number ${bn}: [code: ${ec}] ${message}",
                     ("t", temp_path.generic_string())("p", pending_path.generic_string())
                     ("bn", head_block_num)("ec", ec.value())("message", ec.message()));
-         ilog("Snapshot creation at block ${bn} complete; snapshot will be available once block becomes irreversible", ("bn", head_block_num));
+         ilog("Snapshot creation at block ${bn} complete; snapshot will be available once block ${b} becomes irreversible", ("bn", head_block_num)("b",head_id));
          _pending_snapshot_index.emplace(head_id, head_block_time, next, pending_path.generic_string(), snapshot_path.generic_string());
          add_pending_snapshot_info(snapshot_information{head_id, head_block_num, head_block_time, chain_snapshot_header::current_version, pending_path.generic_string()});
       }

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -212,13 +212,7 @@ void snapshot_scheduler::create_snapshot(next_function<snapshot_information> nex
    auto& pending_by_id = _pending_snapshot_index.get<by_id>();
    auto existing = pending_by_id.find(head_id);
    if(existing != pending_by_id.end()) {
-      // if a snapshot at this block is already pending, attach this requests handler to it
-      pending_by_id.modify(existing, [&next](auto& entry) {
-         entry.next = [prev = entry.next, next](const next_function_variant<snapshot_information>& res) {
-            prev(res);
-            next(res);
-         };
-      });
+      // if a snapshot at this block is already pending, ignore
    } else {
       const auto& pending_path = pending_snapshot<snapshot_information>::get_pending_path(head_id, _snapshots_dir);
 

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -2,7 +2,6 @@
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/pending_snapshot.hpp>
 #include <eosio/chain/snapshot_scheduler.hpp>
-#include <fc/scoped_exit.hpp>
 
 namespace eosio::chain {
 
@@ -16,7 +15,7 @@ void snapshot_scheduler::on_start_block(uint32_t height, chain::controller& chai
          dlog("snapshot scheduler creating a snapshot from the request [start_block_num:${start_block_num}, end_block_num=${end_block_num}, block_spacing=${block_spacing}], height=${height}",
               ("start_block_num", req.start_block_num)("end_block_num", req.end_block_num)("block_spacing", req.block_spacing)("height", height));
 
-         execute_snapshot(req.snapshot_request_id, chain);
+         execute_snapshot(req.snapshot_request_id, chain, req.next);
          snapshot_executed = true;
       }
    };
@@ -65,15 +64,17 @@ void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, cons
    }
 }
 
-snapshot_scheduler::snapshot_schedule_result snapshot_scheduler::schedule_snapshot(const snapshot_request_information& sri) {
-   auto& snapshot_by_value = _snapshot_requests.get<by_snapshot_value>();
-   auto existing = snapshot_by_value.find(std::make_tuple(sri.block_spacing, sri.start_block_num, sri.end_block_num));
-   EOS_ASSERT(existing == snapshot_by_value.end(), chain::duplicate_snapshot_request, "Duplicate snapshot request");
-   EOS_ASSERT(sri.start_block_num <= sri.end_block_num, chain::invalid_snapshot_request, "End block number should be greater or equal to start block number");
-   EOS_ASSERT(sri.start_block_num + sri.block_spacing <= sri.end_block_num, chain::invalid_snapshot_request, "Block spacing exceeds defined by start and end range");
+snapshot_scheduler::snapshot_schedule_result snapshot_scheduler::schedule_snapshot(const snapshot_request_information& sri, next_function<snapshot_information> next) {
+   try {
+      auto& snapshot_by_value = _snapshot_requests.get<by_snapshot_value>();
+      auto existing = snapshot_by_value.find(std::make_tuple(sri.block_spacing, sri.start_block_num, sri.end_block_num));
+      EOS_ASSERT(existing == snapshot_by_value.end(), chain::duplicate_snapshot_request, "Duplicate snapshot request");
+      EOS_ASSERT(sri.start_block_num <= sri.end_block_num, chain::invalid_snapshot_request, "End block number should be greater or equal to start block number");
+      EOS_ASSERT(sri.start_block_num + sri.block_spacing <= sri.end_block_num, chain::invalid_snapshot_request, "Block spacing exceeds defined by start and end range");
 
-   _snapshot_requests.emplace(snapshot_schedule_information{{_snapshot_id++}, {sri.block_spacing, sri.start_block_num, sri.end_block_num, sri.snapshot_description}, {}});
-   x_serialize();
+      _snapshot_requests.emplace(snapshot_schedule_information{{_snapshot_id++}, {sri.block_spacing, sri.start_block_num, sri.end_block_num, sri.snapshot_description}, {}, next});
+      x_serialize();
+   } CATCH_AND_CALL(next);
 
    // returning snapshot_schedule_result
    return snapshot_schedule_result{{_snapshot_id - 1}, {sri.block_spacing, sri.start_block_num, sri.end_block_num, sri.snapshot_description}};
@@ -131,11 +132,14 @@ void snapshot_scheduler::add_pending_snapshot_info(const snapshot_information& s
    }
 }
 
-void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chain) {
+void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chain, next_function<snapshot_information> http_next) {
    _inflight_sid = srid;
-   auto next = [srid, this](const chain::next_function_variant<snapshot_information>& result) {
+   auto next = [srid, this, http_next](const chain::next_function_variant<snapshot_information>& result) {
+      if (http_next)
+         http_next(result);
       if(std::holds_alternative<fc::exception_ptr>(result)) {
-         wlog("Snapshot creation error: ${d}", ("d", std::get<fc::exception_ptr>(result)->to_detail_string()));
+         if (!http_next)
+            wlog("Snapshot creation error: ${d}", ("d", std::get<fc::exception_ptr>(result)->to_detail_string()));
       } else {
          // success, snapshot finalized
          auto snapshot_info = std::get<snapshot_information>(result);
@@ -151,10 +155,10 @@ void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chai
          }
       }
    };
-   create_snapshot(next, chain, {});
+   create_snapshot(next, chain);
 }
 
-void snapshot_scheduler::create_snapshot(next_function<snapshot_information> next, chain::controller& chain, std::function<void(void)> predicate) {
+void snapshot_scheduler::create_snapshot(next_function<snapshot_information> next, chain::controller& chain) {
    auto head_id = chain.head().id();
    const auto head_block_num = chain.head().block_num();
    const auto head_block_time = chain.head().block_time();
@@ -169,7 +173,6 @@ void snapshot_scheduler::create_snapshot(next_function<snapshot_information> nex
    }
 
    auto write_snapshot = [&](const fs::path& p) -> void {
-      if(predicate) predicate();
       fs::create_directory(p.parent_path());
       auto snap_out = std::ofstream(p.generic_string(), (std::ios::out | std::ios::binary));
       auto writer = std::make_shared<ostream_snapshot_writer>(snap_out);

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1812,15 +1812,22 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<chain::snap
       reschedule.cancel();
    }
 
-   // missing start/end is set to head block num, missing end to UINT32_MAX
-   chain::snapshot_scheduler::snapshot_request_information sri = {
-      .block_spacing   = 0,
-      .start_block_num = head_block_num, // use head_block_num in case we are running in irreversible mode so it happens immediately
-      .end_block_num   = std::numeric_limits<uint32_t>::max(),
-      .snapshot_description = ""
-   };
-
-   my->_snapshot_scheduler.schedule_snapshot(sri, std::move(next));
+   if(chain.get_read_mode() == db_read_mode::IRREVERSIBLE) {
+      // /v1/producer/create_snapshot is expected to immediately create a snapshot. When in irreversible mode this
+      // can't be completely faked by scheduling to create on the next start_block as a start_block might never happen.
+      // Create snapshot directly. Since in irreversible mode it can't be forked out there is no need to have the
+      // snapshot scheduler schedule the snapshot, just create it here and now.
+      my->_snapshot_scheduler.create_snapshot(std::move(next), chain);
+   } else {
+      // setup for execute on the next start block
+      chain::snapshot_scheduler::snapshot_request_information sri = {
+         .block_spacing   = 0,
+         .start_block_num = head_block_num + 1,
+         .end_block_num   = std::numeric_limits<uint32_t>::max(),
+         .snapshot_description = ""
+      };
+      my->_snapshot_scheduler.schedule_snapshot(sri, std::move(next));
+   }
 }
 
 chain::snapshot_scheduler::snapshot_schedule_result

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1803,6 +1803,15 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<chain::snap
    chain::controller& chain = my->chain_plug->chain();
    const auto head_block_num = chain.head().block_num();
 
+   auto reschedule = fc::make_scoped_exit([my=my]() { my->schedule_production_loop(); });
+
+   if (chain.is_building_block()) {
+      // abort the pending block
+      my->abort_block();
+   } else {
+      reschedule.cancel();
+   }
+
    // missing start/end is set to head block num, missing end to UINT32_MAX
    chain::snapshot_scheduler::snapshot_request_information sri = {
       .block_spacing   = 0,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1806,7 +1806,7 @@ void producer_plugin::create_snapshot(producer_plugin::next_function<chain::snap
    // missing start/end is set to head block num, missing end to UINT32_MAX
    chain::snapshot_scheduler::snapshot_request_information sri = {
       .block_spacing   = 0,
-      .start_block_num = head_block_num + 1,
+      .start_block_num = head_block_num, // use head_block_num in case we are running in irreversible mode so it happens immediately
       .end_block_num   = std::numeric_limits<uint32_t>::max(),
       .snapshot_description = ""
    };


### PR DESCRIPTION
Instead of generating an error on `/v1/producer/create_snapshot` when the block is forked out, generate a new snapshot and report that snapshot to the user.

Example from fork test:
```
debug 2025-05-22T15:56:19.502 http-1    beast_http_session.hpp:157    handle_request       ] Request:  localhost:8889 POST /v1/producer/create_snapshot HTTP/1.1  Accept-Encoding: identity  Content-Length: 0  Host: localhost:8889  User-Agent: Python-urllib/3.10  Connection: close    
debug 2025-05-22T15:56:19.502 nodeos    snapshot_scheduler.cpp:16     operator()           ] snapshot scheduler creating a snapshot from the request [start_block_num:189, end_block_num=4294967295, block_spacing=0], height=190
info  2025-05-22T15:56:19.503 nodeos    snapshot_scheduler.cpp:219    create_snapshot      ] Starting snapshot creation at block 189
info  2025-05-22T15:56:19.509 nodeos    snapshot_scheduler.cpp:228    create_snapshot      ] Snapshot creation at block 189 complete; snapshot will be available once block 000000bdc5b795aee58a5bcd281c44fe58c91f2a905eaafc6df756af63b6be66 becomes irreversible
debug 2025-05-22T15:56:23.063 nodeos    snapshot_scheduler.cpp:16     operator()           ] snapshot scheduler creating a snapshot from the request [start_block_num:189, end_block_num=4294967295, block_spacing=0], height=190
info  2025-05-22T15:56:23.063 nodeos    snapshot_scheduler.cpp:219    create_snapshot      ] Starting snapshot creation at block 189
info  2025-05-22T15:56:23.069 nodeos    snapshot_scheduler.cpp:228    create_snapshot      ] Snapshot creation at block 189 complete; snapshot will be available once block 000000bdf1cb0972dcf8164828df59f1b320d239d2ac9faaad33526caf7bdad9 becomes irreversible
info  2025-05-22T15:56:47.970 nodeos    pending_snapshot.hpp:57       finalize             ] Snapshot created at block 189 id 000000bdc5b795aee58a5bcd281c44fe58c91f2a905eaafc6df756af63b6be66 invalidated because block was forked out
warn  2025-05-22T15:56:47.970 nodeos    snapshot_scheduler.cpp:45     on_irreversible_bloc ] 3170009 snapshot_finalization_exception: Snapshot Finalization Exception
Snapshot block 189 was forked out of the chain. ID: 000000bdc5b795aee58a5bcd281c44fe58c91f2a905eaafc6df756af63b6be66
    nodeos  pending_snapshot.hpp:59 finalize
info  2025-05-22T15:56:47.970 nodeos    pending_snapshot.hpp:67       finalize             ] Snapshot created at block 189 available at /home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_snapshot_forked_test83768/node_01/snapshots/snapshot-000000bdf1cb0972dcf8164828df59f1b320d239d2ac9faaad33526caf7bdad9.bin
debug 2025-05-22T15:56:47.970 http-0    beast_http_session.hpp:481    send_response        ] Response: localhost:8889 HTTP/1.1 201 Created  Connection: close  Server: nodeos/v2.0.0-dev  Content-Type: application/json  Content-Length: 358    {"head_block_id":"000000bdf1cb0972dcf8164828df59f1b320d239d2ac9faaad33526caf7bdad9","head_block_num":189,"head_block_time":"2025-05-22T15:56:08.000","version":8,"snapshot_name":"/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_snapshot_forked_test83768/node_01/snapshots/snapshot-000000bdf1cb0972dcf8164828df59f1b320d239d2ac9faaad33526caf7bdad9.bin"}
```

Resolves #1489 