### PR TITLE
[1.2.0 -> main] Ensure callback complete before exiting platform_timer stop

### DIFF
--- a/libraries/chain/include/eosio/chain/platform_timer.hpp
+++ b/libraries/chain/include/eosio/chain/platform_timer.hpp
@@ -39,18 +39,22 @@ struct platform_timer {
       _expiration_callback_data = user;
    }
 
-   enum class state_t {
-      running,
+   enum class state_t : uint8_t {
+      running = 0,
       timed_out,
       interrupted,
       stopped
    };
-   state_t timer_state() const { return _state; }
+   state_t timer_state() const { return _state.load().state; }
 
 private:
    void expire_now();
 
-   std::atomic<state_t> _state = state_t::stopped;
+   struct timer_state_t {
+      state_t state = state_t::stopped;
+      bool callback_in_flight = false;
+   };
+   std::atomic<timer_state_t> _state;
    bool timer_running_forever = false;
 
    struct impl;
@@ -71,7 +75,7 @@ private:
 
    std::atomic_bool _callback_variables_busy = false;
    void(*_expiration_callback)(void*) = nullptr;
-   void* _expiration_callback_data;
+   void* _expiration_callback_data = nullptr;
 };
 
 }}

--- a/libraries/chain/include/eosio/chain/thread_utils.hpp
+++ b/libraries/chain/include/eosio/chain/thread_utils.hpp
@@ -8,6 +8,7 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/use_future.hpp>
 #include <future>
+#include <list>
 #include <memory>
 #include <optional>
 #include <thread>

--- a/libraries/chain/platform_timer_asio_fallback.cpp
+++ b/libraries/chain/platform_timer_asio_fallback.cpp
@@ -4,6 +4,7 @@
 #include <fc/fwd_impl.hpp>
 #include <fc/log/logger_config.hpp> //set_os_thread_name()
 
+#include <boost/core/yield_primitives.hpp>
 #include <boost/asio.hpp>
 
 #include <mutex>
@@ -22,6 +23,7 @@ struct platform_timer::impl {
 };
 
 platform_timer::platform_timer() {
+   static_assert(std::atomic<timer_state_t>::is_always_lock_free, "Only lock-free atomics AS-safe.");
    static_assert(sizeof(impl) <= fwd_size);
 
    std::lock_guard guard(timer_ref_mutex);
@@ -56,18 +58,18 @@ platform_timer::~platform_timer() {
 }
 
 void platform_timer::start(fc::time_point tp) {
-   assert(_state == state_t::stopped);
+   assert(timer_state() == state_t::stopped);
    timer_running_forever = tp == fc::time_point::maximum();
    if(timer_running_forever) {
-      _state = state_t::running;
+      _state.store(timer_state_t{.state = state_t::running, .callback_in_flight = false});
       return;
    }
    fc::microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
    timer_running_forever = false;
-   if(x.count() <= 0)
-      _state = state_t::timed_out;
-   else {
-      _state = state_t::running;
+   if(x.count() <= 0) {
+      _state.store(timer_state_t{.state = state_t::timed_out, .callback_in_flight = false});
+   } else {
+      _state.store(timer_state_t{.state = state_t::running, .callback_in_flight = false});
       my->timer->expires_after(std::chrono::microseconds(x.count()));
       my->timer->async_wait([this](const boost::system::error_code& ec) {
          if(ec)
@@ -78,25 +80,35 @@ void platform_timer::start(fc::time_point tp) {
 }
 
 void platform_timer::expire_now() {
-   state_t expected = state_t::running;
-   if (_state.compare_exchange_strong(expected, state_t::timed_out)) {
+   timer_state_t expected{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(expected, timer_state_t{state_t::timed_out, true})) {
       call_expiration_callback();
+      _state.store(timer_state_t{state_t::timed_out, false});
    }
 }
 
 void platform_timer::interrupt_timer() {
-   state_t expected = state_t::running;
-   if (_state.compare_exchange_strong(expected, state_t::interrupted)) {
+   timer_state_t expected{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(expected, timer_state_t{state_t::interrupted, true})) {
       call_expiration_callback();
+      _state.store(timer_state_t{state_t::interrupted, false});
    }
 }
 
 void platform_timer::stop() {
-   const state_t prior_state = _state;
-   if(prior_state == state_t::stopped)
+   // if still running, then interrupt so expire_now() and interrupt_timer() can't start a callback call
+   timer_state_t prior_state{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(prior_state, timer_state_t{state_t::interrupted, false})) {
+      prior_state = timer_state_t{state_t::interrupted, false};
+   }
+
+   for (; prior_state.callback_in_flight; prior_state = _state.load())
+      boost::core::sp_thread_pause();
+
+   if(prior_state.state == state_t::stopped)
       return;
-   _state = state_t::stopped;
-   if(prior_state == state_t::timed_out || timer_running_forever)
+   _state.store(timer_state_t{.state = state_t::stopped, .callback_in_flight = false});
+   if(prior_state.state == state_t::timed_out || timer_running_forever)
       return;
 
    my->timer->cancel();

--- a/libraries/chain/platform_timer_kqueue.cpp
+++ b/libraries/chain/platform_timer_kqueue.cpp
@@ -6,6 +6,8 @@
 #include <fc/exception/exception.hpp>
 #include <fc/log/logger_config.hpp> //set_os_thread_name()
 
+#include <boost/core/yield_primitives.hpp>
+
 #include <mutex>
 #include <thread>
 
@@ -88,52 +90,61 @@ platform_timer::~platform_timer() {
 }
 
 void platform_timer::start(fc::time_point tp) {
-   assert(_state == state_t::stopped);
+   assert(timer_state() == state_t::stopped);
    timer_running_forever = tp == fc::time_point::maximum();
    if(timer_running_forever) {
-      _state = state_t::running;
+      _state.store(timer_state_t{.state = state_t::running, .callback_in_flight = false});
       return;
    }
    fc::microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
    timer_running_forever = false;
-   if(x.count() <= 0)
-      _state = state_t::timed_out;
-   else {
+   if(x.count() <= 0) {
+      _state.store(timer_state_t{.state = state_t::timed_out, .callback_in_flight = false});
+   } else {
       struct kevent64_s aTimerEvent;
       EV_SET64(&aTimerEvent, my->timerid, EVFILT_TIMER, EV_ADD|EV_ENABLE|EV_ONESHOT, NOTE_USECONDS|NOTE_CRITICAL, x.count(), (uint64_t)this, 0, 0);
 
-      _state = state_t::running;
+      _state.store(timer_state_t{.state = state_t::running, .callback_in_flight = false});
       if(kevent64(kqueue_fd, &aTimerEvent, 1, NULL, 0, KEVENT_FLAG_IMMEDIATE, NULL) != 0)
-         _state = state_t::timed_out;
+         _state.store(timer_state_t{.state = state_t::timed_out, .callback_in_flight = false});
    }
 }
 
 void platform_timer::expire_now() {
-   state_t expected = state_t::running;
-   if (_state.compare_exchange_strong(expected, state_t::timed_out)) {
+   timer_state_t expected{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(expected, timer_state_t{state_t::timed_out, true})) {
       call_expiration_callback();
+      _state.store(timer_state_t{state_t::timed_out, false});
    }
 }
 
 void platform_timer::interrupt_timer() {
-   state_t expected = state_t::running;
-   if (_state.compare_exchange_strong(expected, state_t::interrupted)) {
+   timer_state_t expected{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(expected, timer_state_t{state_t::interrupted, true})) {
       call_expiration_callback();
+      _state.store(timer_state_t{state_t::interrupted, false});
    }
 }
 
 void platform_timer::stop() {
-   const state_t prior_state = _state;
-   if(prior_state == state_t::stopped)
+   // if still running, then interrupt so expire_now() and interrupt_timer() can't start a callback call
+   timer_state_t prior_state{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(prior_state, timer_state_t{state_t::interrupted, false})) {
+      prior_state = timer_state_t{state_t::interrupted, false};
+   }
+
+   for (; prior_state.callback_in_flight; prior_state = _state.load())
+      boost::core::sp_thread_pause();
+
+   if(prior_state.state == state_t::stopped)
       return;
-   _state = state_t::stopped;
-   if(prior_state == state_t::timed_out || timer_running_forever)
+   _state.store(timer_state_t{.state = state_t::stopped, .callback_in_flight = false});
+   if(prior_state.state == state_t::timed_out || timer_running_forever)
       return;
 
    struct kevent64_s stop_timer_event;
    EV_SET64(&stop_timer_event, my->timerid, EVFILT_TIMER, EV_DELETE, 0, 0, 0, 0, 0);
    kevent64(kqueue_fd, &stop_timer_event, 1, NULL, 0, KEVENT_FLAG_IMMEDIATE, NULL);
-   _state = state_t::stopped;
 }
 
 }}

--- a/libraries/chain/platform_timer_posix.cpp
+++ b/libraries/chain/platform_timer_posix.cpp
@@ -5,6 +5,8 @@
 #include <fc/fwd_impl.hpp>
 #include <fc/exception/exception.hpp>
 
+#include <boost/core/yield_primitives.hpp>
+
 #include <atomic>
 #include <mutex>
 
@@ -26,6 +28,7 @@ struct platform_timer::impl {
 };
 
 platform_timer::platform_timer() {
+   static_assert(std::atomic<timer_state_t>::is_always_lock_free, "Only lock-free atomics AS-safe.");
    static_assert(sizeof(impl) <= fwd_size);
 
    static bool initialized;
@@ -55,45 +58,56 @@ platform_timer::~platform_timer() {
 }
 
 void platform_timer::start(fc::time_point tp) {
-   assert(_state == state_t::stopped);
+   assert(timer_state() == state_t::stopped);
    timer_running_forever = tp == fc::time_point::maximum();
    if(timer_running_forever) {
-      _state = state_t::running;
+      _state.store(timer_state_t{.state = state_t::running, .callback_in_flight = false});
       return;
    }
    fc::microseconds x = tp.time_since_epoch() - fc::time_point::now().time_since_epoch();
-   if(x.count() <= 0)
-      _state = state_t::timed_out;
-   else {
+   if(x.count() <= 0) {
+      _state.store(timer_state_t{.state = state_t::timed_out, .callback_in_flight = false});
+   } else {
       time_t secs = x.count() / 1000000;
       long nsec = (x.count() - (secs*1000000)) * 1000;
       struct itimerspec enable = {{0, 0}, {secs, nsec}};
-      _state = state_t::running;
-      if(timer_settime(my->timerid, 0, &enable, NULL) != 0)
-         _state = state_t::timed_out;
+      _state.store(timer_state_t{.state = state_t::running, .callback_in_flight = false});
+      if(timer_settime(my->timerid, 0, &enable, NULL) != 0) {
+         _state.store(timer_state_t{.state = state_t::timed_out, .callback_in_flight = false});
+      }
    }
 }
 
 void platform_timer::expire_now() {
-   state_t expected = state_t::running;
-   if (_state.compare_exchange_strong(expected, state_t::timed_out)) {
+   timer_state_t expected{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(expected, timer_state_t{state_t::timed_out, true})) {
       call_expiration_callback();
+      _state.store(timer_state_t{state_t::timed_out, false});
    }
 }
 
 void platform_timer::interrupt_timer() {
-   state_t expected = state_t::running;
-   if (_state.compare_exchange_strong(expected, state_t::interrupted)) {
+   timer_state_t expected{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(expected, timer_state_t{state_t::interrupted, true})) {
       call_expiration_callback();
+      _state.store(timer_state_t{state_t::interrupted, false});
    }
 }
 
 void platform_timer::stop() {
-   const state_t prior_state = _state;
-   if(prior_state == state_t::stopped)
+   // if still running, then interrupt so expire_now() and interrupt_timer() can't start a callback call
+   timer_state_t prior_state{.state = state_t::running, .callback_in_flight = false};
+   if (_state.compare_exchange_strong(prior_state, timer_state_t{state_t::interrupted, false})) {
+      prior_state = timer_state_t{state_t::interrupted, false};
+   }
+
+   for (; prior_state.callback_in_flight; prior_state = _state.load())
+      boost::core::sp_thread_pause();
+
+   if(prior_state.state == state_t::stopped)
       return;
-   _state = state_t::stopped;
-   if(prior_state == state_t::timed_out || timer_running_forever)
+   _state.store(timer_state_t{.state = state_t::stopped, .callback_in_flight = false});
+   if(prior_state.state == state_t::timed_out || timer_running_forever)
       return;
    struct itimerspec disable = {{0, 0}, {0, 0}};
    timer_settime(my->timerid, 0, &disable, NULL);

--- a/unittests/platform_timer_tests.cpp
+++ b/unittests/platform_timer_tests.cpp
@@ -1,0 +1,112 @@
+#include <eosio/chain/thread_utils.hpp>
+#include <eosio/chain/platform_timer.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+namespace eosio {
+using namespace std;
+using namespace chain;
+
+BOOST_AUTO_TEST_SUITE(platform_timer_tests)
+
+BOOST_AUTO_TEST_CASE(correct_num_callbacks_test)
+{
+   named_thread_pool<struct test> pool;
+   const size_t num_threads = 16;
+   pool.start(num_threads, [](const fc::exception& e) {
+      BOOST_ERROR("exception: " + e.to_detail_string());
+   });
+
+   std::atomic<size_t> calls{0};
+   platform_timer t;
+   t.set_expiration_callback([](void* a) {
+      auto atom = (std::atomic<size_t>*)a;
+      ++(*atom);
+   }, &calls);
+   std::mutex m;
+   std::atomic<size_t> barrier(num_threads);
+   for (size_t i = 0; i < num_threads; ++i) {
+      boost::asio::post(pool.get_executor(), [&]() {
+         lock_guard lock(m);
+         t.start(fc::time_point::now() + fc::milliseconds(15));
+         std::this_thread::sleep_for(std::chrono::milliseconds(50));
+         t.stop();
+         --barrier;
+      });
+      if (i % 2 == 0) {
+         boost::asio::post(pool.get_executor(), [&, i]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds((i+1)*10));
+            t.interrupt_timer();
+         });
+      }
+   }
+   for (size_t i = 0; i < 5000; ++i) {
+      if (barrier == 0)
+         break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+   }
+   BOOST_TEST_REQUIRE(barrier == 0);
+   pool.stop();
+
+   BOOST_TEST(calls == num_threads);
+}
+
+std::map<size_t, bool> callback_called;
+std::mutex cc_mtx;
+void called(size_t i) {
+   std::lock_guard lock(cc_mtx);
+   callback_called[i] = true;
+}
+
+/// Test would fail with a sleep in interrupt_timer() before fix
+BOOST_AUTO_TEST_CASE(correct_callback_test)
+{
+   named_thread_pool<struct test> pool;
+   named_thread_pool<struct interrupt> interrupt_pool;
+   const size_t num_threads = 16;
+   pool.start(num_threads, [](const fc::exception& e) {
+      BOOST_ERROR("exception: " + e.to_detail_string());
+   });
+   interrupt_pool.start(num_threads, [](const fc::exception& e) {
+      BOOST_ERROR("exception: " + e.to_detail_string());
+   });
+
+   platform_timer t;
+   std::mutex m;
+   std::atomic<size_t> barrier(num_threads*2);
+   for (size_t i = 0; i < num_threads; ++i) {
+      boost::asio::post(pool.get_executor(), [i, &t, &m, &barrier]() {
+         lock_guard lock(m);
+         t.set_expiration_callback(nullptr, nullptr);
+         t.set_expiration_callback([](void* a) {
+            called((size_t)a);
+         }, (void*)i);
+         t.start(fc::time_point::now() + fc::milliseconds(15));
+         std::this_thread::sleep_for(std::chrono::milliseconds(50));
+         t.stop();
+         --barrier;
+      });
+      boost::asio::post(interrupt_pool.get_executor(), [&, i]() {
+         std::this_thread::sleep_for(std::chrono::milliseconds((i+1)*20));
+         t.interrupt_timer();
+         --barrier;
+      });
+   }
+   for (size_t i = 0; i < 5000; ++i) {
+      if (barrier == 0)
+         break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+   }
+   BOOST_TEST_REQUIRE(barrier == 0);
+   pool.stop();
+
+   std::lock_guard lock(cc_mtx);
+   for (size_t i = 0; i < num_threads; ++i) {
+      BOOST_TEST(callback_called[i]);
+   }
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace eosio


### PR DESCRIPTION
Ensure any inflight `platform_timer` callbacks are complete before exiting `platform_timer::stop()`. This makes sure the correct transaction is interrupted when the callback is called.

Merges `release/1.2` into `main` including #1606 & #1609

Resolves #1601