### PR TITLE
[1.2.1 -> main] P2P: Fix repeated sync request on rejected blocks

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2415,11 +2415,6 @@ namespace eosio {
    // called from connection strand
    void sync_manager::rejected_block( const connection_ptr& c, uint32_t blk_num, closing_mode mode ) {
       c->block_status_monitor_.rejected();
-      // reset sync on rejected block
-      fc::unique_lock g( sync_mtx );
-      sync_last_requested_num = 0;
-      sync_next_expected_num = my_impl->get_fork_db_root_num() + 1;
-      g.unlock();
       if( mode == closing_mode::immediately || c->block_status_monitor_.max_events_violated()) {
          peer_wlog(p2p_blk_log, c, "block ${bn} not accepted, closing connection ${d}",
                    ("d", mode == closing_mode::immediately ? "immediately" : "max violations reached")("bn", blk_num));


### PR DESCRIPTION
When syncing and an `unlinkable` block is encountered, do not reset the sync as this is not needed and it causes the sync to repeatedly be restarted for each successive unlinkable block.

For example:
```
info  2025-07-01T21:22:47.710 net-0     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
info  2025-07-01T21:22:47.710 net-2     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
info  2025-07-01T21:22:47.710 net-2     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
info  2025-07-01T21:22:47.711 net-0     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
info  2025-07-01T21:22:47.711 net-3     net_plugin.cpp:2073           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 36 to 1035, fhead 131, froot 35
```

After, still has the close because of invalid block which we are not planning on fixing:
```
info  2025-07-02T16:50:08.709 net-3     net_plugin.cpp:1914           set_state            ] old state in sync becoming lib catchup
info  2025-07-02T16:50:08.709 net-3     net_plugin.cpp:2015           request_next_chunk   ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] Catching up with chain, our last req is 0, theirs is 778926, next expected 2, fhead 1
info  2025-07-02T16:50:08.709 net-3     net_plugin.cpp:2054           operator()           ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] requesting range 2 to 1001, fhead 1, froot 1
info  2025-07-02T16:50:08.710 net-3     net_plugin.cpp:3356           handle_message       ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] Local network version different: 11 Remote version: 12
debug 2025-07-02T16:50:08.740 nodeos    producer_plugin.cpp:312       report               ] Block #2 eosio trx idle: 209787us out of 210627us, success: 0, 0us, fail: 0, 0us, transient: 0, 0us, other: 840us
warn  2025-07-02T16:50:08.985 net-1     net_plugin.cpp:2403           rejected_block       ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] block 382 not accepted, closing connection max violations reached
info  2025-07-02T16:50:08.985 net-1     net_plugin.cpp:1417           _close               ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] closing
warn  2025-07-02T16:50:08.986 net-1     net_plugin.cpp:2037           request_next_chunk   ] Unable to continue syncing at this time
info  2025-07-02T16:50:08.986 net-1     net_plugin.cpp:1914           set_state            ] old state lib catchup becoming in sync
info  2025-07-02T16:50:09.118 nodeos    controller.cpp:5742           set_proposed_produce ] proposed producer schedule with version 1
info  2025-07-02T16:50:09.130 nodeos    controller.cpp:3333           operator()           ] promoting proposed schedule (set in block 37) to pending; current block: 38 lib: 37 schedule: {"version":1,"producers":[{"producer_name":"bpa","authority":[0,{"threshold":1,"keys":[{"key":"EOS7d2orL4dVtNVGkKbm7JTBLgdMmjqX26QetGy1AQu4YAZCGH2ec","weight":1}]}]},{"producer_name":"bpb","authority":[0,{"threshold":1,"keys":[{"key":"EOS7pwwGiEmVnVMRBETXbYuZhJG9s4SwNuFXwVrCtEPWr5j2gHAS7","weight":1}]}]},{"producer_name":"bpc","authority":[0,{"threshold":1,"keys":[{"key":"EOS8aeuQbh7EN6Xm11HnLUBLo6HqFVtXWC4wSWwDrDdeXvEAN7GJs","weight":1}]}]}]}
info  2025-07-02T16:50:09.198 nodeos    controller.cpp:1489           transition_to_savann ] Transitioning to savanna, IF Genesis Block 90, IF Critical Block 131
info  2025-07-02T16:50:09.201 nodeos    controller.cpp:1534           operator()           ] Transition to instant finality happening after block 131, First IF Proper Block 132
info  2025-07-02T16:50:09.258 net-0     net_plugin.cpp:1914           set_state            ] old state in sync becoming lib catchup
info  2025-07-02T16:50:09.258 net-0     net_plugin.cpp:2015           request_next_chunk   ] ["p2p.testnet-1.vaulta.com:3444" - 1 52.71.134.149:3444] Catching up with chain, our last req is 0, theirs is 778927, next expected 91, fhead 131
```

Merges `release/1.2` into `main` including #1676

Resolves the most important part of #1673