### PR TITLE
[1.2.1] P2P: Fix repeated sync request on rejected blocks

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2398,11 +2398,6 @@ namespace eosio {
    // called from connection strand
    void sync_manager::rejected_block( const connection_ptr& c, uint32_t blk_num, closing_mode mode ) {
       c->block_status_monitor_.rejected();
-      // reset sync on rejected block
-      fc::unique_lock g( sync_mtx );
-      sync_last_requested_num = 0;
-      sync_next_expected_num = my_impl->get_fork_db_root_num() + 1;
-      g.unlock();
       if( mode == closing_mode::immediately || c->block_status_monitor_.max_events_violated()) {
          peer_wlog(c, "block ${bn} not accepted, closing connection ${d}",
                    ("d", mode == closing_mode::immediately ? "immediately" : "max violations reached")("bn", blk_num));


### PR DESCRIPTION
When syncing and an `unlinkable` block is encountered, do not reset the sync as this is not needed and it causes the sync to repeatedly be restarted for each successive unlinkable block.

For example:
```
info  2025-07-01T21:22:47.710 net-0     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
info  2025-07-01T21:22:47.710 net-2     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
info  2025-07-01T21:22:47.710 net-2     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
info  2025-07-01T21:22:47.711 net-0     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
info  2025-07-01T21:22:47.711 net-3     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
```

Resolves the most important part of #1673