### PR TITLE
[1.2.0] Test: Wait on block before verification of pause

### DIFF
--- a/tests/pause_at_block_test.py
+++ b/tests/pause_at_block_test.py
@@ -64,6 +64,9 @@ try:
 
     assert prodNode.waitForLibToAdvance(), "LIB did not advance with paused nodes"
     assert prodNode2.waitForBlock(blockNum), f"Block {blockNum} did not arrive after pausing"
+    assert headNode.waitForBlock(blockNum), f"Block {blockNum} did not arrive after pausing"
+    assert specNode.waitForBlock(blockNum), f"Block {blockNum} did not arrive after pausing"
+    assert irrvNode.waitForBlock(blockNum), f"Block {blockNum} did not arrive after pausing"
 
     Utils.Print(f"Verify paused at block {blockNum}")
     assert prodNode2.getHeadBlockNum() == blockNum, "Prod Node_01 did not pause at block"


### PR DESCRIPTION
Wait on block before trying to verify that the node has not moved past it. Otherwise, it is possible that the node is not at the paused block yet when `getHeadBlockNum()` is called.

Resolves #1637