### PR TITLE
Update tester to allow for a more flexible configuration of its state.

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -488,11 +488,10 @@ namespace eosio::testing {
          }
 
          void schedule_protocol_features_wo_preactivation(const vector<digest_type>& feature_digests);
-         void preactivate_protocol_features(const vector<digest_type>& feature_digests);
-         void preactivate_builtin_protocol_features(const std::vector<builtin_protocol_feature_t>& features);
-         void preactivate_all_builtin_protocol_features();
-         void preactivate_all_but_disable_deferred_trx();
-         void preactivate_savanna_protocol_features();
+         void activate_protocol_features(const vector<digest_type>& feature_digests);
+         void activate_builtin_protocol_features(const std::vector<builtin_protocol_feature_t>& features);
+         void activate_all_builtin_protocol_features();
+         void activate_all_but_disable_deferred_trx();
 
          static genesis_state default_genesis() {
             genesis_state genesis;

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -85,7 +85,7 @@ namespace eosio::testing {
       static const setup_policy preactivate_feature_only;
       static const setup_policy preactivate_feature_and_new_bios;
       static const setup_policy old_wasm_parser;
-      static const setup_policy full_except_do_not_disable_deferred_trx;
+      static const setup_policy before_disable_deferred_trx;
       static const setup_policy full_except_do_not_transition_to_savanna;
       static const setup_policy full;
    };
@@ -746,7 +746,7 @@ namespace eosio::testing {
 
    class tester_no_disable_deferred_trx : public tester {
    public:
-      tester_no_disable_deferred_trx(): tester(setup_policy::full_except_do_not_disable_deferred_trx) {
+      tester_no_disable_deferred_trx(): tester(setup_policy::before_disable_deferred_trx) {
       }
    };
 
@@ -877,7 +877,7 @@ namespace eosio::testing {
    class validating_tester_no_disable_deferred_trx : public validating_tester {
    public:
       validating_tester_no_disable_deferred_trx()
-         : validating_tester({}, nullptr, setup_policy::full_except_do_not_disable_deferred_trx) {}
+         : validating_tester({}, nullptr, setup_policy::before_disable_deferred_trx) {}
    };
 
    // The behavior of legacy_validating_tester is activating all the protocol features

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -32,7 +32,7 @@ std::ostream& operator<<( std::ostream& osm, const fc::variant_object::entry& e 
 
 eosio::chain::asset core_from_string(const std::string& s);
 
-namespace boost { namespace test_tools { namespace tt_detail {
+namespace boost::test_tools::tt_detail {
 
    template<>
    struct print_log_value<fc::variant> {
@@ -58,7 +58,7 @@ namespace boost { namespace test_tools { namespace tt_detail {
       }
    };
 
-} } }
+}
 
 namespace eosio::testing {
 

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -63,7 +63,6 @@ namespace boost { namespace test_tools { namespace tt_detail {
 namespace eosio::testing {
    enum class setup_policy {
       none,
-      old_bios_only,
       preactivate_feature_only,
       preactivate_feature_and_new_bios,
       old_wasm_parser,

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -58,7 +58,7 @@ namespace eosio::testing {
        builtin_protocol_feature_t::bls_primitives}
    };
 
-   const setup_policy setup_policy::full_except_do_not_disable_deferred_trx {
+   const setup_policy setup_policy::before_disable_deferred_trx {
       {setup_action::preactivate_protocol_feature,
        setup_action::set_before_producer_authority_bios_contract,
        setup_action::activate_features},
@@ -115,7 +115,7 @@ namespace eosio::testing {
          os << "preactivate_feature_and_new_bios";
       else if (p == setup_policy::old_wasm_parser)
          os << "old_wasm_parser";
-      else if (p == setup_policy::full_except_do_not_disable_deferred_trx)
+      else if (p == setup_policy::before_disable_deferred_trx)
          os << "full_except_do_not_disable_deferred_trx";
       else if (p == setup_policy::full_except_do_not_transition_to_savanna)
          os << "full_except_do_not_transition_to_savanna";
@@ -336,7 +336,7 @@ namespace eosio::testing {
          }
 
          case setup_action::activate_savanna: {
-            // BLS voting is slow. Use only 1 finalizer for default testser.
+            // BLS voting is slow. Use only 1 finalizer for default tester.
             finalizer_keys fin_keys(*this, 1u /* num_keys */, 1u /* finset_size */);
             fin_keys.activate_savanna(0u /* first_key_idx */);
             break;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -33,9 +33,6 @@ namespace eosio::testing {
          case setup_policy::none:
             os << "none";
             break;
-         case setup_policy::old_bios_only:
-            os << "old_bios_only";
-            break;
          case setup_policy::preactivate_feature_only:
             os << "preactivate_feature_only";
             break;
@@ -234,10 +231,10 @@ namespace eosio::testing {
       };
 
       switch (policy) {
-         case setup_policy::old_bios_only: {
-            set_before_preactivate_bios_contract();
+         case setup_policy::none:
+         default:
             break;
-         }
+
          case setup_policy::preactivate_feature_only: {
             schedule_preactivate_protocol_feature();
             produce_block(); // block production is required to activate protocol feature
@@ -297,9 +294,6 @@ namespace eosio::testing {
 
             break;
          }
-         case setup_policy::none:
-         default:
-            break;
       };
    }
 

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
    BOOST_TEST(!parms.chain_config.get_object().contains("max_action_return_value_size"));
    BOOST_TEST(!parms.wasm_config);
 
-   t.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::action_return_value} );
+   t.activate_builtin_protocol_features( {builtin_protocol_feature_t::action_return_value} );
    t.produce_block();
 
    parms = plugin.get_consensus_parameters({}, fc::time_point::maximum());
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE( get_consensus_parameters ) try {
    BOOST_TEST(v1config.max_action_return_value_size == t.control->get_global_properties().configuration.max_action_return_value_size);
    BOOST_TEST(!parms.wasm_config);
 
-   t.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::configurable_wasm_limits} );
+   t.activate_builtin_protocol_features( {builtin_protocol_feature_t::configurable_wasm_limits} );
    t.produce_block();
    parms = plugin.get_consensus_parameters({}, fc::time_point::maximum());
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1082,8 +1082,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( inline_action_objective_limit, T, testers ) { try
 
 BOOST_AUTO_TEST_CASE(deferred_inline_action_limit) { try {
    const uint32_t _4k = 4 * 1024;
-   tester chain(setup_policy::full_except_do_not_disable_deferred_trx, db_read_mode::HEAD, {_4k + 100});
-   tester chain2(setup_policy::full_except_do_not_disable_deferred_trx, db_read_mode::HEAD, {_4k + 100});
+   tester chain(setup_policy::before_disable_deferred_trx, db_read_mode::HEAD, {_4k + 100});
+   tester chain2(setup_policy::before_disable_deferred_trx, db_read_mode::HEAD, {_4k + 100});
    signed_block_ptr block;
    for (int n=0; n < 2; ++n) {
       block = chain.produce_block();

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -437,8 +437,8 @@ BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
    fc::temp_directory tempdir;
    validating_tester chain( tempdir, true );
    chain.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
-   chain.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::action_return_value} );
-   chain.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
+   chain.activate_builtin_protocol_features( {builtin_protocol_feature_t::action_return_value} );
+   chain.activate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
 
    chain.produce_block();
    chain.create_account( "testapi"_n );
@@ -1320,8 +1320,8 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
    fc::temp_directory tempdir;
    validating_tester chain( tempdir, true );
    chain.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
-   chain.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::replace_deferred} );
-   chain.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
+   chain.activate_builtin_protocol_features( {builtin_protocol_feature_t::replace_deferred} );
+   chain.activate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    chain.produce_block();
 
    const auto& index = chain.control->db().get_index<generated_transaction_multi_index,by_id>();

--- a/unittests/bls_primitives_tests.cpp
+++ b/unittests/bls_primitives_tests.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE( bls_testg1add ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE( bls_testg2add ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE( bls_testg1weightedsum ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE( bls_testg2weightedsum ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -396,7 +396,7 @@ BOOST_AUTO_TEST_CASE( bls_testpairing ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE( bls_testg1map ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -544,7 +544,7 @@ BOOST_AUTO_TEST_CASE( bls_testg2map ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -612,7 +612,7 @@ BOOST_AUTO_TEST_CASE( bls_empty ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -659,7 +659,7 @@ BOOST_AUTO_TEST_CASE( bls_testfpmul ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -721,7 +721,7 @@ BOOST_AUTO_TEST_CASE( bls_testfpexp ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );
@@ -790,7 +790,7 @@ BOOST_AUTO_TEST_CASE( bls_testfpmod ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::bls_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::bls_primitives_test_wasm() );

--- a/unittests/crypto_primitives_tests.cpp
+++ b/unittests/crypto_primitives_tests.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE( alt_bn128_add_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE( alt_bn128_mul_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE( alt_bn128_pair_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE( modexp_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
@@ -513,7 +513,7 @@ BOOST_AUTO_TEST_CASE( modexp_subjective_limit_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE( blake2f_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
@@ -714,7 +714,7 @@ BOOST_AUTO_TEST_CASE( keccak256_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
@@ -765,7 +765,7 @@ BOOST_AUTO_TEST_CASE( sha3_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );
@@ -816,7 +816,7 @@ BOOST_AUTO_TEST_CASE( k1_recover_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::crypto_primitives );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::crypto_primitives_test_wasm() );

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -64,7 +64,7 @@ class currency_tester : public T {
          return trace;
       }
 
-      currency_tester(setup_policy p = setup_policy::full)
+      currency_tester(const setup_policy& p = setup_policy::full)
          :T({}, nullptr, p), abi_ser(json::from_string(test_contracts::eosio_token_abi()).as<abi_def>(), abi_serializer::create_yield_function( T::abi_serializer_max_time ))
       {
          T::create_account( "eosio.token"_n);

--- a/unittests/currency_tests.cpp
+++ b/unittests/currency_tests.cpp
@@ -97,7 +97,7 @@ using currency_testers = boost::mpl::list<currency_tester<legacy_validating_test
 
 class pre_disable_deferred_trx_currency_tester : public currency_tester<legacy_validating_tester> {
    public:
-      pre_disable_deferred_trx_currency_tester() : currency_tester(setup_policy::full_except_do_not_disable_deferred_trx) {}
+      pre_disable_deferred_trx_currency_tester() : currency_tester(setup_policy::before_disable_deferred_trx) {}
 };
 
 template <typename T>

--- a/unittests/get_block_num_tests.cpp
+++ b/unittests/get_block_num_tests.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE( get_block_num ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::get_block_num );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::get_block_num_test_wasm() );

--- a/unittests/params_tests.cpp
+++ b/unittests/params_tests.cpp
@@ -40,7 +40,7 @@ public:
       const auto& d = pfm.get_builtin_digest(builtin_protocol_feature_t::blockchain_parameters);
       BOOST_REQUIRE(d);
       
-      preactivate_protocol_features( {*d} );
+      activate_protocol_features( {*d} );
       produce_block();
    }
 

--- a/unittests/params_tests.cpp
+++ b/unittests/params_tests.cpp
@@ -15,7 +15,7 @@ using mvo = mutable_variant_object;
 class params_tester : public tester {
 public:
    params_tester() : tester(){}
-   params_tester(setup_policy policy) : tester(policy){}
+   params_tester(const setup_policy& policy) : tester(policy){}
 
    void setup(){
       //set parameters intrinsics are priviledged so we need system account here

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(double_activation, T, testers) try {
 
    BOOST_CHECK( !c.control->is_builtin_activated( builtin_protocol_feature_t::only_link_to_existing_permission ) );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
 
    BOOST_CHECK( !c.control->is_builtin_activated( builtin_protocol_feature_t::only_link_to_existing_permission ) );
 
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(require_preactivation_test, T, testers) try {
 
    BOOST_CHECK( !c.control->is_builtin_activated( builtin_protocol_feature_t::only_link_to_existing_permission ) );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.finish_block();
 
    BOOST_CHECK( !c.control->is_builtin_activated( builtin_protocol_feature_t::only_link_to_existing_permission ) );
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(only_link_to_existing_permission_test, T, testers)
       ("requirement", "test" )
    );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // Verify the correct behavior after ONLY_LINK_TO_EXISTING_PERMISSION activation.
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subjective_restrictions_test, T, testers) try {
    };
    restart_with_new_pfs( make_protocol_feature_set(custom_subjective_restrictions) );
    // It should fail
-   BOOST_CHECK_EXCEPTION(  c.preactivate_protocol_features({only_link_to_existing_permission_digest}),
+   BOOST_CHECK_EXCEPTION(  c.activate_protocol_features({only_link_to_existing_permission_digest}),
                            subjective_block_production_exception,
                            fc_exception_message_starts_with(
                               (c.head().block_time() + fc::milliseconds(config::block_interval_ms)).to_iso_string() +
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subjective_restrictions_test, T, testers) try {
    };
    restart_with_new_pfs( make_protocol_feature_set(custom_subjective_restrictions) );
    // It should fail but with different exception
-   BOOST_CHECK_EXCEPTION(  c.preactivate_protocol_features({only_link_to_existing_permission_digest}),
+   BOOST_CHECK_EXCEPTION(  c.activate_protocol_features({only_link_to_existing_permission_digest}),
                            subjective_block_production_exception,
                            fc_exception_message_is(
                               std::string("protocol feature with digest '") +
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subjective_restrictions_test, T, testers) try {
    };
    restart_with_new_pfs( make_protocol_feature_set(custom_subjective_restrictions) );
    // Should be fine now, and activated in the next block
-   BOOST_CHECK_NO_THROW( c.preactivate_protocol_features({only_link_to_existing_permission_digest}) );
+   BOOST_CHECK_NO_THROW( c.activate_protocol_features({only_link_to_existing_permission_digest}) );
    c.produce_block();
    BOOST_CHECK( c.control->is_builtin_activated( builtin_protocol_feature_t::only_link_to_existing_permission ) );
 } FC_LOG_AND_RETHROW()
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subjective_restrictions_test, T, testers) try {
 BOOST_AUTO_TEST_CASE_TEMPLATE(replace_deferred_test, T, testers) try {
    T c( setup_policy::preactivate_feature_and_new_bios );
 
-   c.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
+   c.activate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    c.produce_block();
    c.create_accounts( {"alice"_n, "bob"_n, "test"_n} );
    c.set_code( "test"_n, test_contracts::deferred_test_wasm() );
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(replace_deferred_test, T, testers) try {
    auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::replace_deferred );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage0 );
@@ -531,7 +531,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(no_duplicate_deferred_id_test, T, testers) try {
    T c( setup_policy::preactivate_feature_and_new_bios );
    T c2( setup_policy::none );
 
-   c.preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
+   c.activate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    c.produce_block();
    c.create_accounts( {"alice"_n, "test"_n} );
    c.set_code( "test"_n, test_contracts::deferred_test_wasm() );
@@ -602,7 +602,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(no_duplicate_deferred_id_test, T, testers) try {
    );
    BOOST_REQUIRE_EQUAL(1u, index.size());
 
-   c.preactivate_protocol_features( {*d1, *d2} );
+   c.activate_protocol_features( {*d1, *d2} );
    c.produce_block();
    // The deferred transaction with payload 42 that was scheduled prior to the activation of the protocol features should now be retired.
 
@@ -740,7 +740,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fix_linkauth_restriction, T, testers) { try {
    auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::fix_linkauth_restriction );
    BOOST_REQUIRE( d );
 
-   chain.preactivate_protocol_features( {*d} );
+   chain.activate_protocol_features( {*d} );
    chain.produce_block();
 
    auto validate_allowed = [&] (const char *code, const char *type) {
@@ -776,7 +776,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(disallow_empty_producer_schedule_test, T, testers)
    c.set_producers_legacy( {} );
 
    // After activation, it should not be allowed
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
    BOOST_REQUIRE_EXCEPTION( c.set_producers_legacy( {} ),
                             wasm_execution_error,
@@ -827,7 +827,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(restrict_action_to_self_test, T, testers) { try {
                             subjective_block_production_exception,
                             fc_exception_message_starts_with( "Authorization failure with sent deferred transaction" ) );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // After the protocol feature is preactivated, all the 4 cases will throw an objective unsatisfied_authorization exception
@@ -920,7 +920,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(only_bill_to_first_authorizer, T, testers) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::only_bill_first_authorizer );
    BOOST_REQUIRE( d );
 
-   chain.preactivate_protocol_features( {*d} );
+   chain.activate_protocol_features( {*d} );
    chain.produce_block();
 
    {
@@ -980,7 +980,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(forward_setcode_test, T, testers) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::forward_setcode );
    BOOST_REQUIRE( d );
    c.set_before_producer_authority_bios_contract();
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
    c.set_code( config::system_account_name, test_contracts::reject_all_wasm() );
    c.produce_block();
@@ -1035,7 +1035,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(get_sender_test, T, testers) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::get_sender );
    BOOST_REQUIRE( d );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_code( tester1_account, test_contracts::get_sender_test_wasm() );
@@ -1238,7 +1238,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ram_restrictions_test, T, testers) { try {
    BOOST_REQUIRE( d );
 
    // Activate RAM_RESTRICTIONS protocol feature (this would also disable the subjective mitigation).
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // Cannot send deferred transaction paid by another account that has not authorized the action.
@@ -1355,7 +1355,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(webauthn_producer, T, testers) { try {
       eosio::chain::unactivated_key_type
    );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.push_action(config::system_account_name, "setprods"_n, config::system_account_name, fc::mutable_variant_object()("schedule", waprodsched));
@@ -1384,7 +1384,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(webauthn_create_account, T, testers) { try {
    trx.sign(get_private_key(config::system_account_name, "active"), c.get_chain_id());
    BOOST_CHECK_THROW(c.push_transaction(trx), eosio::chain::unactivated_key_type);
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
    c.push_transaction(trx);
 } FC_LOG_AND_RETHROW() }
@@ -1403,7 +1403,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(webauthn_update_account_auth, T, testers) { try {
                         authority(public_key_type("PUB_WA_WdCPfafVNxVMiW5ybdNs83oWjenQXvSt1F49fg9mv7qrCiRwHj5b38U3ponCFWxQTkDsMC"s))),
                      eosio::chain::unactivated_key_type);
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    c.set_authority("billy"_n, config::active_name, authority(public_key_type("PUB_WA_WdCPfafVNxVMiW5ybdNs83oWjenQXvSt1F49fg9mv7qrCiRwHj5b38U3ponCFWxQTkDsMC"s)));
@@ -1462,7 +1462,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(webauthn_recover_key, T, testers) { try {
    trx.sign(c.get_private_key( "bob"_n, "active" ), c.get_chain_id());
    BOOST_CHECK_THROW(c.push_transaction(trx), eosio::chain::unactivated_signature_type);
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
    c.push_transaction(trx);
 
@@ -1510,7 +1510,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(webauthn_assert_recover_key, T, testers) { try {
    trx.sign(c.get_private_key( "bob"_n, "active" ), c.get_chain_id());
    BOOST_CHECK_THROW(c.push_transaction(trx), eosio::chain::unactivated_signature_type);
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
    c.push_transaction(trx);
 
@@ -1549,7 +1549,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(set_proposed_producers_ex_test, T, testers) { try 
                            wasm_exception,
                            fc_exception_message_is( "env.set_proposed_producers_ex unresolveable" ) );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // ensure it now resolves
@@ -1587,7 +1587,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(producer_schedule_change_extension_test, T, tester
    // aware of the activation.  So the expectation is that if it is activated in the _state_ at block N, block N + 1
    // will bear an extension making header-only validators aware of it, and therefore block N + 2 is the first block
    // where a block may bear a downstream extension.
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    remote.push_block(c.produce_block());
 
    auto last_legacy_block = c.produce_block();
@@ -1688,7 +1688,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(wtmsig_block_signing_inflight_legacy_test, T, test
    c.produce_block();
 
    // activate the feature, and start an in-flight producer schedule change with the legacy format
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    vector<legacy::producer_key> sched = {{"eosio"_n, c.get_public_key("eosio"_n, "bsk")}};
    c.push_action(config::system_account_name, "setprods"_n, config::system_account_name, fc::mutable_variant_object()("schedule", sched));
    c.produce_block();
@@ -1719,7 +1719,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(wtmsig_block_signing_inflight_extension_test, T, t
    c.produce_block();
 
    // activate the feature
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // start an in-flight producer schedule change before the activation is availble to header only validators
@@ -1775,7 +1775,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(set_action_return_value_test, T, testers) { try {
                            wasm_exception,
                            fc_exception_message_is( "env.set_action_return_value unresolveable" ) );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // ensure it now resolves
@@ -1817,7 +1817,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(get_parameters_packed_test, T, testers) { try {
                            wasm_exception,
                            fc_exception_message_is( "env.get_parameters_packed unresolveable" ) );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // ensure it now resolves
@@ -1879,7 +1879,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(set_parameters_packed_test, T, testers) { try {
                            wasm_exception,
                            fc_exception_message_is( "env.set_parameters_packed unresolveable" ) );
 
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // ensure it now resolves
@@ -1982,7 +1982,7 @@ BOOST_AUTO_TEST_CASE( disable_deferred_trxs_stage_1_no_op_test ) { try {
    const auto& pfm = c.control->get_protocol_feature_manager();
    auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::disable_deferred_trxs_stage_1 );
    BOOST_REQUIRE( d );
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // verify send_deferred host function is no-op
@@ -2074,7 +2074,7 @@ BOOST_AUTO_TEST_CASE( disable_deferred_trxs_stage_1_retire_test ) { try {
    const auto& pfm = c.control->get_protocol_feature_manager();
    auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::disable_deferred_trxs_stage_1 );
    BOOST_REQUIRE( d );
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // verify generated_transaction_multi_index still has 1 entry
@@ -2146,7 +2146,7 @@ BOOST_AUTO_TEST_CASE( disable_deferred_trxs_stage_2_test ) { try {
    const auto& pfm = c.control->get_protocol_feature_manager();
    auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::disable_deferred_trxs_stage_1 );
    BOOST_REQUIRE( d );
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
 
    // before disable_deferred_trxs_stage_2 is activated, generated_transaction_multi_index
    // should still have 2 entries
@@ -2155,7 +2155,7 @@ BOOST_AUTO_TEST_CASE( disable_deferred_trxs_stage_2_test ) { try {
 
    d = pfm.get_builtin_digest( builtin_protocol_feature_t::disable_deferred_trxs_stage_2 );
    BOOST_REQUIRE( d );
-   c.preactivate_protocol_features( {*d} );
+   c.activate_protocol_features( {*d} );
    c.produce_block();
 
    // all scheduled deferred trxs are removed upon activation of disable_deferred_trxs_stage_2
@@ -2176,7 +2176,7 @@ BOOST_AUTO_TEST_CASE( disable_deferred_trxs_stage_2_dependency_test ) { try {
    const auto& pfm = c.control->get_protocol_feature_manager();
    auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::disable_deferred_trxs_stage_2 );
    BOOST_REQUIRE( d );
-   BOOST_REQUIRE_EXCEPTION( c.preactivate_protocol_features( {*d} ),
+   BOOST_REQUIRE_EXCEPTION( c.activate_protocol_features( {*d} ),
       protocol_feature_exception,
       fc_exception_message_starts_with("not all dependencies of protocol feature with digest"));
 } FC_LOG_AND_RETHROW() } /// disable_deferred_trxs_stage_2_dependency_test
@@ -2210,7 +2210,7 @@ BOOST_AUTO_TEST_CASE( block_validation_after_stage_1_test ) { try {
    const auto& pfm1 = tester1.control->get_protocol_feature_manager();
    auto d1 = pfm1.get_builtin_digest( builtin_protocol_feature_t::disable_deferred_trxs_stage_1 );
    BOOST_REQUIRE( d1 );
-   tester1.preactivate_protocol_features( {*d1} );
+   tester1.activate_protocol_features( {*d1} );
    tester1.produce_block();
 
    // Create a block with valid transaction
@@ -2248,7 +2248,7 @@ BOOST_AUTO_TEST_CASE( block_validation_after_stage_1_test ) { try {
    const auto& pfm2 = tester2.control->get_protocol_feature_manager();
    auto d2 = pfm2.get_builtin_digest( builtin_protocol_feature_t::disable_deferred_trxs_stage_1 );
    BOOST_REQUIRE( d2 );
-   tester2.preactivate_protocol_features( {*d2} );
+   tester2.activate_protocol_features( {*d2} );
    tester2.produce_block();
 
    // Push the block with delayed transaction to the second chain
@@ -2279,8 +2279,8 @@ static const char import_set_finalizers_wast[] = R"=====(
 )
 )=====";
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(set_finalizers_test, T, testers) { try {
-   T c( setup_policy::preactivate_feature_and_new_bios );
+BOOST_AUTO_TEST_CASE(set_finalizers_test) { try {
+   savanna_tester c( setup_policy::preactivate_feature_and_new_bios );
 
    const auto alice_account = account_name("alice");
    c.create_accounts( {alice_account} );
@@ -2290,7 +2290,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(set_finalizers_test, T, testers) { try {
                            wasm_exception,
                            fc_exception_message_is( "env.set_finalizers unresolveable" ) );
 
-   c.preactivate_savanna_protocol_features();
+   c.activate_builtin_protocol_features({builtin_protocol_feature_t::savanna}); // will activate all preceding features savanna depends on
    c.produce_block();
 
    // ensure it now resolves, forward setcode enabled so will call automatically

--- a/unittests/savanna_cluster.cpp
+++ b/unittests/savanna_cluster.cpp
@@ -2,7 +2,7 @@
 
 namespace savanna_cluster {
 
-node_t::node_t(size_t node_idx, cluster_t& cluster, setup_policy policy /* = setup_policy::none */)
+node_t::node_t(size_t node_idx, cluster_t& cluster, const setup_policy& policy /* = setup_policy::none */)
    : tester(policy)
    , _node_idx(node_idx)
    , _last_vote({}, false)

--- a/unittests/savanna_cluster.hpp
+++ b/unittests/savanna_cluster.hpp
@@ -126,7 +126,7 @@ namespace savanna_cluster {
       cluster_t&                                      _cluster;
 
    public:
-      node_t(size_t node_idx, cluster_t& cluster, setup_policy policy = setup_policy::none);
+      node_t(size_t node_idx, cluster_t& cluster, const setup_policy& policy = setup_policy::none);
 
       virtual ~node_t();
 

--- a/unittests/wasm_config_tests.cpp
+++ b/unittests/wasm_config_tests.cpp
@@ -1258,7 +1258,7 @@ BOOST_FIXTURE_TEST_CASE(large_custom_section, old_wasm_tester)
    set_code( "hugecustom"_n, okay_custom );
 
    // It's also okay once CONFIGURABLE_WASM_LIMITS is activated
-   preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+   activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
    produce_block();
 
    set_code( "hugecustom"_n, custom_section_wasm );

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -727,9 +727,12 @@ void test_big_memory(setup_policy policy) {
 
 }
 
-BOOST_DATA_TEST_CASE( big_memory, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
-   test_big_memory<legacy_validating_tester>(policy);
-   test_big_memory<savanna_validating_tester>(policy);
+BOOST_DATA_TEST_CASE(big_memory,
+                     bdata::make({&setup_policy::preactivate_feature_and_new_bios, &setup_policy::old_wasm_parser,
+                                  &setup_policy::full_except_do_not_transition_to_savanna, &setup_policy::full}),
+                     policy)
+try {
+   test_big_memory<validating_tester>(*policy);
 } FC_LOG_AND_RETHROW()
 
 template<typename T>
@@ -749,9 +752,11 @@ void test_table_init(setup_policy policy) {
 
 }
 
-BOOST_DATA_TEST_CASE( table_init_tests, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
-   test_table_init<legacy_validating_tester>(policy);
-   test_table_init<savanna_validating_tester>(policy);
+BOOST_DATA_TEST_CASE(table_init_tests,
+                     bdata::make({&setup_policy::preactivate_feature_and_new_bios, &setup_policy::old_wasm_parser,
+                                  &setup_policy::full_except_do_not_transition_to_savanna, &setup_policy::full}),
+                     policy) try {
+   test_table_init<validating_tester>(*policy);
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( table_init_oob, T, validating_testers ) try {
@@ -974,9 +979,11 @@ void test_lotso_globals(setup_policy policy) {
 
 }
 
-BOOST_DATA_TEST_CASE( lotso_globals, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
-   test_lotso_globals<legacy_validating_tester>(policy);
-   test_lotso_globals<savanna_validating_tester>(policy);
+BOOST_DATA_TEST_CASE(lotso_globals,
+                     bdata::make({&setup_policy::preactivate_feature_and_new_bios, &setup_policy::old_wasm_parser,
+                                  &setup_policy::full_except_do_not_transition_to_savanna, &setup_policy::full}),
+                     policy) try {
+   test_lotso_globals<validating_tester>(*policy);
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( offset_check_old, T, validating_testers ) try {
@@ -1841,9 +1848,11 @@ void test_depth(setup_policy policy) {
 
 }
 
-BOOST_DATA_TEST_CASE( depth_tests, bdata::make({setup_policy::preactivate_feature_and_new_bios, setup_policy::old_wasm_parser, setup_policy::full}), policy ) try {
-   test_depth<legacy_validating_tester>(policy);
-   test_depth<savanna_validating_tester>(policy);
+BOOST_DATA_TEST_CASE(depth_tests,
+                     bdata::make({&setup_policy::preactivate_feature_and_new_bios, &setup_policy::old_wasm_parser,
+                                  &setup_policy::full_except_do_not_transition_to_savanna, &setup_policy::full}),
+                     policy) try {
+   test_depth<validating_tester>(*policy);
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE_TEMPLATE( varuint_memory_flags_tests, T, validating_testers ) try {

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -693,7 +693,7 @@ template<typename T>
 void test_big_memory(setup_policy policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
-      t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+      t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
    t.produce_block();
 
@@ -739,7 +739,7 @@ template<typename T>
 void test_table_init(setup_policy policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
-      t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+      t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
    t.produce_block();
 
    t.create_accounts( {"tableinit"_n} );
@@ -955,7 +955,7 @@ template<typename T>
 void test_lotso_globals(setup_policy policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
-      t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+      t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
    t.produce_block();
 
@@ -1795,7 +1795,7 @@ template<typename T>
 void test_depth(setup_policy policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
-      t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+      t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
    t.produce_block();
    t.create_accounts( {"depth"_n} );
@@ -1879,7 +1879,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( varuint_memory_flags_tests, T, validating_testers
    }
 
    // Activate new parser
-   t.preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
+   t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
    t.produce_block();
 
    // We should still be able to execute the old code

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -690,7 +690,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( check_global_reset, T, validating_testers ) try {
 
 //Make sure we can create a wasm with maximum pages, but not grow it any
 template<typename T>
-void test_big_memory(setup_policy policy) {
+void test_big_memory(const setup_policy& policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
       t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
@@ -736,7 +736,7 @@ try {
 } FC_LOG_AND_RETHROW()
 
 template<typename T>
-void test_table_init(setup_policy policy) {
+void test_table_init(const setup_policy& policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
       t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
@@ -952,7 +952,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( nested_limit_test, T, validating_testers ) try {
 
 
 template<typename T>
-void test_lotso_globals(setup_policy policy) {
+void test_lotso_globals(const setup_policy& policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
       t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
@@ -1792,7 +1792,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( big_maligned_host_ptr, T, validating_testers ) tr
 } FC_LOG_AND_RETHROW()
 
 template<typename T>
-void test_depth(setup_policy policy) {
+void test_depth(const setup_policy& policy) {
    T t(flat_set<account_name>{}, {}, policy);
    if(policy != setup_policy::full)
       t.activate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});

--- a/unittests/whitelist_blacklist_tests.cpp
+++ b/unittests/whitelist_blacklist_tests.cpp
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE( deferred_blacklist_failure ) { try {
    whitelist_blacklist_tester<tester> tester1;
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
-   tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
+   tester1.chain->activate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    tester1.chain->produce_block();
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( blacklist_onerror, T, whitelist_blacklist_validat
    T tester1;
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
-   tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
+   tester1.chain->activate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    tester1.chain->produce_block();
    tester1.chain->set_code( "bob"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "bob"_n,  test_contracts::deferred_test_abi() );
@@ -428,7 +428,7 @@ BOOST_AUTO_TEST_CASE( actor_blacklist_inline_deferred ) { try {
    whitelist_blacklist_tester<tester> tester1;
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
-   tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
+   tester1.chain->activate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    tester1.chain->produce_block();
    tester1.chain->set_code( "alice"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "alice"_n,  test_contracts::deferred_test_abi() );
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE( blacklist_sender_bypass ) { try {
    whitelist_blacklist_tester<tester> tester1;
    tester1.init();
    tester1.chain->execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
-   tester1.chain->preactivate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
+   tester1.chain->activate_builtin_protocol_features( {builtin_protocol_feature_t::crypto_primitives} );
    tester1.chain->produce_block();
    tester1.chain->set_code( "alice"_n, test_contracts::deferred_test_wasm() );
    tester1.chain->set_abi( "alice"_n,  test_contracts::deferred_test_abi() );


### PR DESCRIPTION
Instead of an `enum` for `setup_policy`, use a class containing:

1. a list of actions
2. a list of protocol features to activate.

Also rename some ill-named `preactivate*` to `activate*`.