### PR TITLE
Remove retire_deferred_trxs from producer_plugin

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -227,7 +227,6 @@ namespace eosio::chain {
           *
           */
          transaction_trace_ptr push_scheduled_transaction( const transaction_id_type& scheduled,
-                                                           fc::time_point block_deadline, fc::microseconds max_transaction_time,
                                                            uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time );
 
          void assemble_and_complete_block( const signer_callback_type& signer_callback );

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -501,7 +501,7 @@ namespace eosio::testing {
          vector<transaction_id_type> scheduled_trxs;
          while ((scheduled_trxs = get_scheduled_transactions()).size() > 0 ) {
             for( const auto& trx : scheduled_trxs ) {
-               auto trace = control->push_scheduled_transaction( trx, fc::time_point::maximum(), fc::microseconds::maximum(), DEFAULT_BILLED_CPU_TIME_US, true );
+               auto trace = control->push_scheduled_transaction( trx, DEFAULT_BILLED_CPU_TIME_US, true );
                if( !no_throw && trace->except ) {
                   // this always throws an fc::exception, since the original exception is copied into an fc::exception
                   throw *trace->except;

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1171,7 +1171,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester_no_disable
       auto dtrxs = get_scheduled_transactions();
       BOOST_CHECK_EQUAL(dtrxs.size(), 1);
       for (const auto& trx: dtrxs) {
-         control->push_scheduled_transaction(trx, fc::time_point::maximum(), fc::microseconds::maximum(), 0, false);
+         control->push_scheduled_transaction(trx, 0, false);
       }
       BOOST_CHECK_EQUAL(1, count);
       BOOST_REQUIRE(trace);
@@ -1198,7 +1198,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, validating_tester_no_disable
       auto dtrxs = get_scheduled_transactions();
       BOOST_CHECK_EQUAL(dtrxs.size(), 1);
       for (const auto& trx: dtrxs) {
-         control->push_scheduled_transaction(trx, fc::time_point::maximum(), fc::microseconds::maximum(), billed_cpu_time_us, true);
+         control->push_scheduled_transaction(trx, billed_cpu_time_us, true);
       }
       BOOST_CHECK_EQUAL(1, count);
       BOOST_CHECK(trace);

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -205,7 +205,7 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester_no_disabl
    BOOST_REQUIRE_EQUAL(scheduled_trxs.size(), 1u);
 
    auto billed_cpu_time_us = control->get_global_properties().configuration.min_transaction_cpu_usage;
-   auto dtrace = control->push_scheduled_transaction(scheduled_trxs.front(), fc::time_point::maximum(), fc::microseconds::maximum(), billed_cpu_time_us, true);
+   auto dtrace = control->push_scheduled_transaction(scheduled_trxs.front(), billed_cpu_time_us, true);
    BOOST_REQUIRE_EQUAL(dtrace->except.has_value(), true);
    BOOST_REQUIRE_EQUAL(dtrace->except->code(), missing_auth_exception::code_value);
 

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -2089,8 +2089,7 @@ BOOST_AUTO_TEST_CASE( disable_deferred_trxs_stage_1_retire_test ) { try {
    }
 
    // attemp to retire the trx
-   auto deadline = fc::time_point::now() + fc::milliseconds(10); // 10ms more than enough
-   auto trace = c.control->push_scheduled_transaction(trx_id, deadline, fc::microseconds::maximum(), 0, false);
+   auto trace = c.control->push_scheduled_transaction(trx_id, 0, false);
 
    // the trx was retired as "expired" and RAM was refunded even though delay_until not reached
    BOOST_REQUIRE_EQUAL( trace->receipt->status, transaction_receipt::expired );


### PR DESCRIPTION
No longer need `retire_deferred_trxs` in `producer_plugin`.

Resolves #1149 