### PR TITLE
[1.2.1 -> main] Test: Wait on node to stop advancing LIB

### DIFF
--- a/tests/disaster_recovery_3.py
+++ b/tests/disaster_recovery_3.py
@@ -79,15 +79,21 @@ try:
     assert node1.waitForLibToAdvance(), "Node1 did not advance LIB after snapshot of Node0"
     assert node0.waitForLibToAdvance(), "Node0 did not advance LIB after snapshot"
 
-    Print("Stop production on Node0 and Node1")
+    Print("Stop production on all nodes")
     assert node0.waitForProducer("defproducera"), "Node 0 did not produce"
-    for node in [node0, node1]:
+    for node in [node0, node1, node2, node3]:
         node.processUrllibRequest("producer", "pause", exitOnError=True)
-    node0.waitForLibNotToAdvance()
+    assert node0.waitForLibNotToAdvance(), "Node0 LIB is still advancing"
 
     currentLIB = node0.getIrreversibleBlockNum()
+    currentLIB1 = node1.getIrreversibleBlockNum()
+    assert currentLIB == currentLIB1, f"Node0 {currentLIB} and Node1 {currentLIB1} LIBs do not match"
     n_LIB = currentLIB + 1
     libBlock = node0.getBlock(n_LIB)
+
+    Print("Resume production on Node2 and Node3")
+    for node in [node2, node3]:
+        node.processUrllibRequest("producer", "resume", exitOnError=True)
 
     Print("Shutdown two nodes at LIB N-1, should be locked on block after N")
     for node in [node0, node1]:


### PR DESCRIPTION
Wait on node to stop advancing LIB and verify both nodes are the same LIB after LIB has stopped.
The test was previously not stopping LIB. It should now be more reliable as production is paused on all nodes and LIB is verified to be stopped.

Merges `release/1.2` into `main` including #1659

Resolves #1658 