### PR TITLE
[1.2.1 -> main] Test: Do not error when there is an in-coming connection

### DIFF
--- a/tests/auto_bp_gossip_peering_test.py
+++ b/tests/auto_bp_gossip_peering_test.py
@@ -241,6 +241,8 @@ try:
         if conn["is_socket_open"] is False:
             continue
         peer_addr = conn["peer"]
+        if len(peer_addr) == 0:
+            continue
         found.append(peer_names[peer_addr])
 
     Print(f"Found connections of Node_03: {found}")


### PR DESCRIPTION
Ignore in-coming connection when evaluating the connected peers.

Merges `release/1.2` into `main` including #1657 

Resolves #1656