### PR TITLE
[1.2.1 -> main] Test: Modify sync test to sync from the same node

### DIFF
--- a/tests/p2p_sync_throttle_test.py
+++ b/tests/p2p_sync_throttle_test.py
@@ -52,8 +52,8 @@ try:
     Print("Stand up cluster")
     # Custom topology:
     #    prodNode <-> nonProdNode
-    #                             <-> throttlingNode <-> throttledNode
-    #                             <-> unThrottledNode
+    #                             <-> throttlingNode <-> throttledNode  (20KB/s)
+    #                                                <-> unThrottledNode (1TB/s)
     #
     # Compare the sync time of throttledNode and unThrottledNode
     if cluster.launch(pnodes=pnodes, unstartedNodes=3, totalNodes=total_nodes, prodCount=prod_count,
@@ -109,17 +109,24 @@ try:
     throttlingNode.cmd[i+1] = throttlingNode.cmd[i+1] + ':20KB/s'
     throttleListenIP, throttleListenPort = throttleListenAddr.split(':')
     throttlingNode.cmd.append('--p2p-listen-endpoint')
-    throttlingNode.cmd.append(f'{throttleListenIP}:{int(throttleListenPort)+100}:1TB/s')
+    unThrottleListenAddr = f'{throttleListenIP}:{int(throttleListenPort)+100}'
+    throttlingNode.cmd.append(f'{unThrottleListenAddr}:1TB/s')
 
     cluster.biosNode.kill(signal.SIGTERM)
 
     Print("Launch throttling node")
     cluster.launchUnstarted(1)
-
     assert throttlingNode.verifyAlive(), "throttling node did not launch"
 
     # Throttling node was offline during block generation and once online receives blocks as fast as possible
     assert throttlingNode.waitForBlock(endLargeBlocksHeadBlock), f'wait for block {endLargeBlocksHeadBlock}  on throttled node timed out'
+
+    throttledNode = cluster.unstartedNodes[0]
+    throttledNode.cmd.append('--p2p-peer-address')
+    throttledNode.cmd.append(throttleListenAddr)
+    unThrottledNode = cluster.unstartedNodes[1]
+    unThrottledNode.cmd.append('--p2p-peer-address')
+    unThrottledNode.cmd.append(unThrottleListenAddr)
 
     Print("Launch throttled and un-throttled nodes")
     clusterStart = time.time()

--- a/tests/p2p_sync_throttle_test_shape.json
+++ b/tests/p2p_sync_throttle_test_shape.json
@@ -132,7 +132,6 @@
         }
       ],
       "peers": [
-        "testnet_02"
       ],
       "producers": [],
       "dont_start": true,
@@ -156,7 +155,6 @@
         }
       ],
       "peers": [
-        "testnet_01"
       ],
       "producers": [],
       "dont_start": true,


### PR DESCRIPTION
In an attempt to make the `p2p_sync_throttle_test` more stable and fair, sync both the throttled node and unthrottled node from the same peer.

Merges `release/1.2` into `main` including #1647 

Resolves #1643
