### PR TITLE
[1.2.0-rc3 -> main] P2P: agent-name

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4317,7 +4317,7 @@ namespace eosio {
            "   myprod,myhostname.com:9876,198.51.100.1\n"
            "   myprod,myhostname2.com:9876,[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"
            )
-         ( "agent-name", bpo::value<string>()->default_value("Vault Agent"), "The name supplied to identify this node amongst the peers.")
+         ( "agent-name", bpo::value<string>()->default_value("Spring Agent"), "The name supplied to identify this node amongst the peers.")
          ( "allowed-connection", bpo::value<vector<string>>()->multitoken()->default_value({"any"}, "any"), "Can be 'any' or 'producers' or 'specified' or 'none'. If 'specified', peer-key must be specified at least once. If only 'producers', peer-key is not required. 'producers' and 'specified' may be combined.")
          ( "peer-key", bpo::value<vector<string>>()->composing()->multitoken(), "Optional public key of peer allowed to connect.  May be used multiple times.")
          ( "peer-private-key", bpo::value<vector<string>>()->composing()->multitoken(),


### PR DESCRIPTION
Change default `agent-name` to `Spring Agent".

Related to #1537

Merges `release/1.2` into `main` including #1551 
