### PR TITLE
[2.0.0-dev] Rethrow correct transaction trace type

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1307,8 +1307,8 @@ struct controller_impl {
 
          if( trace->except_ptr )
             std::rethrow_exception(trace->except_ptr);
-         if( trace->except)
-            trace->except->rethrow();
+         if(trace->except)
+            assert(trace->except_ptr); // except/except_ptr always set together
          getpeerkeys_res_t res;
          if (!trace->action_traces.empty()) {
             const auto& act_trace = trace->action_traces[0];
@@ -3376,7 +3376,8 @@ struct controller_impl {
             if( onblock_trace->except ) {
                if (onblock_trace->except->code() == interrupt_exception::code_value) {
                   ilog("Interrupt of onblock ${bn}", ("bn", chain_head.block_num() + 1));
-                  onblock_trace->except->rethrow();
+                  assert(onblock_trace->except_ptr); // always set together
+                  std::rethrow_exception(onblock_trace->except_ptr);
                }
                wlog("onblock ${block_num} is REJECTING: ${entire_trace}",
                     ("block_num", chain_head.block_num() + 1)("entire_trace", onblock_trace));
@@ -3898,7 +3899,8 @@ struct controller_impl {
                   } else {
                      edump((*trace));
                   }
-                  trace->except->rethrow();
+                  assert(trace->except_ptr); // always set together
+                  std::rethrow_exception(trace->except_ptr);
                }
 
                EOS_ASSERT(trx_receipts.size() > 0, block_validate_exception,

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -491,7 +491,8 @@ namespace eosio::testing {
          for( auto itr = unapplied_transactions.begin(); itr != unapplied_transactions.end();  ) {
             auto trace = control->push_transaction( itr->trx_meta, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true, 0 );
             if(!no_throw && trace->except) {
-               trace->except->rethrow();
+               assert(trace->except_ptr);
+               std::rethrow_exception(trace->except_ptr);
             }
             itr = unapplied_transactions.erase( itr );
             res.unapplied_transaction_traces.emplace_back( std::move(trace) );
@@ -502,7 +503,8 @@ namespace eosio::testing {
             for( const auto& trx : scheduled_trxs ) {
                auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
                if( !no_throw && trace->except ) {
-                  trace->except->rethrow();
+                  assert(trace->except_ptr);
+                  std::rethrow_exception(trace->except_ptr);
                }
             }
          }
@@ -735,7 +737,6 @@ namespace eosio::testing {
       auto fut = transaction_metadata::start_recover_keys( ptrx, control->get_thread_pool(), control->get_chain_id(), time_limit, transaction_metadata::trx_type::input );
       auto r = control->push_transaction( fut.get(), deadline, fc::microseconds::maximum(), billed_cpu_time_us, billed_cpu_time_us > 0, 0 );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except ) r->except->rethrow();
       return r;
    } FC_RETHROW_EXCEPTIONS( warn, "transaction_header: ${header}", ("header", transaction_header(trx.get_transaction()) )) }
 
@@ -762,7 +763,6 @@ namespace eosio::testing {
       auto r = control->push_transaction( fut.get(), deadline, fc::microseconds::maximum(), billed_cpu_time_us, billed_cpu_time_us > 0, 0 );
       if (no_throw) return r;
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except)  r->except->rethrow();
       return r;
    } FC_RETHROW_EXCEPTIONS( warn, "transaction_header: ${header}, billed_cpu_time_us: ${billed}",
                             ("header", transaction_header(trx) ) ("billed", billed_cpu_time_us))

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1005,7 +1005,6 @@ void transaction_tests(T& chain) {
       auto fut = transaction_metadata::start_recover_keys( std::move( ptrx ), chain.control->get_thread_pool(), chain.get_chain_id(), time_limit, transaction_metadata::trx_type::input );
       auto r = chain.control->push_transaction( fut.get(), fc::time_point::maximum(), fc::microseconds::maximum(), T::DEFAULT_BILLED_CPU_TIME_US, true, 0 );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except) r->except->rethrow();
       tx_trace = r;
       chain.produce_block();
       BOOST_CHECK(tx_trace->action_traces.front().console == sha_expect);

--- a/unittests/checktime_tests.cpp
+++ b/unittests/checktime_tests.cpp
@@ -143,8 +143,7 @@ BOOST_AUTO_TEST_CASE( checktime_interrupt_test) { try {
    } );
 
    // apply block, caught in an "infinite" loop
-   BOOST_CHECK_EXCEPTION( other.push_block(signed_block::create_signed_block(std::move(copy_b))), fc::exception,
-                          [](const fc::exception& e) { return e.code() == interrupt_exception::code_value; } );
+   BOOST_CHECK_THROW( other.push_block(signed_block::create_signed_block(std::move(copy_b))), interrupt_exception);
 
    th.join();
 

--- a/unittests/test_utils.hpp
+++ b/unittests/test_utils.hpp
@@ -96,7 +96,6 @@ void push_trx(Tester& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cpu
    auto res = test.control->push_transaction( fut.get(), fc::time_point::now() + fc::milliseconds(max_block_cpu_ms),
                                               fc::milliseconds(max_cpu_usage_ms), billed_cpu_time_us, explicit_bill, 0 );
    if( res->except_ptr ) std::rethrow_exception( res->except_ptr );
-   if( res->except ) res->except->rethrow();
 };
 
 static constexpr unsigned int DJBH(const char* cp) {

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -2000,7 +2000,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( billed_cpu_test, T, testers ) try {
                      uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time, uint32_t subjective_cpu_bill_us ) {
       auto r = chain.control->push_transaction( trx, deadline, fc::microseconds::maximum(), billed_cpu_time_us, explicit_billed_cpu_time, subjective_cpu_bill_us );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except ) r->except->rethrow();
       return r;
    };
 


### PR DESCRIPTION
`transaction_trace::except` slices exception on storage. When rethrowing trace exceptions, use `transaction_trace::except_ptr` which preserves the exception type.

Resolves #1667 