### PR TITLE
SC: Revert SHiP Support for call_trace

### DIFF
--- a/libraries/state_history/abi.cpp
+++ b/libraries/state_history/abi.cpp
@@ -137,22 +137,6 @@ extern const char* const state_history_plugin_abi = R"({
             ]
         },
         {
-            "name": "call_trace_v0", "fields": [
-                { "name": "call_ordinal", "type": "varuint32" },
-                { "name": "sender_ordinal", "type": "varuint32" },
-                { "name": "receiver", "type": "name" },
-                { "name": "read_only", "type": "bool" },
-                { "name": "data", "type": "bytes" },
-                { "name": "elapsed", "type": "int64" },
-                { "name": "console", "type": "string" },
-                { "name": "console_markers", "type": "varuint32[]" },
-                { "name": "except", "type": "string?" },
-                { "name": "error_code", "type": "uint64?" },
-                { "name": "error_id", "type": "int64?" },
-                { "name": "return_value", "type": "bytes" }
-            ]
-        },
-        {
             "name": "action_trace_v0", "fields": [
                 { "name": "action_ordinal", "type": "varuint32" },
                 { "name": "creator_action_ordinal", "type": "varuint32" },
@@ -181,24 +165,6 @@ extern const char* const state_history_plugin_abi = R"({
                 { "name": "except", "type": "string?" },
                 { "name": "error_code", "type": "uint64?" },
                 { "name": "return_value", "type": "bytes"}
-            ]
-        },
-        {
-            "name": "action_trace_v2", "fields": [
-                { "name": "action_ordinal", "type": "varuint32" },
-                { "name": "creator_action_ordinal", "type": "varuint32" },
-                { "name": "receipt", "type": "action_receipt?" },
-                { "name": "receiver", "type": "name" },
-                { "name": "act", "type": "action" },
-                { "name": "context_free", "type": "bool" },
-                { "name": "elapsed", "type": "int64" },
-                { "name": "console", "type": "string" },
-                { "name": "account_ram_deltas", "type": "account_delta[]" },
-                { "name": "except", "type": "string?" },
-                { "name": "error_code", "type": "uint64?" },
-                { "name": "return_value", "type": "bytes"},
-                { "name": "call_traces", "type": "call_trace[]"},
-                { "name": "console_markers", "type": "varuint32[]"}
             ]
         },
         {
@@ -743,8 +709,7 @@ extern const char* const state_history_plugin_abi = R"({
         { "name": "result", "types": ["get_status_result_v0", "get_blocks_result_v0", "get_blocks_result_v1", "get_status_result_v1"] },
 
         { "name": "action_receipt", "types": ["action_receipt_v0"] },
-        { "name": "call_trace", "types": ["call_trace_v0"] },
-        { "name": "action_trace", "types": ["action_trace_v0", "action_trace_v1", "action_trace_v2"] },
+        { "name": "action_trace", "types": ["action_trace_v0", "action_trace_v1"] },
         { "name": "partial_transaction", "types": ["partial_transaction_v0"] },
         { "name": "transaction_trace", "types": ["transaction_trace_v0"] },
         { "name": "transaction_variant", "types": ["transaction_id", "packed_transaction"] },

--- a/libraries/state_history/include/eosio/state_history/serialization.hpp
+++ b/libraries/state_history/include/eosio/state_history/serialization.hpp
@@ -578,6 +578,13 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper_stat
    return ds;
 }
 
+template <typename ST>
+datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper_stateless<eosio::chain::account_delta>& obj) {
+   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.account.to_uint64_t()));
+   fc::raw::pack(ds, as_type<int64_t>(obj.obj.delta));
+   return ds;
+}
+
 inline std::optional<uint64_t> cap_error_code(const std::optional<uint64_t>& error_code) {
    std::optional<uint64_t> result;
 
@@ -596,47 +603,9 @@ inline std::optional<uint64_t> cap_error_code(const std::optional<uint64_t>& err
 }
 
 template <typename ST>
-datastream<ST>& operator<<(datastream<ST>& ds, const history_context_wrapper_stateless<bool, eosio::chain::call_trace>& obj) {
-   bool debug_mode = obj.context;
-   fc::raw::pack(ds, fc::unsigned_int(0));
-   fc::raw::pack(ds, as_type<fc::unsigned_int>(obj.obj.call_ordinal));
-   fc::raw::pack(ds, as_type<fc::unsigned_int>(obj.obj.sender_ordinal));
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.receiver.to_uint64_t()));
-   fc::raw::pack(ds, as_type<bool>(obj.obj.read_only));
-   fc::raw::pack(ds, as_type<eosio::chain::bytes>(obj.obj.data));
-   fc::raw::pack(ds, as_type<int64_t>(debug_mode ? obj.obj.elapsed.count() : 0));
-   if (debug_mode) {
-      fc::raw::pack(ds, as_type<std::string>(obj.obj.console));
-      fc::raw::pack(ds, as_type<std::vector<fc::unsigned_int>>(obj.obj.console_markers));
-   } else {
-      fc::raw::pack(ds, as_type<std::string>({}));
-      fc::raw::pack(ds, as_type<std::vector<fc::unsigned_int>>({}));
-   }
-   std::optional<std::string> e;
-   if (obj.obj.except) {
-      if (debug_mode)
-         e = obj.obj.except->to_string();
-      else
-         e = "Y";
-   }
-   fc::raw::pack(ds, as_type<std::optional<std::string>>(e));
-   fc::raw::pack(ds, as_type<std::optional<uint64_t>>(debug_mode ? obj.obj.error_code : cap_error_code(obj.obj.error_code)));
-   fc::raw::pack(ds, as_type<std::optional<int64_t>>( obj.obj.error_id ));
-   fc::raw::pack(ds, as_type<eosio::chain::bytes>(obj.obj.return_value));
-   return ds;
-}
-
-template <typename ST>
-datastream<ST>& operator<<(datastream<ST>& ds, const history_serial_wrapper_stateless<eosio::chain::account_delta>& obj) {
-   fc::raw::pack(ds, as_type<uint64_t>(obj.obj.account.to_uint64_t()));
-   fc::raw::pack(ds, as_type<int64_t>(obj.obj.delta));
-   return ds;
-}
-
-template <typename ST>
 datastream<ST>& operator<<(datastream<ST>& ds, const history_context_wrapper_stateless<bool, eosio::chain::action_trace>& obj) {
    bool debug_mode = obj.context;
-   fc::raw::pack(ds, fc::unsigned_int(2));
+   fc::raw::pack(ds, fc::unsigned_int(1));
    fc::raw::pack(ds, as_type<fc::unsigned_int>(obj.obj.action_ordinal));
    fc::raw::pack(ds, as_type<fc::unsigned_int>(obj.obj.creator_action_ordinal));
    fc::raw::pack(ds, bool(obj.obj.receipt));
@@ -663,12 +632,7 @@ datastream<ST>& operator<<(datastream<ST>& ds, const history_context_wrapper_sta
    fc::raw::pack(ds, as_type<std::optional<std::string>>(e));
    fc::raw::pack(ds, as_type<std::optional<uint64_t>>(debug_mode ? obj.obj.error_code : cap_error_code(obj.obj.error_code)));
    fc::raw::pack(ds, as_type<eosio::chain::bytes>(obj.obj.return_value));
-   history_context_serialize_container(ds, debug_mode, as_type<std::vector<eosio::chain::call_trace>>(obj.obj.call_traces));
-   if (debug_mode) {
-      fc::raw::pack(ds, as_type<std::vector<fc::unsigned_int>>(obj.obj.console_markers));
-   } else {
-      fc::raw::pack(ds, as_type<std::vector<fc::unsigned_int>>({}));
-   }
+
    return ds;
 }
 


### PR DESCRIPTION
The team has decided not to support `call_trace` in `SHiP`.

Remove the SHiP related changes introduced by https://github.com/AntelopeIO/spring/pull/1340

Resolves https://github.com/AntelopeIO/spring/issues/1542