### PR TITLE
[1.2.0-rc3] P2P: Allow p2p-bp-gossip-endpoint with duplicate server addresses

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/gossip_bps_index.hpp
@@ -17,9 +17,9 @@ struct gossip_bp_index_t {
             tag<struct by_producer>,
             composite_key< gossip_bp_peers_message::signed_bp_peer,
                member<gossip_bp_peers_message::bp_peer, name, &gossip_bp_peers_message::bp_peer::producer_name>,
-               const_mem_fun<gossip_bp_peers_message::signed_bp_peer, const std::string&, &gossip_bp_peers_message::signed_bp_peer::server_endpoint>
-            >,
-            composite_key_compare< std::less<>, std::less<> >
+               const_mem_fun<gossip_bp_peers_message::signed_bp_peer, const std::string&, &gossip_bp_peers_message::signed_bp_peer::server_endpoint>,
+               const_mem_fun<gossip_bp_peers_message::signed_bp_peer, const std::string&, &gossip_bp_peers_message::signed_bp_peer::outbound_ip_address>
+            >
          >,
          ordered_non_unique<
             tag< struct by_expiry >,


### PR DESCRIPTION
Allow `p2p-bp-gossip-endpoint` with duplicate server addresses. 
Uniqueness of `p2p-bp-gossip-endpoint` is now on  the tuple `[bp-account,outbound-ip-address]`.

Resolves #1592 