### PR TITLE
[1.1.6] P2P: Fix IPv6 support

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/net_utils.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/net_utils.hpp
@@ -80,7 +80,7 @@ namespace detail {
          return {};
       }
       string::size_type colon2 = peer_add.find(':', colon + 1);
-      string host = peer_add.substr( 0, colon );
+      string host = end_bracket != 0 ? peer_add.substr( 1, end_bracket - 1 ) : peer_add.substr( 0, colon );
       string port = peer_add.substr( colon + 1, colon2 == string::npos ? string::npos : colon2 - (colon + 1));
       string remainder = colon2 == string::npos ? "" : peer_add.substr( colon2 + 1 );
       return {std::move(host), std::move(port), std::move(remainder)};

--- a/plugins/net_plugin/tests/rate_limit_parse_unittest.cpp
+++ b/plugins/net_plugin/tests/rate_limit_parse_unittest.cpp
@@ -49,10 +49,10 @@ BOOST_AUTO_TEST_CASE(test_parse_rate_limit) {
    BOOST_CHECK_EQUAL(listen_addr, "localhost:9879");
    BOOST_CHECK_EQUAL(block_sync_rate_limit, 500u);
    std::tie(listen_addr, block_sync_rate_limit) = eosio::net_utils::parse_listen_address(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(listen_addr, "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:9876");
+   BOOST_CHECK_EQUAL(listen_addr, "2001:db8:85a3:8d3:1319:8a2e:370:7348:9876");
    BOOST_CHECK_EQUAL(block_sync_rate_limit, 250000u);
    std::tie(listen_addr, block_sync_rate_limit) = eosio::net_utils::parse_listen_address(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(listen_addr, "[::1]:9876");
+   BOOST_CHECK_EQUAL(listen_addr, "::1:9876");
    BOOST_CHECK_EQUAL(block_sync_rate_limit, 250000u);
    BOOST_CHECK_EXCEPTION(eosio::net_utils::parse_listen_address(p2p_addresses.at(which++)), eosio::chain::plugin_config_exception,
                          [](const eosio::chain::plugin_config_exception& e)
@@ -82,10 +82,10 @@ BOOST_AUTO_TEST_CASE(test_parse_rate_limit) {
    BOOST_CHECK_EQUAL(listen_addr, "localhost:9879");
    BOOST_CHECK_EQUAL(block_sync_rate_limit, 500u);
    std::tie(listen_addr, block_sync_rate_limit) = eosio::net_utils::parse_listen_address(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(listen_addr, "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:9876");
+   BOOST_CHECK_EQUAL(listen_addr, "2001:db8:85a3:8d3:1319:8a2e:370:7348:9876");
    BOOST_CHECK_EQUAL(block_sync_rate_limit, 250000u);
    std::tie(listen_addr, block_sync_rate_limit) = eosio::net_utils::parse_listen_address(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(listen_addr, "[::1]:9876");
+   BOOST_CHECK_EQUAL(listen_addr, "::1:9876");
    BOOST_CHECK_EQUAL(block_sync_rate_limit, 250000u);
    BOOST_CHECK_EXCEPTION(eosio::net_utils::parse_listen_address(p2p_addresses.at(which++)), eosio::chain::plugin_config_exception,
                          [](const eosio::chain::plugin_config_exception& e)
@@ -172,11 +172,11 @@ BOOST_AUTO_TEST_CASE(test_split_host_port_type) {
    BOOST_CHECK_EQUAL(port, "9879");
    BOOST_CHECK_EQUAL(type, "");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(host, "[2001:db8:85a3:8d3:1319:8a2e:370:7348]");
+   BOOST_CHECK_EQUAL(host, "2001:db8:85a3:8d3:1319:8a2e:370:7348");
    BOOST_CHECK_EQUAL(port, "9876");
    BOOST_CHECK_EQUAL(type, "");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(host, "[::1]");
+   BOOST_CHECK_EQUAL(host, "::1");
    BOOST_CHECK_EQUAL(port, "9876");
    BOOST_CHECK_EQUAL(type, "");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(test_split_host_port_type) {
    BOOST_CHECK_EQUAL(port, "");
    BOOST_CHECK_EQUAL(type, "");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(host, "[::1]");
+   BOOST_CHECK_EQUAL(host, "::1");
    BOOST_CHECK_EQUAL(port, "9876");
    BOOST_CHECK_EQUAL(type, "");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
@@ -216,11 +216,11 @@ BOOST_AUTO_TEST_CASE(test_split_host_port_type) {
    BOOST_CHECK_EQUAL(port, "9879");
    BOOST_CHECK_EQUAL(type, "trx");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(host, "[2001:db8:85a3:8d3:1319:8a2e:370:7348]");
+   BOOST_CHECK_EQUAL(host, "2001:db8:85a3:8d3:1319:8a2e:370:7348");
    BOOST_CHECK_EQUAL(port, "9876");
    BOOST_CHECK_EQUAL(type, "trx");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(host, "[::1]");
+   BOOST_CHECK_EQUAL(host, "::1");
    BOOST_CHECK_EQUAL(port, "9876");
    BOOST_CHECK_EQUAL(type, "trx");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(test_split_host_port_type) {
    BOOST_CHECK_EQUAL(port, "");
    BOOST_CHECK_EQUAL(type, "");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));
-   BOOST_CHECK_EQUAL(host, "[::1]");
+   BOOST_CHECK_EQUAL(host, "::1");
    BOOST_CHECK_EQUAL(port, "9876");
    BOOST_CHECK_EQUAL(type, "trx");
    std::tie(host, port, type) = eosio::net_utils::split_host_port_type(p2p_addresses.at(which++));


### PR DESCRIPTION
During the consolidation of address parsing in release 1.1, parsing of IPv6 addresses was broken.

Release 1.0 removed `[` & `]` from the host. See https://github.com/AntelopeIO/spring/blob/v1.0.5/plugins/net_plugin/net_plugin.cpp#L1211

This PR restores the removal of `[` & `]` which fixes IPv6 support in `net_plugin`.

Resolves #1588 