### PR TITLE
[1.2.0-rc3 -> main] P2P: Trim addresses

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -172,10 +172,12 @@ public:
             EOS_ASSERT(comma_pos != std::string::npos, chain::plugin_config_exception,
                        "p2p-bp-gossip-endpoint ${e} must consist of bp-account-name,inbound-server-endpoint,outbound-ip-address separated by commas, second comma is missing", ("e", entry));
             auto inbound_server_endpoint = rest.substr(0, comma_pos);
+            boost::trim(inbound_server_endpoint);
             const auto& [host, port, type] = net_utils::split_host_port_type(inbound_server_endpoint);
             EOS_ASSERT( !host.empty() && !port.empty() && type.empty(), chain::plugin_config_exception,
                         "Invalid p2p-bp-gossip-endpoint inbound server endpoint ${p}, syntax host:port", ("p", inbound_server_endpoint));
             auto outbound_ip_address = rest.substr(comma_pos + 1);
+            boost::trim(outbound_ip_address);
             EOS_ASSERT( outbound_ip_address.length() <= net_utils::max_p2p_address_length, chain::plugin_config_exception,
                         "p2p-bp-gossip-endpoint outbound-ip-address ${a} too long, must be less than ${m}",
                         ("a", outbound_ip_address)("m", net_utils::max_p2p_address_length) );

--- a/plugins/net_plugin/tests/rate_limit_parse_unittest.cpp
+++ b/plugins/net_plugin/tests/rate_limit_parse_unittest.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_split_host_port_type) {
       , "0.0.0.0:9776:blk:0"
       , "0.0.0.0:9877:trx:640KB/s"
       , "192.168.0.1:9878:blk:20MiB/s"
-      , "localhost:9879:trx:0.5KB/s"
+      , " localhost:9879:trx:0.5KB/s"
       , "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:9876:trx:250KB/s"
       , "[::1]:9876:trx:250KB/s"
       , "2001:db8:85a3:8d3:1319:8a2e:370:7348:9876:trx:250KB/s"


### PR DESCRIPTION
Remove leading-trailing spaces from `p2p-bp-gossip-endpoint` values to avoid peers attempting to connect to a host with a leading or trailing space. Also trim all host names when using them to avoid attempting to use a host from a peer with a leading or trailing space.

Merges `release/1.2` into `main` including #1597 

Resolves #1585 
