### PR TITLE
[1.2.1] Test: Allow more time for node to startup and sync

### DIFF
--- a/tests/snapshot_in_svnn_transition_test.py
+++ b/tests/snapshot_in_svnn_transition_test.py
@@ -116,7 +116,7 @@ try:
           chainArg=None
        isRelaunchSuccess = node.relaunch(chainArg=chainArg)
        assert isRelaunchSuccess, "Failed to relaunch node with snapshot"
-       assert node.waitForLibToAdvance(), "LIB did not advance after restart from snapshot"
+       assert node.waitForLibToAdvance(timeout=60), "LIB did not advance after restart from snapshot"
 
     Print("Restart snapshot node with snapshot with blocks")
     restartWithSnapshot(nodeSnap, rmBlocks=False)


### PR DESCRIPTION
Test failed because it took just over 30 seconds to sync up.

Resolves #1705 