### PR TITLE
switch cleos to using UTF8 locale; allows using IDN endpoints

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2793,6 +2793,8 @@ int main( int argc, char** argv ) {
 
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
 
+   setlocale(LC_CTYPE, "C.UTF-8");
+
    wallet_url = default_wallet_url;
 
    CLI::App app{"Command Line Interface to Spring Client"};


### PR DESCRIPTION
Switch cleos to opting in to UTF8 locale which makes everything just work when using `--url` with an IDN hostname. `LC_CTYPE, "C.UTF-8"` should be the most conservative opt in here (vs something like `LC_ALL, ""` which will use the system configured locale which might affect how dates are printed etc) but I'm still not 100% sure if there is any potential fall out.