### PR TITLE
Optimize default logger

### DIFF
--- a/libraries/libfc/include/fc/log/logger.hpp
+++ b/libraries/libfc/include/fc/log/logger.hpp
@@ -3,7 +3,7 @@
 #include <fc/log/log_message.hpp>
 #include <string>
 
-inline std::string DEFAULT_LOGGER = "default";
+inline const std::string DEFAULT_LOGGER = "default";
 
 namespace fc
 {
@@ -20,9 +20,10 @@ namespace fc
       }
     @endcode
     */
-   class logger 
+   class logger
    {
       public:
+         static logger& default_logger();
          static logger get( const std::string& name = DEFAULT_LOGGER );
          static void update( const std::string& name, logger& log );
 
@@ -105,34 +106,19 @@ namespace fc
   FC_MULTILINE_MACRO_END
 
 #define tlog( FORMAT, ... ) \
-  FC_MULTILINE_MACRO_BEGIN \
-   if( auto lL = (fc::logger::get(DEFAULT_LOGGER)); lL.is_enabled( fc::log_level::all ) ) \
-      lL.log( FC_LOG_MESSAGE( all, FORMAT, __VA_ARGS__ ) ); \
-  FC_MULTILINE_MACRO_END
+   fc_tlog( fc::logger::default_logger(), FORMAT, __VA_ARGS__)
 
 #define dlog( FORMAT, ... ) \
-  FC_MULTILINE_MACRO_BEGIN \
-   if( auto lL = (fc::logger::get(DEFAULT_LOGGER)); lL.is_enabled( fc::log_level::debug ) ) \
-      lL.log( FC_LOG_MESSAGE( debug, FORMAT, __VA_ARGS__ ) ); \
-  FC_MULTILINE_MACRO_END
+   fc_dlog( fc::logger::default_logger(), FORMAT, __VA_ARGS__)
 
 #define ilog( FORMAT, ... ) \
-  FC_MULTILINE_MACRO_BEGIN \
-   if( auto lL = (fc::logger::get(DEFAULT_LOGGER)); lL.is_enabled( fc::log_level::info ) ) \
-      lL.log( FC_LOG_MESSAGE( info, FORMAT, __VA_ARGS__ ) ); \
-  FC_MULTILINE_MACRO_END
+   fc_ilog( fc::logger::default_logger(), FORMAT, __VA_ARGS__)
 
 #define wlog( FORMAT, ... ) \
-  FC_MULTILINE_MACRO_BEGIN \
-   if( auto lL = (fc::logger::get(DEFAULT_LOGGER)); lL.is_enabled( fc::log_level::warn ) ) \
-      lL.log( FC_LOG_MESSAGE( warn, FORMAT, __VA_ARGS__ ) ); \
-  FC_MULTILINE_MACRO_END
+   fc_wlog( fc::logger::default_logger(), FORMAT, __VA_ARGS__)
 
 #define elog( FORMAT, ... ) \
-  FC_MULTILINE_MACRO_BEGIN \
-   if( auto lL = (fc::logger::get(DEFAULT_LOGGER)); lL.is_enabled( fc::log_level::error ) ) \
-      lL.log( FC_LOG_MESSAGE( error, FORMAT, __VA_ARGS__ ) ); \
-  FC_MULTILINE_MACRO_END
+   fc_elog( fc::logger::default_logger(), FORMAT, __VA_ARGS__)
 
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/stringize.hpp>

--- a/libraries/libfc/src/log/logger.cpp
+++ b/libraries/libfc/src/log/logger.cpp
@@ -8,6 +8,8 @@
 
 namespace fc {
 
+    inline static logger the_default_logger;
+
     class logger::impl {
       public:
          impl()
@@ -91,6 +93,10 @@ namespace fc {
 
     logger logger::get( const std::string& s ) {
        return log_config::get_logger( s );
+    }
+
+    logger& logger::default_logger() {
+       return the_default_logger;
     }
 
     void logger::update( const std::string& name, logger& log ) {

--- a/libraries/libfc/src/log/logger_config.cpp
+++ b/libraries/libfc/src/log/logger_config.cpp
@@ -73,7 +73,8 @@ namespace fc {
       log_config::get().logger_map.clear();
       log_config::get().appender_map.clear();
 
-      logger default_logger = log_config::get().logger_map[DEFAULT_LOGGER];
+      logger::default_logger() = log_config::get().logger_map[DEFAULT_LOGGER];
+      logger& default_logger = logger::default_logger();
 
       for( size_t i = 0; i < cfg.appenders.size(); ++i ) {
          // create appender


### PR DESCRIPTION
Use a global default logger to avoid mutex, map lookup, and shared_ptr copy on use of default logger.
For example, `dlog` would acquire a mutex, do a map lookup, and then create a shared_ptr copy of the logger just to check the log level.