### PR TITLE
[1.2.0 -> main] Test: Increase timeout

### DIFF
--- a/tests/production_pause_vote_timeout.py
+++ b/tests/production_pause_vote_timeout.py
@@ -171,7 +171,8 @@ try:
     centerNode.relaunch()
 
     Print("Verify production unpaused and LIB advances after restart of centerNode")
-    assert node0.waitForLibToAdvance(), "node0 did not advance LIB"
+    # large timeout as it can take a while for votes to catchup and LIB to advance
+    assert node0.waitForLibToAdvance(timeout=60), "node0 did not advance LIB"
     assert node1.waitForLibToAdvance(), "node1 did not advance LIB"
     assert producercNode.waitForLibToAdvance(), "producercNode did not advance LIB"
     assert producercNode.processUrllibRequest("producer", "paused", returnType=ReturnType.raw) == b'false', "producercNode should have resumed production after centerNode restarted"


### PR DESCRIPTION
On slow ci/cd machines it can take a while for votes to catchup and LIB to move.

Merges `release/1.2` into `main` including #1630 

Resolves #1629 