### PR TITLE
[1.2.1] Report error on invalid block

### DIFF
--- a/unittests/blocks_log_replay_tests.cpp
+++ b/unittests/blocks_log_replay_tests.cpp
@@ -158,14 +158,20 @@ BOOST_FIXTURE_TEST_CASE(replay_stop_multiple, blog_replay_fixture) try {
    stop_and_resume_replay(last_head_block_num - 3);
 } FC_LOG_AND_RETHROW()
 
-void currupt_blocks_log(path block_dir) {
+void currupt_blocks_log(path block_dir, block_num_type block_num) {
+   fc::datastream<fc::cfile> index_file;
+   index_file.set_file_path(block_dir / "blocks.index");
+   index_file.open(fc::cfile::update_rw_mode);
+   index_file.seek(sizeof(uint64_t) * (block_num + 1));
+   uint64_t pos = 0;
+   index_file.read((char*)&pos, sizeof(pos));
+   index_file.close();
+
    fc::datastream<fc::cfile> blockslog;
    std::string bad_str = "bad corruption";
    blockslog.set_file_path(block_dir / "blocks.log");
    blockslog.open(fc::cfile::update_rw_mode);
-   blockslog.seek_end(0);
-   size_t size = blockslog.tellp();
-   blockslog.seek(size/2);
+   blockslog.seek(pos);
    blockslog.write((char*)&bad_str, bad_str.size());
    blockslog.flush();
    blockslog.close();
@@ -186,7 +192,7 @@ BOOST_FIXTURE_TEST_CASE(replay_exception, blog_replay_fixture) try {
    std::filesystem::copy(copied_config.blocks_dir / "blocks.log", tmp_dir.path() / "blocks.log");
    std::filesystem::copy(copied_config.blocks_dir / "blocks.index", tmp_dir.path() / "blocks.index");
 
-   currupt_blocks_log(copied_config.blocks_dir);
+   currupt_blocks_log(copied_config.blocks_dir, last_irreversible_block_num-5);
 
    bool exception_thrown = false;
    try {


### PR DESCRIPTION
Switch from `assert` to `EOS_ASSERT` for better error reporting while validating blocks.

Resolves #1671 