### PR TITLE
Add stricter abi version checkes in `cleos` and `abi_serializer`

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -136,11 +136,9 @@ namespace eosio { namespace chain {
       auto abi_version = abi.get_version();
       EOS_ASSERT(!!abi_version, unsupported_abi_version_exception, "Unrecognized abi version: ${v}",
                  ("v", abi.version));
-#if 0
       EOS_ASSERT(*abi_version <= current_abi_support, unsupported_abi_version_exception,
                  "ABI has an unsupported version: ${v}, current nodeos supports up to: ${vc}",
-                 ("v", std::string(version_str))("vc", current_abi_support.str()));
-#endif
+                 ("v", abi.version)("vc", current_abi_support.str()));
 
       size_t types_size = abi.types.size();
       size_t structs_size = abi.structs.size();

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -133,18 +133,14 @@ namespace eosio { namespace chain {
 
    void abi_serializer::set_abi(abi_def abi, const yield_function_t& yield) {
       impl::abi_traverse_context ctx(yield, fc::microseconds{});
-
-      static constexpr std::string version_header = "eosio::abi/";
-      EOS_ASSERT(starts_with(abi.version, version_header), unsupported_abi_version_exception,
-                 "Unexpected abi version string, should start with: " + version_header);
-
-      std::string_view version_str(abi.version.c_str() + version_header.size(), abi.version.size() - version_header.size());
-      version_t abi_version(version_str);
-      EOS_ASSERT(abi_version.is_valid(), unsupported_abi_version_exception, "Unrecognized abi version: ${v}",
-                 ("v", std::string(version_str)));
-      EOS_ASSERT(abi_version <= current_abi_support, unsupported_abi_version_exception,
+      auto abi_version = abi.get_version();
+      EOS_ASSERT(!!abi_version, unsupported_abi_version_exception, "Unrecognized abi version: ${v}",
+                 ("v", abi.version));
+#if 0
+      EOS_ASSERT(*abi_version <= current_abi_support, unsupported_abi_version_exception,
                  "ABI has an unsupported version: ${v}, current nodeos supports up to: ${vc}",
                  ("v", std::string(version_str))("vc", current_abi_support.str()));
+#endif
 
       size_t types_size = abi.types.size();
       size_t structs_size = abi.structs.size();

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -134,7 +134,17 @@ namespace eosio { namespace chain {
    void abi_serializer::set_abi(abi_def abi, const yield_function_t& yield) {
       impl::abi_traverse_context ctx(yield, fc::microseconds{});
 
-      EOS_ASSERT(starts_with(abi.version, "eosio::abi/1."), unsupported_abi_version_exception, "ABI has an unsupported version");
+      static constexpr std::string version_header = "eosio::abi/";
+      EOS_ASSERT(starts_with(abi.version, version_header), unsupported_abi_version_exception,
+                 "Unexpected abi version string, should start with: " + version_header);
+
+      std::string_view version_str(abi.version.c_str() + version_header.size(), abi.version.size() - version_header.size());
+      version_t abi_version(version_str);
+      EOS_ASSERT(abi_version.is_valid(), unsupported_abi_version_exception, "Unrecognized abi version: ${v}",
+                 ("v", std::string(version_str)));
+      EOS_ASSERT(abi_version <= current_abi_support, unsupported_abi_version_exception,
+                 "ABI has an unsupported version: ${v}, current nodeos supports up to: ${vc}",
+                 ("v", std::string(version_str))("vc", current_abi_support.str()));
 
       size_t types_size = abi.types.size();
       size_t structs_size = abi.structs.size();

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -16,6 +16,37 @@ using std::function;
 using std::pair;
 using namespace fc;
 
+struct version_t {
+   uint8_t major = 0;
+   uint8_t minor = 0;
+   bool    valid = false;
+
+   version_t(uint8_t major, uint8_t minor) : major(major), minor(minor), valid(true) {}
+
+   version_t(std::string_view sv) {
+      auto last = sv.data() + sv.size();
+      auto [ptr, ec] = std::from_chars(sv.data(), last, major);
+      if (ec == std::errc() && *ptr == '.')
+         valid = (std::from_chars(ptr+1, last, minor).ec == std::errc());
+   }
+
+   friend auto operator<=>(const version_t&, const version_t&) = default;
+   friend bool operator==(const version_t&, const version_t&) = default;
+
+   std::string str() const {
+      std::ostringstream oss;
+      oss << std::to_string(major) << '.' << std::to_string(minor);
+      return oss.str();
+   }
+
+   bool is_valid() const {
+      return valid;
+   }
+
+};
+
+inline static const version_t current_abi_support(1, 3); // 1.3 adds support for bitset and fixed size arrays
+
 namespace impl {
    struct abi_from_variant;
    struct abi_to_variant;

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -16,36 +16,14 @@ using std::function;
 using std::pair;
 using namespace fc;
 
-struct version_t {
-   uint8_t major = 0;
-   uint8_t minor = 0;
-   bool    valid = false;
-
-   version_t(uint8_t major, uint8_t minor) : major(major), minor(minor), valid(true) {}
-
-   version_t(std::string_view sv) {
-      auto last = sv.data() + sv.size();
-      auto [ptr, ec] = std::from_chars(sv.data(), last, major);
-      if (ec == std::errc() && *ptr == '.')
-         valid = (std::from_chars(ptr+1, last, minor).ec == std::errc());
-   }
-
-   friend auto operator<=>(const version_t&, const version_t&) = default;
-   friend bool operator==(const version_t&, const version_t&) = default;
-
-   std::string str() const {
-      std::ostringstream oss;
-      oss << std::to_string(major) << '.' << std::to_string(minor);
-      return oss.str();
-   }
-
-   bool is_valid() const {
-      return valid;
-   }
-
-};
-
-inline static const version_t current_abi_support(1, 3); // 1.3 adds support for bitset and fixed size arrays
+// ---------------------------
+// 1.1  variants
+//      binary extensions
+// 1.2  action return values
+// 1.3  bitset
+//      sync calls
+// ---------------------------
+inline static const version_t current_abi_support(1, 3);
 
 namespace impl {
    struct abi_from_variant;

--- a/plugins/trace_api_plugin/test/test_data_handlers.cpp
+++ b/plugins/trace_api_plugin/test/test_data_handlers.cpp
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          },
          {}, {}, {}
       );
-      abi.version = "eosio::abi/1.";
+      abi.version = "eosio::abi/1.0";
 
       abi_data_handler handler(exception_handler{});
       handler.add_abi("alice"_n, std::move(abi));
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          },
          {}, {}, {}
       );
-      abi.version = "eosio::abi/1.";
+      abi.version = "eosio::abi/1.0";
       abi.action_results = { std::vector<chain::action_result_def>{ chain::action_result_def{ "foo"_n, "foor"} } };
 
       abi_data_handler handler(exception_handler{});
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          },
          {}, {}, {}
       );
-      abi.version = "eosio::abi/1.";
+      abi.version = "eosio::abi/1.0";
 
       abi_data_handler handler(exception_handler{});
       handler.add_abi("alice"_n, std::move(abi));
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          },
          {}, {}, {}
       );
-      abi.version = "eosio::abi/1.";
+      abi.version = "eosio::abi/1.0";
 
       abi_data_handler handler(exception_handler{});
       handler.add_abi("alice"_n, std::move(abi));
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          },
          {}, {}, {}
       );
-      abi.version = "eosio::abi/1.";
+      abi.version = "eosio::abi/1.0";
 
       bool log_called = false;
       abi_data_handler handler([&log_called](const exception_with_context& ){log_called = true;});
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_SUITE(abi_data_handler_tests)
          },
          {}, {}, {}
       );
-      abi.version = "eosio::abi/1.";
+      abi.version = "eosio::abi/1.0";
 
       abi_data_handler handler(exception_handler{});
       handler.add_abi("alice"_n, std::move(abi));

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -355,26 +355,50 @@ chain::action generate_nonce_action() {
    return chain::action( {}, config::null_account_name, name("nonce"), fc::raw::pack(fc::time_point::now().time_since_epoch().count()));
 }
 
+template <class F>
+bool abi_valid(const abi_def& abi, F&& f) {
+   std::optional<version_t> abi_ver(abi.get_version());
+   if (abi_ver && abi_ver <= current_abi_support)
+      return true;
+
+   if (!abi_ver)
+      std::cerr << std::forward<F>(f)() << " has an unrecognized version: " << abi.version << '\n';
+   else
+      std::cerr << std::forward<F>(f)() << " (" << abi_ver->str() << ") is higher than supported by cleos ("
+                << current_abi_support.str() << "). Please upgrade.\n";
+   return false;
+}
+
 //resolver for ABI serializer to decode actions in proposed transaction in multisig contract
 auto abi_serializer_resolver = [](const name& account) -> std::optional<abi_serializer> {
    static unordered_map<account_name, std::optional<abi_serializer> > abi_cache;
    auto it = abi_cache.find( account );
    if ( it == abi_cache.end() ) {
-      std::optional<abi_serializer> abis;
+      std::optional<abi_def> abi;
       if (abi_files_override.find(account) != abi_files_override.end()) {
-         abis.emplace( fc::json::from_file(abi_files_override[account]).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ));
+         abi.emplace(fc::json::from_file(abi_files_override[account]).as<abi_def>());
       } else {
          const auto raw_abi_result = call(get_raw_abi_func, fc::mutable_variant_object("account_name", account));
          const auto raw_abi_blob = raw_abi_result["abi"].as_blob().data;
          if (raw_abi_blob.size() != 0) {
-            abis.emplace(fc::raw::unpack<abi_def>(raw_abi_blob), abi_serializer::create_yield_function( abi_serializer_max_time ));
+            abi.emplace(fc::raw::unpack<abi_def>(raw_abi_blob));
          } else {
             std::cerr << "ABI for contract " << account.to_string() << " not found. Action data will be shown in hex only." << std::endl;
          }
       }
-      abi_cache.emplace( account, abis );
 
-      return abis;
+      std::optional<abi_serializer> ser;
+      if (abi) {
+         if (abi_valid(*abi, [&]() -> std::string {
+            std::ostringstream oss;
+            oss << "ABI for contract \"" << account.to_string() << "\"";
+            return oss.str();
+         })) {
+            ser.emplace(abi_serializer(std::move(*abi), abi_serializer::create_yield_function(abi_serializer_max_time)));
+         }
+      }
+      abi_cache.emplace(account, ser);
+      return ser;
    }
    return it->second;
 };
@@ -3565,9 +3589,9 @@ int main( int argc, char** argv ) {
 
         EOS_ASSERT( std::filesystem::exists( abiPath ), abi_file_not_found, "no abi file found ${f}", ("f", abiPath)  );
 
-        abi_bytes = fc::raw::pack(fc::json::from_file(abiPath).as<abi_def>());
-      } else {
-        abi_bytes = bytes();
+        auto abi = fc::json::from_file(abiPath).as<abi_def>();
+        FC_ASSERT( abi_valid(abi, []() { return std::string{"ABI"}; }), "Incorrect ABI version");
+        abi_bytes = fc::raw::pack(abi);
       }
 
       if (!suppress_duplicate_check) {


### PR DESCRIPTION
Resolves #1580.