### PR TITLE
CLI: Add URI to cleos error message

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -63,13 +63,13 @@ fc::variant do_http_call(const config_t& config, const std::string& base_uri, co
       } else if( status_code == 404 ) {
          // Unknown endpoint
          if (path.compare(0, chain_func_base.size(), chain_func_base) == 0) {
-            throw chain::missing_chain_api_plugin_exception(FC_LOG_MESSAGE(error, "Chain API plugin is not enabled on specified endpoint"));
+            throw chain::missing_chain_api_plugin_exception(FC_LOG_MESSAGE(error, "Chain API plugin is not enabled on endpoint: ${e}", ("e", base_uri)));
          } else if (path.compare(0, wallet_func_base.size(), wallet_func_base) == 0) {
-            throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available on specified endpoint"));
+            throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available on endpoint: ${e}", ("e", base_uri)));
          } else if (path.compare(0, history_func_base.size(), history_func_base) == 0) {
-            throw chain::missing_history_api_plugin_exception(FC_LOG_MESSAGE(error, "History API support is not enabled on specified endpoint"));
+            throw chain::missing_history_api_plugin_exception(FC_LOG_MESSAGE(error, "History API support is not enabled on endpoint: ${e}", ("e", base_uri)));
          } else if (path.compare(0, net_func_base.size(), net_func_base) == 0) {
-            throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled on specified endpoint"));
+            throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled on endpoint: ${e}", ("e", base_uri)));
          }
       } else {
          auto &&error_info = response_result.as<eosio::error_results>().error;


### PR DESCRIPTION
Add the URI to `cleos` error message of endpoint misconfiguration.

```
07/7/25 10:34:47 ➜  bin git:(GH-990-ship-index-check) ✗ ./cleos get info
Error 3110001: Missing Chain API Plugin
Ensure that you have eosio::chain_api_plugin added to your node's configuration and enabled on the specified endpoint.
For example:
http-server-address   = http-category-address
http-category-address = chain_ro,127.0.0.1:8081
http-category-address = chain_rw,[::]:8083
Error Details:
Chain API plugin is not enabled on endpoint: http://127.0.0.1:8888
```

Resolves #1683 