### PR TITLE
Test: Setup tests to have non-consecutive block producers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_signal_throw_test.py ${CMAKE_C
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_startup_catchup.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_startup_catchup.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_snapshot_diff_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_snapshot_diff_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_snapshot_forked_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_snapshot_forked_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bridge_consecutive_shape.json ${CMAKE_CURRENT_BINARY_DIR}/bridge_consecutive_shape.json COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_forked_chain_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_forked_chain_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_short_fork_take_over_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_short_fork_take_over_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_run_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_run_test.py COPYONLY)

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -175,7 +175,8 @@ class Cluster(object):
         unstartedNodes: non-producer nodes that are configured into the launch, but not started.  Should be included in totalNodes.
         totalNodes: producer + non-producer nodes + unstarted non-producer nodes count
         prodCount: producers per producer node count
-        topo: cluster topology (as defined by launcher, and "bridge" shape that is specific to this launch method)
+        topo: cluster topology (as defined by launcher, and "bridge" shape that is specific to this launch method).
+              bridge configures producers non-consecutive in nodes.
         delay: delay between individual nodes launch (as defined by launcher)
           delay 0 exposes a bootstrap bug where producer handover may have a large gap confusing nodes and bringing system to a halt.
         onlyBios: When true, only loads the bios contract (and not more full bootstrapping).

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -375,17 +375,9 @@ class Cluster(object):
             biosNodeObject=None
             bridgeNodes={}
             producerNodes={}
-            producers=[]
-            for append in range(ord('a'),ord('a')+numProducers):
-                name="defproducer" + chr(append)
-                producers.append(name)
-
-            # first group starts at 0
-            secondGroupStart=int((numProducers+1)/2)
             producerGroup1=[]
             producerGroup2=[]
 
-            Utils.Print("producers=%s" % (producers))
             shapeFileNodeMap = {}
             def getNodeNum(nodeName):
                 p=re.compile(r'^testnet_(\d+)$')
@@ -412,31 +404,17 @@ class Cluster(object):
                 if (numNodeProducers==0):
                     bridgeNodes[nodeName]=shapeFileNode
                 else:
+                    # producer node, add it to our producerNodes map
                     producerNodes[nodeName]=shapeFileNode
-                    group=None
-                    # go through all the producers for this node and determine which group on the bridged network they are in
-                    for shapeFileNodeProd in shapeFileNodeProds:
-                        producerIndex=0
-                        for prod in producers:
-                            if prod==shapeFileNodeProd:
-                                break
-                            producerIndex+=1
 
-                        prodGroup=None
-                        if producerIndex<secondGroupStart:
-                            prodGroup=1
-                            if group is None:
-                                group=prodGroup
-                                producerGroup1.append(nodeName)
-                                Utils.Print("Group1 grouping producerIndex=%s, secondGroupStart=%s" % (producerIndex,secondGroupStart))
-                        else:
-                            prodGroup=2
-                            if group is None:
-                                group=prodGroup
-                                producerGroup2.append(nodeName)
-                                Utils.Print("Group2 grouping producerIndex=%s, secondGroupStart=%s" % (producerIndex,secondGroupStart))
-                        if group!=prodGroup:
-                            Utils.errorExit("Node configuration not consistent with \"bridge\" topology. Node %s has producers that fall into both halves of the bridged network" % (nodeName))
+                    # assign producer to either group1 or group2
+                    if len(producerGroup1) <= len(producerGroup2):
+                        producerGroup1.append(nodeName)
+                    else:
+                        producerGroup2.append(nodeName)
+
+            Utils.Print(f"Producer Group 1: {producerGroup1}")
+            Utils.Print(f"Producer Group 2: {producerGroup2}")
 
             for _,bridgeNode in bridgeNodes.items():
                 bridgeNode["peers"]=[]

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -260,7 +260,7 @@ class Node(Transactions):
         return found
 
     def waitForProducer(self, producer, timeout=None, exitOnError=False):
-        self.waitForAnyProducer(producer, timeout, exitOnError)
+        return self.waitForAnyProducer(producer, timeout, exitOnError)
 
     # returns True if the node has missed next scheduled production round.
     def missedNextProductionRound(self):

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -256,7 +256,7 @@ class Node(Transactions):
             return self.getInfo()["head_block_producer"] in producers
         found = Utils.waitForBool(isProducerInList, timeout)
         assert not exitOnError or found, \
-            f"Waited for {time.perf_counter()-start} sec but never found producer: {producers}. Started with {initialProducer} and ended with {self.getInfo()['head_block_producer']}"
+            f"Waited for {time.perf_counter()-start} sec but never found a producer in: {producers}. Started with {initialProducer} and ended with {self.getInfo()['head_block_producer']}"
         return found
 
     def waitForProducer(self, producer, timeout=None, exitOnError=False):

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -244,8 +244,6 @@ class Node(Transactions):
         return True
 
     def waitForAnyProducer(self, producers, timeout=None, exitOnError=False):
-        if not isinstance(producers, list):
-            producers = [producers] # ensure producers is always a list
         if timeout is None:
             # default to the typical configuration of 21 producers, each producing 12 blocks in a row (every 1/2 second)
             timeout = 21 * 6
@@ -260,7 +258,7 @@ class Node(Transactions):
         return found
 
     def waitForProducer(self, producer, timeout=None, exitOnError=False):
-        return self.waitForAnyProducer(producer, timeout, exitOnError)
+        return self.waitForAnyProducer([producer], timeout, exitOnError)
 
     # returns True if the node has missed next scheduled production round.
     def missedNextProductionRound(self):

--- a/tests/TestHarness/launcher.py
+++ b/tests/TestHarness/launcher.py
@@ -283,9 +283,7 @@ class cluster_generator:
         non_bios = self.args.pnodes - 1
 
         # generate all defproducer names upfront
-        def_producers_names = []
-        for i in range(self.args.producers):
-            def_producers_names.append(producer_name(i))
+        def_producers_names = [producer_name(i) for i in range(self.args.producers)]
 
         node_count = 0
         to_not_start_node = self.args.total_nodes - self.args.unstarted_nodes - 1

--- a/tests/TestHarness/launcher.py
+++ b/tests/TestHarness/launcher.py
@@ -287,7 +287,7 @@ class cluster_generator:
         for i in range(self.args.producers):
             def_producers_names.append(producer_name(i))
 
-        i = 0
+        node_count = 0
         to_not_start_node = self.args.total_nodes - self.args.unstarted_nodes - 1
         accounts = createAccountKeys(len(self.network.nodes.values()))
         for account, node in zip(accounts, self.network.nodes.values()):
@@ -301,13 +301,13 @@ class cluster_generator:
                 node.producers.append('eosio')
             else:
                 node.keys.append(KeyStrings(account.ownerPublicKey, account.ownerPrivateKey, account.blsFinalizerPublicKey, account.blsFinalizerPrivateKey, account.blsFinalizerPOP))
-                if i < non_bios:
+                if node_count < non_bios:
                     # calculate number of defproducers this producer node gets
                     count = self.args.producers // non_bios
-                    if i < (self.args.producers % non_bios):
+                    if node_count < (self.args.producers % non_bios):
                         count += 1
                     # assign non-consecutive producers
-                    producer_idx_for_node = i
+                    producer_idx_for_node = node_count
                     producers_assigned_to_node = 0
                     while producers_assigned_to_node < count:
                         if producer_idx_for_node < len(def_producers_names):
@@ -320,9 +320,9 @@ class cluster_generator:
                     for j in range(0, self.args.shared_producers):
                         prodname = producer_name(j, True)
                         node.producers.append(prodname)
-                node.dont_start = i >= to_not_start_node
+                node.dont_start = node_count >= to_not_start_node
             if not is_bios:
-                i += 1
+                node_count += 1
 
     def generate(self):
         {

--- a/tests/TestHarness/launcher.py
+++ b/tests/TestHarness/launcher.py
@@ -281,10 +281,13 @@ class cluster_generator:
         if self.args.pnodes < 2:
             raise RuntimeError(f'Unable to allocate producers due to insufficient pnodes = {self.args.pnodes}')
         non_bios = self.args.pnodes - 1
-        per_node = int(self.args.producers / non_bios)
-        extra = self.args.producers % non_bios
+
+        # generate all defproducer names upfront
+        def_producers_names = []
+        for i in range(self.args.producers):
+            def_producers_names.append(producer_name(i))
+
         i = 0
-        producer_number = 0
         to_not_start_node = self.args.total_nodes - self.args.unstarted_nodes - 1
         accounts = createAccountKeys(len(self.network.nodes.values()))
         for account, node in zip(accounts, self.network.nodes.values()):
@@ -294,20 +297,26 @@ class cluster_generator:
                                             '5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3',
                                             'PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q',
                                             'PVT_BLS_edLoUiiP2FfMem4la3Ek8zxIDjDjOFylRw9ymdeOVCC0CuXN',
-                                             'SIG_BLS_L5MXQpJTX_v7cXDy4ML4fWVw_69MKuG5qTq7dD_Zb3Yuw1RbMXBOYXDoAbFF37gFmHudY3kkqXtETLs9nMTjTaTwgdDZWpFy1_csEIZT-xIOQttc76bpZhI67902g2sIDf6JSf9JtbhdTUc_HNbL7H2ZR2bqGS3YPbV5z7x24AR2vwTcJogMqLyy6H5nKQAEwIvXcL15gbs2EkH_ch-IZDdn4F0zUYifpOo-ovXY_CX_yL2rKIx_2a9IHg0pPrMOdfHs9A'))
+                                            'SIG_BLS_L5MXQpJTX_v7cXDy4ML4fWVw_69MKuG5qTq7dD_Zb3Yuw1RbMXBOYXDoAbFF37gFmHudY3kkqXtETLs9nMTjTaTwgdDZWpFy1_csEIZT-xIOQttc76bpZhI67902g2sIDf6JSf9JtbhdTUc_HNbL7H2ZR2bqGS3YPbV5z7x24AR2vwTcJogMqLyy6H5nKQAEwIvXcL15gbs2EkH_ch-IZDdn4F0zUYifpOo-ovXY_CX_yL2rKIx_2a9IHg0pPrMOdfHs9A'))
                 node.producers.append('eosio')
             else:
                 node.keys.append(KeyStrings(account.ownerPublicKey, account.ownerPrivateKey, account.blsFinalizerPublicKey, account.blsFinalizerPrivateKey, account.blsFinalizerPOP))
                 if i < non_bios:
-                    count = per_node
-                    if extra:
+                    # calculate number of defproducers this producer node gets
+                    count = self.args.producers // non_bios
+                    if i < (self.args.producers % non_bios):
                         count += 1
-                        extra -= 1
-                    while count > 0:
-                        prodname = producer_name(producer_number)
-                        node.producers.append(prodname)
-                        producer_number += 1
-                        count -= 1
+                    # assign non-consecutive producers
+                    producer_idx_for_node = i
+                    producers_assigned_to_node = 0
+                    while producers_assigned_to_node < count:
+                        if producer_idx_for_node < len(def_producers_names):
+                            node.producers.append(def_producers_names[producer_idx_for_node])
+                        else:
+                            break # ran out of available producers
+                        # increment index by non_bios to pick the next producer in the alternating sequence
+                        producer_idx_for_node += non_bios
+                        producers_assigned_to_node += 1
                     for j in range(0, self.args.shared_producers):
                         prodname = producer_name(j, True)
                         node.producers.append(prodname)

--- a/tests/bridge_consecutive_shape.json
+++ b/tests/bridge_consecutive_shape.json
@@ -1,4 +1,4 @@
-i{
+{
   "name": "testnet_", 
   "nodes": {
     "bios": {
@@ -20,15 +20,12 @@ i{
         "eosio"
       ], 
       "dont_start": false, 
-      "config_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_bios", 
-      "data_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_bios", 
-      "p2p_port": 9776, 
+      "p2p_port": 9776,
       "http_port": 8788, 
       "host_name": "localhost", 
       "public_name": "localhost", 
-      "listen_addr": "0.0.0.0", 
-      "_dot_label": "localhost:9776\nbios\nprod=eosio"
-    }, 
+      "listen_addr": "0.0.0.0"
+    },
     "testnet_00": {
       "index": 0, 
       "name": "testnet_00", 
@@ -58,15 +55,12 @@ i{
         "defproducerk"
       ], 
       "dont_start": false, 
-      "config_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_00", 
-      "data_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_00", 
-      "p2p_port": 9876, 
+      "p2p_port": 9876,
       "http_port": 8888, 
       "host_name": "localhost", 
       "public_name": "localhost", 
-      "listen_addr": "0.0.0.0", 
-      "_dot_label": "localhost:9876\ntestnet_00\nprod=defproducera\ndefproducerc\ndefproducere\ndefproducerg\ndefproduceri\ndefproducerk\ndefproducerm\ndefproducero\ndefproducerq\ndefproducers\ndefproduceru"
-    }, 
+      "listen_addr": "0.0.0.0"
+    },
     "testnet_01": {
       "index": 1, 
       "name": "testnet_01", 
@@ -95,15 +89,12 @@ i{
         "defproduceru"
       ], 
       "dont_start": false, 
-      "config_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_01", 
-      "data_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_01", 
-      "p2p_port": 9877, 
+      "p2p_port": 9877,
       "http_port": 8889, 
       "host_name": "localhost", 
       "public_name": "localhost", 
-      "listen_addr": "0.0.0.0", 
-      "_dot_label": "localhost:9877\ntestnet_01\nprod=defproducerb\ndefproducerd\ndefproducerf\ndefproducerh\ndefproducerj\ndefproducerl\ndefproducern\ndefproducerp\ndefproducerr\ndefproducert"
-    }, 
+      "listen_addr": "0.0.0.0"
+    },
     "testnet_02": {
       "index": 2, 
       "name": "testnet_02", 
@@ -119,14 +110,11 @@ i{
       "peers": [], 
       "producers": [], 
       "dont_start": false, 
-      "config_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_02", 
-      "data_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_02", 
-      "p2p_port": 9878, 
+      "p2p_port": 9878,
       "http_port": 8890, 
       "host_name": "localhost", 
       "public_name": "localhost", 
-      "listen_addr": "0.0.0.0", 
-      "_dot_label": "localhost:9878\ntestnet_02\nprod=<none>"
+      "listen_addr": "0.0.0.0"
     }
   }
 }

--- a/tests/bridge_consecutive_shape.json
+++ b/tests/bridge_consecutive_shape.json
@@ -14,7 +14,9 @@
         }
       ], 
       "peers": [
-        "testnet_00"
+        "testnet_00",
+        "testnet_01",
+        "testnet_02"
       ], 
       "producers": [
         "eosio"
@@ -39,7 +41,7 @@
         }
       ], 
       "peers": [
-        "testnet_01"
+        "testnet_02"
       ], 
       "producers": [
         "defproducera", 
@@ -107,7 +109,10 @@
           "blspop": "SIG_BLS_s0wR5U-ZXPNOqJDm_TjJ-6bEAwx2cAGTuTlQDPx6Rx1_dxc7Km0RqzV0_fHx1hgSzZ64Q15AlNkjZnexGWjQDyr9COxA5gfxpYvloqgg3Y3b35plIK-DMj8FgbXyoHgJulkc4sKjz-GGvcAziXQsPk9gKUnOMb1SXekCw2V_J28Iec1CapRAmWh0WhAyepQSoBEglFR4UuaaGU2YeD2gTFa2bDZLgw88sOtLd5ElCW0pAvRB8rIYPFiRKNcPBCAXxD4unw"
         }
       ], 
-      "peers": [], 
+      "peers": [
+        "testnet_00",
+        "testnet_01"
+      ],
       "producers": [], 
       "dont_start": false, 
       "p2p_port": 9878,

--- a/tests/bridge_consecutive_shape.json
+++ b/tests/bridge_consecutive_shape.json
@@ -1,0 +1,132 @@
+i{
+  "name": "testnet_", 
+  "nodes": {
+    "bios": {
+      "index": -100, 
+      "name": "bios", 
+      "keys": [
+        {
+          "pubkey": "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV", 
+          "privkey": "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3", 
+          "blspubkey": "PUB_BLS_qVbh4IjYZpRGo8U_0spBUM-u-r_G0fMo4MzLZRsKWmm5uyeQTp74YFaMN9IDWPoVVT5rj_Tw1gvps6K9_OZ6sabkJJzug3uGfjA6qiaLbLh5Fnafwv-nVgzzzBlU2kwRrcHc8Q", 
+          "blsprivkey": "PVT_BLS_edLoUiiP2FfMem4la3Ek8zxIDjDjOFylRw9ymdeOVCC0CuXN", 
+          "blspop": "SIG_BLS_L5MXQpJTX_v7cXDy4ML4fWVw_69MKuG5qTq7dD_Zb3Yuw1RbMXBOYXDoAbFF37gFmHudY3kkqXtETLs9nMTjTaTwgdDZWpFy1_csEIZT-xIOQttc76bpZhI67902g2sIDf6JSf9JtbhdTUc_HNbL7H2ZR2bqGS3YPbV5z7x24AR2vwTcJogMqLyy6H5nKQAEwIvXcL15gbs2EkH_ch-IZDdn4F0zUYifpOo-ovXY_CX_yL2rKIx_2a9IHg0pPrMOdfHs9A"
+        }
+      ], 
+      "peers": [
+        "testnet_00"
+      ], 
+      "producers": [
+        "eosio"
+      ], 
+      "dont_start": false, 
+      "config_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_bios", 
+      "data_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_bios", 
+      "p2p_port": 9776, 
+      "http_port": 8788, 
+      "host_name": "localhost", 
+      "public_name": "localhost", 
+      "listen_addr": "0.0.0.0", 
+      "_dot_label": "localhost:9776\nbios\nprod=eosio"
+    }, 
+    "testnet_00": {
+      "index": 0, 
+      "name": "testnet_00", 
+      "keys": [
+        {
+          "pubkey": "EOS58bRG15HnYQMH9yFfVCPiXyhgQCpdMpoi5aT3CSxX6Nuu6HUBe", 
+          "privkey": "5JyLErL1RVcNR7q5yMqsUUqHqgHmLAwfkpFuWPkWbvAJKuFQQSx", 
+          "blspubkey": "PUB_BLS_Hkv1BIScaHPyKH52dy7e1bjDwYW8kBQW6N6e59vAWmDZHnY8hlZLkoHyIwdcOesNCPwiP-TSvdk8qgNsR0RGFAoc13FGdQnIBaoLsFIz5qsiNDTfQNbfbbH5KHkSbOcOUGnh0A", 
+          "blsprivkey": "PVT_BLS_j9AZd7cjYlZF_GL96Daz46di2SUnDv7J_6d2bM8IqiHZw6vF", 
+          "blspop": "SIG_BLS_XsP4fszr59XIvAb71apSyid-jQUaeP-UlLTC2x79UEeTxce9HIXfoV5h-ocrsi8QsigtkPhzI83finWr0koi7R6MJUFZpuiPN2gpJy9bG2c4GSRQCrGEqaKgGjRnkTQXkqwoVMuOkw2rYwVc3sMGylK1mn_8Wy2A7MXxaJDBWKwZ1O_0G5QqcsOyIgTFG4AH8NmMAHW4nW32h_cgN2x8znsyKHIKUwmRAbVt85KTK_JQmN_bTWlfMsCVq4MoMGgPzk7mgA"
+        }
+      ], 
+      "peers": [
+        "testnet_01"
+      ], 
+      "producers": [
+        "defproducera", 
+        "defproducerb", 
+        "defproducerc", 
+        "defproducerd", 
+        "defproducere", 
+        "defproducerf", 
+        "defproducerg", 
+        "defproducerh", 
+        "defproduceri", 
+        "defproducerj", 
+        "defproducerk"
+      ], 
+      "dont_start": false, 
+      "config_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_00", 
+      "data_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_00", 
+      "p2p_port": 9876, 
+      "http_port": 8888, 
+      "host_name": "localhost", 
+      "public_name": "localhost", 
+      "listen_addr": "0.0.0.0", 
+      "_dot_label": "localhost:9876\ntestnet_00\nprod=defproducera\ndefproducerc\ndefproducere\ndefproducerg\ndefproduceri\ndefproducerk\ndefproducerm\ndefproducero\ndefproducerq\ndefproducers\ndefproduceru"
+    }, 
+    "testnet_01": {
+      "index": 1, 
+      "name": "testnet_01", 
+      "keys": [
+        {
+          "pubkey": "EOS8SP4SNN1K99xSzSFdALE2EvQKZRVPs79uDWFHbHzZ1D1pb91gm", 
+          "privkey": "5KHGSCcqFbqcMocuCYtVXSTneaTxYjSXKEtt1jPkRF5jmNfFzbN", 
+          "blspubkey": "PUB_BLS_IYqOgcnPXr9-Mv3-gf6Sze3JLFs1eCe1OTY1ft0kZ1HR2divFoQo4aVZz1Fs_zAFsi0Nyi0_Q2XeQxOC56dxe9SJXl2EyKNayuL4Y529R64sN8n631dTsz108wvKqjMMikUB_Q", 
+          "blsprivkey": "PVT_BLS_QVqINeGe9I-iza3nds96NjBmCV3mFzT2oQrWt68ftnKSfu9p", 
+          "blspop": "SIG_BLS_KXMdN7HLS6bh--xIGdGxvvY_i882ehusrAcFJaXxh0XibKoGOetOYNZ-rnpNNTAPcDbr72oOoid-MEOzsphPEsr23_LXG-D8V8-_PDNWktoH2EWzZ0VxmkGc0k4A-HUUAJxhsO35koFKA7JeuHF7EPwlO1quzXuxBHYVoclQQ2g3pXxcIhVx1KF29d4HVmwStfyftNRdai7zyHv8tmlb1O_A-zUNac-q63H8uDpg58MDN8eOzVX2DzDlCzBr5wgZ2mh-iw"
+        }
+      ], 
+      "peers": [
+        "testnet_02"
+      ], 
+      "producers": [
+        "defproducerl", 
+        "defproducerm", 
+        "defproducern", 
+        "defproducero", 
+        "defproducerp", 
+        "defproducerq", 
+        "defproducerr", 
+        "defproducers", 
+        "defproducert", 
+        "defproduceru"
+      ], 
+      "dont_start": false, 
+      "config_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_01", 
+      "data_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_01", 
+      "p2p_port": 9877, 
+      "http_port": 8889, 
+      "host_name": "localhost", 
+      "public_name": "localhost", 
+      "listen_addr": "0.0.0.0", 
+      "_dot_label": "localhost:9877\ntestnet_01\nprod=defproducerb\ndefproducerd\ndefproducerf\ndefproducerh\ndefproducerj\ndefproducerl\ndefproducern\ndefproducerp\ndefproducerr\ndefproducert"
+    }, 
+    "testnet_02": {
+      "index": 2, 
+      "name": "testnet_02", 
+      "keys": [
+        {
+          "pubkey": "EOS5Su6SRtZX7apichujG5m8Djnw1M9a5bwG7DQR1P7t5gpFEF1Kc", 
+          "privkey": "5KASFkMz5KTaPJQ663QvoaZRieyhKfnbCUxyGc6tLDHzY4WAVUr", 
+          "blspubkey": "PUB_BLS_DLasUMfL844jMyF3bYQ7X2w8annFsWlxtNcVcxdB6Xm2gBQFxZf0QWz6mQo5YCMDbZFIAAblGSe9o0gRWwfOYr2rwqP9SxPDmBc1c7gzvMNqmZD1a7TMjqPvvSS7PL8KMVr7cg", 
+          "blsprivkey": "PVT_BLS_lgUyhhqs0-8v5_6QKRzlGSkwb3_81KwoLyfcHLj1PDUD03xG", 
+          "blspop": "SIG_BLS_s0wR5U-ZXPNOqJDm_TjJ-6bEAwx2cAGTuTlQDPx6Rx1_dxc7Km0RqzV0_fHx1hgSzZ64Q15AlNkjZnexGWjQDyr9COxA5gfxpYvloqgg3Y3b35plIK-DMj8FgbXyoHgJulkc4sKjz-GGvcAziXQsPk9gKUnOMb1SXekCw2V_J28Iec1CapRAmWh0WhAyepQSoBEglFR4UuaaGU2YeD2gTFa2bDZLgw88sOtLd5ElCW0pAvRB8rIYPFiRKNcPBCAXxD4unw"
+        }
+      ], 
+      "peers": [], 
+      "producers": [], 
+      "dont_start": false, 
+      "config_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_02", 
+      "data_dir_name": "/home/heifner/ext/leap/cmake-build-debug/TestLogs/nodeos_forked_chain_test182472/node_02", 
+      "p2p_port": 9878, 
+      "http_port": 8890, 
+      "host_name": "localhost", 
+      "public_name": "localhost", 
+      "listen_addr": "0.0.0.0", 
+      "_dot_label": "localhost:9878\ntestnet_02\nprod=<none>"
+    }
+  }
+}

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -164,8 +164,8 @@ try:
 
     # ***   setup topogrophy   ***
 
-    # "bridge" bridge_consecutive_shape.json shape connects defproducera through defproducerk (in node0) to each other
-    # and defproducerl through defproduceru (in node01)
+    # bridge_consecutive_shape.json shape connects defproducera through defproducerk (consecutive in node0) to each other
+    # and defproducerl through defproduceru (consecutive in node01)
     # and the only connection between those 2 groups is through the bridge node
 
     if cluster.launch(prodCount=prodCount, topo="./tests/bridge_consecutive_shape.json", pnodes=totalProducerNodes,

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -164,10 +164,11 @@ try:
 
     # ***   setup topogrophy   ***
 
-    # "bridge" shape connects defprocera through defproducerk (in node0) to each other and defproducerl through defproduceru (in node01)
+    # "bridge" bridge_consecutive_shape.json shape connects defproducera through defproducerk (in node0) to each other
+    # and defproducerl through defproduceru (in node01)
     # and the only connection between those 2 groups is through the bridge node
 
-    if cluster.launch(prodCount=prodCount, topo="bridge", pnodes=totalProducerNodes,
+    if cluster.launch(prodCount=prodCount, topo="./tests/bridge_consecutive_shape.json", pnodes=totalProducerNodes,
                       totalNodes=totalNodes, totalProducers=totalProducers, activateIF=activateIF, biosFinalizer=False,
                       specificExtraNodeosArgs=specificExtraNodeosArgs, extraNodeosArgs=extraNodeosArgs) is False:
         Utils.cmdError("launcher")

--- a/tests/nodeos_short_fork_take_over_test.py
+++ b/tests/nodeos_short_fork_take_over_test.py
@@ -137,7 +137,7 @@ try:
 
     # ***   setup topogrophy   ***
 
-    # "bridge" shape connects defprocera through defproducerk (in node0) to each other and defproducerl through defproduceru (in node01)
+    # "bridge" shape distributes defproducera,defproducerc in node0 and defproducerb in node1
     # and the only connection between those 2 groups is through the bridge node
     if cluster.launch(prodCount=2, topo="bridge", pnodes=totalProducerNodes,
                       totalNodes=totalNodes, totalProducers=totalProducers, activateIF=activateIF,
@@ -178,28 +178,11 @@ try:
     cluster.biosNode.kill(signal.SIGTERM)
 
     Utils.Print("catching defproducera")
-    tries = 120
+    node.waitForProducer("defproducera", timeout=60)
+    Utils.Print("catching the start of defproducerc")
+    node.waitForProducer("defproducerc", timeout=60)
+
     blockNum = node.getHeadBlockNum()
-    blockProducer=node.getBlockProducerByNum(blockNum)
-    while blockProducer != "defproducera" and tries > 0:
-        blockNum+=1
-        blockProducer=node.getBlockProducerByNum(blockNum)
-        tries = tries - 1
-
-    if tries == 0:
-        Utils.errorExit("failed to catch a block produced by defproducera")
-
-    Utils.Print("catching the start of defproducerb")
-    tries = 30
-    while blockProducer != "defproducerb" and tries > 0:
-        blockNum+=1
-        blockProducer=node.getBlockProducerByNum(blockNum)
-        tries = tries - 1
-
-    if tries == 0:
-        Utils.errorExit("failed to catch a block produced by defproducerb")
-
-    blockNum+=1
     blockProducer=node.getBlockProducerByNum(blockNum)
     blockProducer1=node1.getBlockProducerByNum(blockNum)
     Utils.Print("block number %d is producer by %s in node0" % (blockNum, blockProducer))
@@ -210,9 +193,9 @@ try:
     # block number to start expecting node killed after
     preKillBlockNum=nonProdNode.getBlockNum()
     preKillBlockProducer=nonProdNode.getBlockProducerByNum(preKillBlockNum)
-    # kill before defproducerc
-    killAtProducer="defproducerb"
-    inRowCountPerProducer=10 # kill before c can produce
+    # kill before defproducerb
+    killAtProducer="defproducera"
+    inRowCountPerProducer=10 # kill before b can produce
     nonProdNode.killNodeOnProducer(producer=killAtProducer, whereInSequence=(inRowCountPerProducer-1))
 
 
@@ -324,7 +307,7 @@ try:
         info=prodNode.getInfo()
         Print("node info: %s" % (info))
 
-    Print("killing node1(defproducerc) so that bridge node will frist connect to node0 (defproducera, defproducerb)")
+    Print("killing node1(defproducerb) so that bridge node will frist connect to node0 (defproducera, defproducerc)")
     node1.kill(killSignal=15)
     time.sleep(2)
     if node1.verifyAlive():
@@ -334,7 +317,7 @@ try:
     if not nonProdNode.relaunch(None):
         errorExit("Failure - (non-production) node %d should have restarted" % (nonProdNode.nodeNum))
 
-    Print("Relaunch node 1 (defproducerc) and let it connect to brigde node that already synced up with node 0")
+    Print("Relaunch node 1 (defproducerb) and let it connect to brigde node that already synced up with node 0")
     time.sleep(10)
     if not node1.relaunch(chainArg=" --enable-stale-production "):
         errorExit("Failure - (non-production) node 1 should have restarted")
@@ -387,8 +370,8 @@ try:
     Print("Identifying the producers from the saved LIB to the current highest head, from block %d to %d" % (libNumAroundDivergence, endBlockNum))
 
     for blockNum in range(libNumAroundDivergence,endBlockNum):
-        blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum)
-        blockProducer1=prodNodes[1].getBlockProducerByNum(blockNum)
+        blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum, waitForBlock=False)
+        blockProducer1=prodNodes[1].getBlockProducerByNum(blockNum, waitForBlock=False)
         blockProducers0.append({"blockNum":blockNum, "prod":blockProducer0})
         blockProducers1.append({"blockNum":blockNum, "prod":blockProducer1})
 

--- a/tests/prod_preactivation_test.py
+++ b/tests/prod_preactivation_test.py
@@ -141,6 +141,7 @@ try:
     Print("found digest ", digest, " of PREACTIVATE_FEATURE")
 
     node0 = cluster.getNode(0)
+    node1 = cluster.getNode(1)
     contract="eosio.bios"
     contractDir="libraries/testing/contracts/old_versions/v1.7.0-develop-preactivate_feature/%s" % (contract)
     wasmFile="%s.wasm" % (contract)
@@ -155,26 +156,10 @@ try:
 
     secwait = 30
     Print("Wait for node 1 to produce...")
-    node = cluster.getNode(1)
-    while secwait > 0:
-       info = node.getInfo()
-       if info["head_block_producer"] >= "defproducerl" and info["head_block_producer"] <= "defproduceru":
-          break
-       time.sleep(1)
-       secwait = secwait - 1
+    node1.waitForAnyProducer(["defproducerb", "defproducerd", "defproducerf", "defproducerh", "defproducerj", "defproducerl", "defproducern", "defproducerp", "defproducerr", "defproducert"], timeout=secwait)
 
-    secwait = 30
-    Print("Waiting until node 0 start to produce...")
-    node = cluster.getNode(1)
-    while secwait > 0:
-       info = node.getInfo()
-       if info["head_block_producer"] >= "defproducera" and info["head_block_producer"] <= "defproducerk":
-          break
-       time.sleep(1)
-       secwait = secwait - 1
-
-    if secwait <= 0:
-       errorExit("No producer of node 0")
+    Print("Wait for node 0 to produce...")
+    node0.waitForAnyProducer(["defproducera", "defproducerc", "defproducere", "defproducerg", "defproduceri", "defproducerk", "defproducerm", "defproducero", "defproducerq", "defproducers", "defproduceru"], timeout=secwait)
 
     resource = "producer"
     command = "schedule_protocol_feature_activations"
@@ -195,16 +180,7 @@ try:
         errorExit("bios contract not result in expected unresolveable error")
 
     Print("now wait for node 1 produce a block...")
-    secwait = 30 # wait for node 1 produce a block
-    while secwait > 0:
-       info = node.getInfo()
-       if info["head_block_producer"] >= "defproducerl" and info["head_block_producer"] <= "defproduceru":
-          break
-       time.sleep(1)
-       secwait = secwait - 1
-
-    if secwait <= 0:
-       errorExit("No blocks produced by node 1")
+    node1.waitForAnyProducer(["defproducerb", "defproducerd", "defproducerf", "defproducerh", "defproducerj", "defproducerl", "defproducern", "defproducerp", "defproducerr", "defproducert"], timeout=secwait)
 
     time.sleep(0.6)
     retMap = node0.publishContract(cluster.eosioAccount, contractDir, wasmFile, abiFile, waitForTransBlock=True, shouldFail=False)

--- a/tests/transition_to_if.py
+++ b/tests/transition_to_if.py
@@ -16,11 +16,10 @@ Print=Utils.Print
 errorExit=Utils.errorExit
 
 appArgs = AppArgs()
-args=TestHelper.parse_args({"-p","-d","-s","--keep-logs","--dump-error-details","-v","--leave-running","--unshared"},
+args=TestHelper.parse_args({"-p","-d","--keep-logs","--dump-error-details","-v","--leave-running","--unshared"},
                             applicationSpecificArgs=appArgs)
 pnodes=args.p if args.p > 4 else 4
 delay=args.d
-topo=args.s
 debug=args.v
 prod_count = 1 # per node prod count
 total_nodes=pnodes+1
@@ -38,13 +37,13 @@ try:
 
     cluster.setWalletMgr(walletMgr)
 
-    Print(f'producing nodes: {pnodes}, topology: {topo}, delay between nodes launch: {delay} second{"s" if delay != 1 else ""}')
+    Print(f'producing nodes: {pnodes}, delay between nodes launch: {delay} second{"s" if delay != 1 else ""}')
 
     numTrxGenerators=2
     Print("Stand up cluster")
     # For now do not load system contract as it does not support setfinalizer
     specificExtraNodeosArgs = { irreversibleNodeId: "--read-mode irreversible"}
-    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, prodCount=prod_count, maximumP2pPerHost=total_nodes+numTrxGenerators, topo=topo, delay=delay, loadSystemContract=False,
+    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, prodCount=prod_count, maximumP2pPerHost=total_nodes+numTrxGenerators, delay=delay, loadSystemContract=False,
                       activateIF=False, specificExtraNodeosArgs=specificExtraNodeosArgs) is False:
         errorExit("Failed to stand up eos cluster.")
 

--- a/tests/transition_to_if.py
+++ b/tests/transition_to_if.py
@@ -83,17 +83,17 @@ try:
     info = cluster.biosNode.getInfo(exitOnError=True)
     assert (info["head_block_num"] - info["last_irreversible_block_num"]) < 9, "Instant finality enabled LIB diff should be small"
 
-    # launch setup node_00 (defproducera - defproducerf), node_01 (defproducerg - defproducerk),
-    #              node_02 (defproducerl - defproducerp), node_03 (defproducerq - defproduceru)
-    # with setprods of (defproducera, defproducerg, defproducerl, defproducerq)
-    assert cluster.biosNode.waitForProducer("defproducerq"), "defproducerq did not produce"
+    # launcher setup node_00 (defproducera,e,i,m,q,u), node_01 (defproducerb,f,j,n,r),
+    #                node_02 (defproducerc,g,k,o,s),   node_03 (defproducerd,h,l,p,t)
+    # launcher setprods with first producer of each node (defproducera,b,c,d)
+    assert cluster.biosNode.waitForProducer("defproducerd"), "defproducerd did not produce"
 
     Print("Set prods")
-    # should take effect in first block of defproducerg slot (so defproducerh)
-    assert cluster.setProds(["defproducerb", "defproducerh", "defproducerm", "defproducerr"]), "setprods failed"
+    # should take effect in first block of defproducerb slot (so defproducerc)
+    assert cluster.setProds(["defproducere", "defproducerf", "defproducerg", "defproducerh"]), "setprods failed"
     setProdsBlockNum = cluster.biosNode.getBlockNum()
     assert cluster.biosNode.waitForBlock(setProdsBlockNum+12+12+1), "Block of new producers not reached"
-    assert cluster.biosNode.getInfo(exitOnError=True)["head_block_producer"] == "defproducerh", "setprods should have taken effect"
+    assert cluster.biosNode.getInfo(exitOnError=True)["head_block_producer"] == "defproducerf", "setprods should have taken effect"
     assert cluster.getNode(4).waitForBlock(setProdsBlockNum + 12 + 12 + 1), "Block of new producers not reached on irreversible node"
 
     Print("Set finalizers")


### PR DESCRIPTION
By default, configure integration tests nodes to have non-consecutive block producers. Before if 4 producers were configured with 2 producer nodes the block producers would be configured as `node_00[defproducera,defproducerb]`, `node_01[defproducerc,defproducerd]`. Now they will be configured as `node_00[defproducera,defproducerc]`,  `node_01[defproducerb,defproducerd]`.

Related to #1492 