### PR TITLE
cleos convert unpack_hex

### DIFF
--- a/docs/02_cleos/03_command-reference/convert/index.md
+++ b/docs/02_cleos/03_command-reference/convert/index.md
@@ -1,8 +1,9 @@
 ## Description
-Pack and unpack transactions
+Pack and unpack data
 
 ## subcommands
 - [pack_transaction](pack_transaction.md) - From plain signed json to packed form
 - [unpack_transaction](unpack_transaction.md) - From packed to plain signed json form
 - [pack_action_data](pack_action_data.md) - From json action data to packed form
 - [unpack_action_data](unpack_action_data.md) - From packed to json action data form
+- [unpack_hex](unpack_hex.md) - From packed HEX to JSON form

--- a/docs/02_cleos/03_command-reference/convert/unpack_hex.md
+++ b/docs/02_cleos/03_command-reference/convert/unpack_hex.md
@@ -1,0 +1,77 @@
+## Description
+
+From packed HEX to json form
+
+## Positionals
+
+- `hex` _TEXT_ - The packed HEX of built-in types including: signed_block, transaction/action_trace, transaction, action, abi_def
+
+## Options
+
+- `-h,--help` - Print this help message and exit
+
+## Usage
+
+```sh
+cleos convert unpack_hex da9fbe9042e1bc9bd64d7a4506534d492107a29f79ad671c1fea19ae3fb70eb403000000023b3d4b01000000038159f32d3c8073a6a2f1ad5aa26e2e804a7815c2b5ef729e84fb803101006400000000000000000000000000000000000000000001010000010000000000ea3055ccfe3b56076237b0b6da2f580652ee1420231b96d3d96b28183769ac932c9e5902000000000000000200000000000000010000000000ea3055020000000000000000000000000000ea30550000000000ea305500000000221acfa4010000000000ea305500000000a8ed32329801013b3d4b0000000000ea30550000000000015ab65a885a31e441ac485ebd2aeba87bf7ee6e7bcc40bf3a24506ba1000000000000000000000000000000000000000000000000000000000000000062267e8b11d7d8f28e1f991a4de2b08cf92500861af2795765bdc9263cd6f4cd000000000001000021010ec7e080177b2c02b278d5088611686b49d739925a92d9bfcacd7fc6b74053bd00000000000000000000da9fbe9042e1bc9bd64d7a4506534d492107a29f79ad671c1fea19ae3fb70eb403000000023b3d4b01000000038159f32d3c8073a6a2f1ad5aa26e2e804a7815c2b5ef729e84fb803100000000000000000000
+```
+
+## Output
+
+
+```json
+{
+  "id": "da9fbe9042e1bc9bd64d7a4506534d492107a29f79ad671c1fea19ae3fb70eb4",
+  "block_num": 3,
+  "block_time": "2020-01-01T00:00:01.000",
+  "producer_block_id": "000000038159f32d3c8073a6a2f1ad5aa26e2e804a7815c2b5ef729e84fb8031",
+  "receipt": {
+    "status": "executed",
+    "cpu_usage_us": 100,
+    "net_usage_words": 0
+  },
+  "elapsed": 0,
+  "net_usage": 0,
+  "scheduled": false,
+  "action_traces": [{
+    "action_ordinal": 1,
+    "creator_action_ordinal": 0,
+    "closest_unnotified_ancestor_action_ordinal": 0,
+    "receipt": {
+      "receiver": "eosio",
+      "act_digest": "ccfe3b56076237b0b6da2f580652ee1420231b96d3d96b28183769ac932c9e59",
+      "global_sequence": 2,
+      "recv_sequence": 2,
+      "auth_sequence": [[
+        "eosio",
+        2
+      ]
+      ],
+      "code_sequence": 0,
+      "abi_sequence": 0
+    },
+    "receiver": "eosio",
+    "act": {
+      "account": "eosio",
+      "name": "onblock",
+      "authorization": [{
+        "actor": "eosio",
+        "permission": "active"
+      }
+      ],
+      "data": "013b3d4b0000000000ea30550000000000015ab65a885a31e441ac485ebd2aeba87bf7ee6e7bcc40bf3a24506ba1000000000000000000000000000000000000000000000000000000000000000062267e8b11d7d8f28e1f991a4de2b08cf92500861af2795765bdc9263cd6f4cd000000000001000021010ec7e080177b2c02b278d5088611686b49d739925a92d9bfcacd7fc6b74053bd"
+    },
+    "context_free": false,
+    "elapsed": 0,
+    "console": "",
+    "trx_id": "da9fbe9042e1bc9bd64d7a4506534d492107a29f79ad671c1fea19ae3fb70eb4",
+    "block_num": 3,
+    "block_time": "2020-01-01T00:00:01.000",
+    "producer_block_id": "000000038159f32d3c8073a6a2f1ad5aa26e2e804a7815c2b5ef729e84fb8031",
+    "account_ram_deltas": [],
+    "return_value": ""
+  }
+  ],
+  "failed_dtrx_trace": null
+}
+```

--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -341,3 +341,31 @@ namespace eosio { namespace chain {
    }
 
 } } // eosio::chain
+
+namespace fc {
+
+template<typename T> struct get_typename<eosio::chain::copyable_atomic<T>> {
+   static const char* name()  {
+      static std::string n = std::string("copyable_atomic<") + get_typename<T>::name() + ">";
+      return n.c_str();
+   }
+};
+
+template<typename T>
+void to_variant(const eosio::chain::copyable_atomic<T>& e, fc::variant& v) {
+   T t = e.load();
+   if constexpr (std::is_same_v<T, bool>) {
+      v = t;
+   } else {
+      to_variant( t, v );
+   }
+}
+
+template<typename T>
+void from_variant(const fc::variant& v, eosio::chain::copyable_atomic<T>& e) {
+   T t;
+   from_variant( v, t );
+   e.store(t);
+}
+
+} // namespace fc

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2957,6 +2957,71 @@ int main( int argc, char** argv ) {
       std::cout << fc::json::to_pretty_string(unpacked_action_data_json) << std::endl;
    });
 
+   // unpack hex
+   string packed_hex;
+   auto unpack_hex = convert->add_subcommand("unpack_hex", localized("From packed HEX to JSON form"));
+   unpack_hex->add_option("hex", packed_hex, localized("The packed HEX of built-in types including: signed_block, transaction/action_trace, transaction, action, abi_def"))->required();
+   unpack_hex->callback([&] {
+      EOS_ASSERT( packed_hex.size() >= 2, transaction_type_exception, "No packed HEX data found" );
+      vector<char> packed_blob(packed_hex.size()/2);
+      fc::from_hex(packed_hex, packed_blob.data(), packed_blob.size());
+      bool success = false;
+      try {
+         auto v = fc::raw::unpack<block_state_legacy>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<signed_block>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<transaction_trace>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<action_trace>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<transaction_receipt>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<packed_transaction>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<signed_transaction>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<transaction>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<abi_def>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+      try {
+         auto v = fc::raw::unpack<action>( packed_blob );
+         std::cout << fc::json::to_pretty_string(v) << std::endl;
+         success = true;
+      } catch (...) {}
+
+      if (!success) {
+         std::cerr << "ERROR: Unable to convert the packed hex" << std::endl;
+      }
+   });
+
    // validate subcommand
    auto validate = app.add_subcommand("validate", localized("Validate transactions"));
    validate->require_subcommand();


### PR DESCRIPTION
Add new `cleos` `convert` functionality of `unpack_hex`.

I have created a one-off exec one too many times and decided to just add this functionality to `cleos`. It is handy for decoding the deep-mind output that is hex encoded.