### PR TITLE
[1.2.0-rc3] Test: Wait for pause to take affect

### DIFF
--- a/tests/disaster_recovery_3.py
+++ b/tests/disaster_recovery_3.py
@@ -83,7 +83,7 @@ try:
     assert node0.waitForProducer("defproducera"), "Node 0 did not produce"
     for node in [node0, node1]:
         node.processUrllibRequest("producer", "pause", exitOnError=True)
-    time.sleep(0.5)
+    node0.waitForLibNotToAdvance()
 
     currentLIB = node0.getIrreversibleBlockNum()
     n_LIB = currentLIB + 1


### PR DESCRIPTION
Instead of just sleeping, wait for the pause to take affect and LIB to stop.

Resolves #1564 