### PR TITLE
Test: block_log_util - Allow more blocks in forkdb

### DIFF
--- a/tests/block_log_util_test.py
+++ b/tests/block_log_util_test.py
@@ -101,7 +101,8 @@ try:
     assert len(fork_db_only) + len(blockLog_only) == len(blockLog), "size mismatch"
     assert fork_db_only[0]["block_num"] == blockLog_lib+1, "first block number of fork_db_only is expected to be lib+1"
     forkdb_head = fork_db_only[-1]["block_num"]
-    assert forkdb_head == headBlockNum or forkdb_head == headBlockNum + 1, "last block number of fork_db_only is expected to be headBlockNum, or maybe headBlockNum + 1 if head advanced after getInfo"
+    assert forkdb_head >= headBlockNum and forkdb_head <= headBlockNum + 3, \
+        f"last block number {forkdb_head} of fork_db_only is expected to be headBlockNum {headBlockNum}, or maybe a few after if head advanced after getInfo"
 
     output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.smoke_test)
     expectedStr="no problems found"


### PR DESCRIPTION
Update test to allow for a few blocks in the forkdb after SIGTERM. It is possible that after `get_info` but before the node shutsdown that a few blocks are produced.

See #1633 for details.

Resolves #1633 