### PR TITLE
[1.2.0] Test: Increase timeout

### DIFF
--- a/tests/production_pause_vote_timeout.py
+++ b/tests/production_pause_vote_timeout.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 import os
 import shutil
@@ -171,7 +172,8 @@ try:
     centerNode.relaunch()
 
     Print("Verify production unpaused and LIB advances after restart of centerNode")
-    assert node0.waitForLibToAdvance(), "node0 did not advance LIB"
+    # large timeout as it can take a while for votes to catchup and LIB to advance
+    assert node0.waitForLibToAdvance(timeout=60), "node0 did not advance LIB"
     assert node1.waitForLibToAdvance(), "node1 did not advance LIB"
     assert producercNode.waitForLibToAdvance(), "producercNode did not advance LIB"
     assert producercNode.processUrllibRequest("producer", "paused", returnType=ReturnType.raw) == b'false', "producercNode should have resumed production after centerNode restarted"

--- a/tests/production_pause_vote_timeout.py
+++ b/tests/production_pause_vote_timeout.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 import os
 import shutil


### PR DESCRIPTION
On slow ci/cd machines it can take a while for votes to catchup and LIB to move.

Resolves #1629 