### PR TITLE
Add core.vaulta support to cleos

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -149,7 +149,7 @@ std::string clean_output( std::string str ) {
 
 constexpr name core_vaulta_name = "core.vaulta"_n;
 constexpr name eosio_token_name = "eosio.token"_n;
-const symbol a_symbol = symbol::from_string("4,A");
+const symbol a_symbol = symbol{4, "A"};
 string default_url = "http://127.0.0.1:8888";
 string default_wallet_url = "unix://" + (determine_home_directory() / "eosio-wallet" / (string(key_store_executable_name) + ".sock")).string();
 string wallet_url; //to be set to default_wallet_url in main

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -149,7 +149,7 @@ std::string clean_output( std::string str ) {
 
 constexpr name core_vaulta_name = "core.vaulta"_n;
 constexpr name eosio_token_name = "eosio.token"_n;
-const symbol a_symbol = symbol::from_string("A");
+const symbol a_symbol = symbol::from_string("4,A");
 string default_url = "http://127.0.0.1:8888";
 string default_wallet_url = "unix://" + (determine_home_directory() / "eosio-wallet" / (string(key_store_executable_name) + ".sock")).string();
 string wallet_url; //to be set to default_wallet_url in main

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -4516,7 +4516,7 @@ int main( int argc, char** argv ) {
    });
 
    // system subcommand
-   auto system = app.add_subcommand("system", localized("Send eosio.system contract action to the blockchain."));
+   auto system = app.add_subcommand("system", localized("Send system action to eosio contract or core.vaulta contract for A asset"));
    system->require_subcommand();
 
    auto createAccountSystem = create_account_subcommand( system, false /*simple*/ );

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -147,8 +147,9 @@ std::string clean_output( std::string str ) {
    return fc::escape_string( str, nullptr, escape_control_chars );
 }
 
-const name core_vaulta_name = "core.vaulta"_n;
-const name eosio_token_name = "eosio.token"_n;
+constexpr name core_vaulta_name = "core.vaulta"_n;
+constexpr name eosio_token_name = "eosio.token"_n;
+const symbol a_symbol = symbol::from_string("A");
 string default_url = "http://127.0.0.1:8888";
 string default_wallet_url = "unix://" + (determine_home_directory() / "eosio-wallet" / (string(key_store_executable_name) + ".sock")).string();
 string wallet_url; //to be set to default_wallet_url in main
@@ -246,14 +247,14 @@ bool is_public_key_str(const std::string& potential_key_str) {
 }
 
 name to_default_token_contract(const asset& a) {
-   if (a.symbol_name() == "A") {
+   if (a.get_symbol() == a_symbol) {
       return core_vaulta_name ;
    }
    return eosio_token_name;
 }
 
 name to_default_contract(const asset& a) {
-   if (a.symbol_name() == "A") {
+   if (a.get_symbol() == a_symbol) {
       return core_vaulta_name;
    }
    return config::system_account_name;
@@ -917,8 +918,8 @@ authority parse_json_authority_or_key(const std::string& authorityJsonOrFile) {
 asset to_asset( account_name code, const string& s ) {
    static map< pair<account_name, eosio::chain::symbol_code>, eosio::chain::symbol> cache;
    auto a = asset::from_string( s );
-   eosio::chain::symbol asset_symbol = a.get_symbol();
-   eosio::chain::symbol_code sym = asset_symbol.to_symbol_code();
+   symbol asset_symbol = a.get_symbol();
+   symbol_code sym = asset_symbol.to_symbol_code();
    if (code.empty()) {
       code = to_default_token_contract(a);
    }

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -250,6 +250,13 @@ bool is_public_key_str(const std::string& potential_key_str) {
    return boost::istarts_with(potential_key_str, "EOS") || boost::istarts_with(potential_key_str, "PUB_R1") ||  boost::istarts_with(potential_key_str, "PUB_K1") ||  boost::istarts_with(potential_key_str, "PUB_WA");
 }
 
+name to_default_token_contract(const asset& a) {
+   if (a.symbol_name() == "A") {
+      return "core.vaulta"_n;
+   }
+   return "eosio.token"_n;
+}
+
 name to_default_contract(const asset& a) {
    if (a.symbol_name() == "A") {
       return "core.vaulta"_n;
@@ -918,7 +925,7 @@ asset to_asset( account_name code, const string& s ) {
    eosio::chain::symbol asset_symbol = a.get_symbol();
    eosio::chain::symbol_code sym = asset_symbol.to_symbol_code();
    if (code.empty()) {
-      code = to_default_contract_from_asset(s);
+      code = to_default_token_contract(a);
    }
    auto it = cache.find( make_pair(code, sym) );
    auto sym_str = a.symbol_name();
@@ -3690,9 +3697,8 @@ int main( int argc, char** argv ) {
 
       name token_contract = name{con};
       if (token_contract.empty()) {
-         token_contract = to_default_contract_from_asset(amount);
-         if (token_contract == config::system_account_name)
-            token_contract = "eosio.token"_n;
+         asset a = asset::from_string(amount);
+         token_contract = to_default_token_contract(a);
       }
       auto transfer_amount = to_asset(token_contract, amount);
       auto transfer = create_transfer(token_contract, name(sender), name(recipient), transfer_amount, memo);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -149,7 +149,7 @@ std::string clean_output( std::string str ) {
 
 constexpr name core_vaulta_name = "core.vaulta"_n;
 constexpr name eosio_token_name = "eosio.token"_n;
-const symbol a_symbol = symbol{4, "A"};
+const char* a_symbol_str = "A";
 string default_url = "http://127.0.0.1:8888";
 string default_wallet_url = "unix://" + (determine_home_directory() / "eosio-wallet" / (string(key_store_executable_name) + ".sock")).string();
 string wallet_url; //to be set to default_wallet_url in main
@@ -247,14 +247,14 @@ bool is_public_key_str(const std::string& potential_key_str) {
 }
 
 name to_default_token_contract(const asset& a) {
-   if (a.get_symbol() == a_symbol) {
+   if (a.symbol_name() == a_symbol_str) {
       return core_vaulta_name ;
    }
    return eosio_token_name;
 }
 
 name to_default_contract(const asset& a) {
-   if (a.get_symbol() == a_symbol) {
+   if (a.symbol_name() == a_symbol_str) {
       return core_vaulta_name;
    }
    return config::system_account_name;

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -679,49 +679,49 @@ try:
     Print("Publish contract")
     trans=node.publishContract(vaultaAccount, contractDir, wasmFile, abiFile, waitForTransBlock=True)
     if trans is None:
-        cmdError("%s set contract core.vaulta" % (ClientName))
+        cmdError(f"{ClientName} set contract core.vaulta")
         errorExit("Failed to publish contract.")
 
     Print("push create action to core.vaulta contract")
     contract="core.vaulta"
     action="create"
-    data="{\"issuer\":\"core.vaulta\",\"maximum_supply\":\"100000.0000 A\",\"can_freeze\":\"0\",\"can_recall\":\"0\",\"can_whitelist\":\"0\"}"
+    data="""{"issuer":"core.vaulta","maximum_supply":"100000.0000 A","can_freeze":"0","can_recall":"0","can_whitelist":"0"}"""
     opts="--permission core.vaulta@active"
     trans=node.pushMessage(contract, action, data, opts)
     try:
         assert(trans)
         assert(trans[0])
     except (AssertionError, KeyError) as _:
-        Print("ERROR: Failed push create action to core.vaulta contract assertion. %s" % (trans))
+        Print(f"ERROR: Failed push create action to core.vaulta contract assertion. {trans}")
         raise
     transId=Node.getTransId(trans[1])
     node.waitForTransactionInBlock(transId)
 
     Print("push issue action to core.vaulta contract")
     action="issue"
-    data="{\"to\":\"core.vaulta\",\"quantity\":\"100000.0000 A\",\"memo\":\"issue\"}"
+    data="""{"to":"core.vaulta","quantity":"100000.0000 A","memo":"issue"}"""
     opts="--permission core.vaulta@active"
     trans=node.pushMessage(contract, action, data, opts)
     try:
         assert(trans)
         assert(trans[0])
     except (AssertionError, KeyError) as _:
-        Print("ERROR: Failed push issue action to core.vaulta contract assertion. %s" % (trans))
+        Print(f"ERROR: Failed push issue action to core.vaulta contract assertion. {trans}")
         raise
     transId=Node.getTransId(trans[1])
     node.waitForTransactionInBlock(transId)
 
     Print("transfer should use core.vaulta since A asset is used, otherwise it will fail")
     transferAmount="97.5321 A"
-    Print("Transfer funds %s from account %s to %s" % (transferAmount, defproduceraAccount.name, testeraAccount.name))
+    Print(f"Transfer funds {transferAmount} from account {defproduceraAccount.name} to {testeraAccount.name}")
     node.transferFunds(vaultaAccount, testeraAccount, transferAmount, "test transfer", waitForTransBlock=True)
 
     expectedAmount=transferAmount
-    Print("Verify transfer, Expected: %s" % (expectedAmount))
+    Print(f"Verify transfer, Expected: {expectedAmount}")
     actualAmount=node.getTableAccountBalance("core.vaulta", testeraAccount.name)
     if expectedAmount != actualAmount:
         cmdError("FAILURE - transfer failed")
-        errorExit("Transfer verification failed. Excepted %s, actual: %s" % (expectedAmount, actualAmount))
+        errorExit(f"Transfer verification failed. Excepted {expectedAmount}, actual: {actualAmount}")
 
     buyRamAmount = '"85.5 A"'
     buyRamCmd = f"--abi-file core.vaulta:unittests/contracts/eosio.system/eosio.system.abi system buyram -j {testeraAccount.name} {testeraAccount.name} {buyRamAmount} -p {testeraAccount.name}@active"


### PR DESCRIPTION
`cleos` commands like `transfer` and `buyram` that are provided an `A` asset use `core.vaulta` instead of `eosio.token` / `eosio` contract. Commands that use any other asset, including `EOS`, continue to default to `eosio.token` (for transfer) and `eosio` for all other commands.

Deprecated commands: `canceldelay`, `rentcpu`, `rentnet`, `fundnetloan`, `defundnetload`, `fundcpuloan`, `defundcpuload`.

Resolves #1612