### PR TITLE
[2.0.0-dev] Enforce gxx version 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ set( SPRING_UTIL_EXECUTABLE_NAME spring-util )
 
 # http://stackoverflow.com/a/18369825
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0)
-        message(FATAL_ERROR "GCC version must be at least 11.0.0!")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.4)
+        message(FATAL_ERROR "GCC version must be at least 11.4.0!")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ set( SPRING_UTIL_EXECUTABLE_NAME spring-util )
 
 # http://stackoverflow.com/a/18369825
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.2)
-        message(FATAL_ERROR "GCC version must be at least 10.2.0!")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0)
+        message(FATAL_ERROR "GCC version must be at least 11.0.0!")
     endif()
 endif()
 


### PR DESCRIPTION
Update top level CMakeLists.txt to check for and require gnu version 11 or better. Clear error message for someone with older build, for example Ubuntu 20, that may pick up earlier version of the compilers. 

