### PR TITLE
try 2: allow `hash()` to take multiple arguments similar to `pack()`

### DIFF
--- a/benchmark/hash.cpp
+++ b/benchmark/hash.cpp
@@ -25,62 +25,62 @@ void hash_benchmarking() {
    }
 
    auto sha1_small_msg = [&]() {
-      fc::sha1::hash(small_message);
+      fc::sha1::hash_raw(small_message);
    };
    benchmarking("sha1 (" + std::to_string(small_message.length()) + " bytes)", sha1_small_msg);
 
    auto sha1_large_msg = [&]() {
-      fc::sha1::hash(large_message);
+      fc::sha1::hash_raw(large_message);
    };
    benchmarking("sha1 (" + std::to_string(large_message.length()) + " bytes)", sha1_large_msg);
 
    auto sha256_small_msg = [&]() {
-      fc::sha256::hash(small_message);
+      fc::sha256::hash_raw(small_message);
    };
    benchmarking("sha256 (" + std::to_string(small_message.length()) + " bytes)", sha256_small_msg);
 
    auto sha256_large_msg = [&]() {
-      fc::sha256::hash(large_message);
+      fc::sha256::hash_raw(large_message);
    };
    benchmarking("sha256 (" + std::to_string(large_message.length()) + " bytes)", sha256_large_msg);
 
    auto sha512_small_msg = [&]() {
-      fc::sha512::hash(small_message);
+      fc::sha512::hash_raw(small_message);
    };
    benchmarking("sha512 (" + std::to_string(small_message.length()) + " bytes)", sha512_small_msg);
 
    auto sha512_large_msg = [&]() {
-      fc::sha512::hash(large_message);
+      fc::sha512::hash_raw(large_message);
    };
    benchmarking("sha512 (" + std::to_string(large_message.length()) + " bytes)", sha512_large_msg);
 
    auto ripemd160_small_msg = [&]() {
-      fc::ripemd160::hash(small_message);
+      fc::ripemd160::hash_raw(small_message);
    };
    benchmarking("ripemd160 (" + std::to_string(small_message.length()) + " bytes)", ripemd160_small_msg);
 
    auto ripemd160_large_msg = [&]() {
-      fc::ripemd160::hash(large_message);
+      fc::ripemd160::hash_raw(large_message);
    };
    benchmarking("ripemd160 (" + std::to_string(large_message.length()) + " bytes)", ripemd160_large_msg);
 
    auto sha3_small_msg = [&]() {
-      fc::sha3::hash(small_message, true);
+      fc::sha3::hash_raw(small_message, true);
    };
    benchmarking("sha3-256 (" + std::to_string(small_message.length()) + " bytes)", sha3_small_msg);
 
    auto sha3_large_msg = [&]() {
-      fc::sha3::hash(large_message, true);
+      fc::sha3::hash_raw(large_message, true);
    };
    benchmarking("sha3-256 (" + std::to_string(large_message.length()) + " bytes)", sha3_large_msg);
 
    auto keccak_small_msg = [&]() {
-      fc::sha3::hash(small_message, false);
+      fc::sha3::hash_raw(small_message, false);
    };
    benchmarking("keccak256 (" + std::to_string(small_message.length()) + " bytes)", keccak_small_msg);
 
    auto keccak_large_msg = [&]() {
-      fc::sha3::hash(large_message, false);
+      fc::sha3::hash_raw(large_message, false);
    };
    benchmarking("keccak256 (" + std::to_string(large_message.length()) + " bytes)", keccak_large_msg);
 

--- a/benchmark/key.cpp
+++ b/benchmark/key.cpp
@@ -13,7 +13,7 @@ namespace eosio::benchmark {
 
 void k1_sign_benchmarking() {
    auto payload = "Test Cases";
-   auto digest = sha256::hash(payload, const_strlen(payload));
+   auto digest = sha256::hash_raw(std::string_view(payload));
    auto private_key_string = std::string("5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3");
    auto key = private_key(private_key_string);
 
@@ -40,7 +40,7 @@ void k1_benchmarking() {
 
 void r1_benchmarking() {
    auto payload = "Test Cases";
-   auto digest = sha256::hash(payload, const_strlen(payload));
+   auto digest = sha256::hash_raw(std::string_view(payload));
    auto key = private_key::generate<r1::private_key_shim>();
 
    auto sign_f = [&]() {
@@ -60,7 +60,7 @@ static fc::crypto::webauthn::signature make_webauthn_sig(const fc::crypto::r1::p
                                                          const std::string& json) {
 
    //webauthn signature is sha256(auth_data || client_data_hash)
-   fc::sha256 client_data_hash = fc::sha256::hash(json);
+   fc::sha256 client_data_hash = fc::sha256::hash_raw(json);
    fc::sha256::encoder e;
    e.write((char*)auth_data.data(), auth_data.size());
    e.write(client_data_hash.data(), client_data_hash.data_size());
@@ -82,8 +82,8 @@ static fc::crypto::webauthn::signature make_webauthn_sig(const fc::crypto::r1::p
 
 void wa_benchmarking() {
    static const r1::private_key priv = fc::crypto::r1::private_key::generate();
-   static const fc::sha256 d = fc::sha256::hash("sup"s);
-   static const fc::sha256 origin_hash = fc::sha256::hash("fctesting.invalid"s);
+   static const fc::sha256 d = fc::sha256::hash_raw("sup"s);
+   static const fc::sha256 origin_hash = fc::sha256::hash_raw("fctesting.invalid"s);
    std::string json = "{\"origin\":\"https://fctesting.invalid\",\"type\":\"webauthn.get\", \"challenge\":\"" + fc::base64url_encode(d.data(), d.data_size()) + "\"}";
    std::vector<uint8_t> auth_data(37);
    memcpy(auth_data.data(), origin_hash.data(), sizeof(origin_hash));

--- a/benchmark/merkle.cpp
+++ b/benchmark/merkle.cpp
@@ -11,7 +11,7 @@ std::vector<digest_type> create_test_digests(size_t n) {
    std::vector<digest_type> v;
    v.reserve(n);
    for (size_t i=0; i<n; ++i)
-      v.push_back(fc::sha256::hash(std::string{"Node"} + std::to_string(i)));
+      v.push_back(fc::sha256::hash_raw(std::string{"Node"} + std::to_string(i)));
    return v;
 }
 

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -141,7 +141,7 @@ void apply_eosio_setcode(apply_context& context) {
    int64_t code_size = (int64_t)act.code.size();
 
    if( code_size > 0 ) {
-     code_hash = fc::sha256::hash( act.code.data(), (uint32_t)act.code.size() );
+     code_hash = fc::sha256::hash_raw( act.code );
      wasm_interface::validate(context.control, act.code);
    }
 

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -454,7 +454,7 @@ namespace impl {
             if( act.account == config::system_account_name && act.name == "setcode"_n ) {
                auto setcode_act = act.data_as<setcode>();
                if( setcode_act.code.size() > 0 ) {
-                  fc::sha256 code_hash = fc::sha256::hash(setcode_act.code.data(), (uint32_t) setcode_act.code.size());
+                  fc::sha256 code_hash = fc::sha256::hash_raw(setcode_act.code);
                   mvo("code_hash", code_hash);
                }
                return false; // still want the hex data included

--- a/libraries/chain/include/eosio/chain/action.hpp
+++ b/libraries/chain/include/eosio/chain/action.hpp
@@ -96,20 +96,8 @@ namespace eosio { namespace chain {
    };
 
    inline digest_type generate_action_digest(const action& act, const vector<char>& action_output) {
-      std::array<digest_type,2> hashes;
       const action_base& base = act;
-
-      fc::sha256::encoder enc;
-      fc::raw::pack(enc, base);
-      hashes[0] = enc.result();
-
-      enc.reset();
-      fc::raw::pack(enc, act.data, action_output);
-      hashes[1] = enc.result();
-
-      enc.reset();
-      fc::raw::pack(enc, hashes);
-      return enc.result();
+      return fc::sha256::hash(fc::sha256::hash(base), fc::sha256::hash(act.data, action_output));
    }
 
 } } /// namespace eosio::chain

--- a/libraries/libfc/include/fc/crypto/hash_concepts.hpp
+++ b/libraries/libfc/include/fc/crypto/hash_concepts.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <concepts>
+
+template <typename T>
+concept ContiguousCharSource = requires(const T& obj) {
+   { obj.data() } -> std::convertible_to<const char*>;
+   { obj.size() } -> std::unsigned_integral;
+};

--- a/libraries/libfc/include/fc/crypto/ripemd160.hpp
+++ b/libraries/libfc/include/fc/crypto/ripemd160.hpp
@@ -2,7 +2,7 @@
 
 #include <fc/fwd.hpp>
 #include <fc/crypto/hash_concepts.hpp>
-#include <fc/io/raw_fwd.hpp>
+#include <fc/io/raw.hpp>
 #include <fc/reflect/typename.hpp>
 
 namespace fc{
@@ -27,11 +27,12 @@ class ripemd160
       return e.result();
     }
 
-    template<typename T>
-    static ripemd160 hash( const T& t ) 
+    template<typename... T>
+    requires ( sizeof...(T) > 0 )
+    static ripemd160 hash( const T&... t )
     { 
       ripemd160::encoder e; 
-      fc::raw::pack(e,t);
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/ripemd160.hpp
+++ b/libraries/libfc/include/fc/crypto/ripemd160.hpp
@@ -20,8 +20,6 @@ class ripemd160
     char*    data()const;
     size_t data_size()const { return 160/8; }
 
-    static ripemd160 hash( const fc::sha512& h );
-    static ripemd160 hash( const fc::sha256& h );
     static ripemd160 hash( const char* d, uint32_t dlen );
     static ripemd160 hash( const std::string& );
 

--- a/libraries/libfc/include/fc/crypto/ripemd160.hpp
+++ b/libraries/libfc/include/fc/crypto/ripemd160.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <fc/fwd.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw_fwd.hpp>
 #include <fc/reflect/typename.hpp>
 
@@ -20,8 +21,11 @@ class ripemd160
     char*    data()const;
     size_t data_size()const { return 160/8; }
 
-    static ripemd160 hash( const char* d, uint32_t dlen );
-    static ripemd160 hash( const std::string& );
+    static ripemd160 hash_raw(const ContiguousCharSource auto& r) {
+      encoder e;
+      e.write(r.data(), r.size());
+      return e.result();
+    }
 
     template<typename T>
     static ripemd160 hash( const T& t ) 

--- a/libraries/libfc/include/fc/crypto/sha1.hpp
+++ b/libraries/libfc/include/fc/crypto/sha1.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 
 namespace fc{
 
@@ -17,8 +18,11 @@ class sha1
     const char* data()const;
     size_t data_size()const { return 20; }
 
-    static sha1 hash( const char* d, uint32_t dlen );
-    static sha1 hash( const std::string& );
+    static sha1 hash_raw(const ContiguousCharSource auto& r) {
+      encoder e;
+      e.write(r.data(), r.size());
+      return e.result();
+    }
 
     template<typename T>
     static sha1 hash( const T& t ) 

--- a/libraries/libfc/include/fc/crypto/sha1.hpp
+++ b/libraries/libfc/include/fc/crypto/sha1.hpp
@@ -2,6 +2,7 @@
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
 #include <fc/crypto/hash_concepts.hpp>
+#include <fc/io/raw.hpp>
 
 namespace fc{
 
@@ -24,11 +25,12 @@ class sha1
       return e.result();
     }
 
-    template<typename T>
-    static sha1 hash( const T& t ) 
+    template<typename... T>
+    requires ( sizeof...(T) > 0 )
+    static sha1 hash( const T&... t )
     { 
       sha1::encoder e; 
-      e << t; 
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha224.hpp
+++ b/libraries/libfc/include/fc/crypto/sha224.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <unordered_map>
 #include <fc/fwd.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw_fwd.hpp>
 #include <fc/string.hpp>
 
@@ -20,8 +21,11 @@ class sha224
     const char* data()const;
     size_t data_size()const { return 224 / 8; }
 
-    static sha224 hash( const char* d, uint32_t dlen );
-    static sha224 hash( const std::string& );
+    static sha224 hash_raw(const ContiguousCharSource auto& r) {
+      encoder e;
+      e.write(r.data(), r.size());
+      return e.result();
+    }
 
     template<typename T>
     static sha224 hash( const T& t ) 

--- a/libraries/libfc/include/fc/crypto/sha224.hpp
+++ b/libraries/libfc/include/fc/crypto/sha224.hpp
@@ -2,8 +2,7 @@
 #include <unordered_map>
 #include <fc/fwd.hpp>
 #include <fc/crypto/hash_concepts.hpp>
-#include <fc/io/raw_fwd.hpp>
-#include <fc/string.hpp>
+#include <fc/io/raw.hpp>
 
 namespace fc
 {
@@ -27,11 +26,12 @@ class sha224
       return e.result();
     }
 
-    template<typename T>
-    static sha224 hash( const T& t ) 
+    template<typename... T>
+    requires ( sizeof...(T) > 0 )
+    static sha224 hash( const T&... t )
     { 
       sha224::encoder e; 
-      fc::raw::pack(e,t);
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha256.hpp
+++ b/libraries/libfc/include/fc/crypto/sha256.hpp
@@ -4,6 +4,7 @@
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw_fwd.hpp>
 #include <boost/functional/hash.hpp>
 
@@ -32,8 +33,11 @@ class sha256
        return (_hash[0] | _hash[1] | _hash[2] | _hash[3]) == 0;
     }
 
-    static sha256 hash( const char* d, uint32_t dlen );
-    static sha256 hash( const std::string& );
+    static sha256 hash_raw(const ContiguousCharSource auto& r) {
+       encoder e;
+       e.write(r.data(), r.size());
+       return e.result();
+    }
 
     template<typename T>
     static sha256 hash( const T& t ) 

--- a/libraries/libfc/include/fc/crypto/sha256.hpp
+++ b/libraries/libfc/include/fc/crypto/sha256.hpp
@@ -113,8 +113,6 @@ class sha256
   void to_variant( const sha256& bi, variant& v );
   void from_variant( const variant& v, sha256& bi );
 
-  uint64_t hash64(const char* buf, size_t len);    
-
 } // fc
 
 namespace std

--- a/libraries/libfc/include/fc/crypto/sha256.hpp
+++ b/libraries/libfc/include/fc/crypto/sha256.hpp
@@ -2,10 +2,9 @@
 #include <span>
 #include <compare>
 #include <fc/fwd.hpp>
-#include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
 #include <fc/crypto/hash_concepts.hpp>
-#include <fc/io/raw_fwd.hpp>
+#include <fc/io/raw.hpp>
 #include <boost/functional/hash.hpp>
 
 namespace fc
@@ -39,11 +38,12 @@ class sha256
        return e.result();
     }
 
-    template<typename T>
-    static sha256 hash( const T& t ) 
+    template<typename... T>
+    requires ( sizeof...(T) > 0 )
+    static sha256 hash( const T&... t )
     { 
       sha256::encoder e; 
-      fc::raw::pack(e,t);
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha256.hpp
+++ b/libraries/libfc/include/fc/crypto/sha256.hpp
@@ -34,7 +34,6 @@ class sha256
 
     static sha256 hash( const char* d, uint32_t dlen );
     static sha256 hash( const std::string& );
-    static sha256 hash( const sha256& );
 
     template<typename T>
     static sha256 hash( const T& t ) 

--- a/libraries/libfc/include/fc/crypto/sha3.hpp
+++ b/libraries/libfc/include/fc/crypto/sha3.hpp
@@ -2,6 +2,7 @@
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 #include <fc/io/raw_fwd.hpp>
 #include <boost/functional/hash.hpp>
 
@@ -23,13 +24,11 @@ public:
 	char* data();
 	size_t data_size() const { return 256 / 8; }
 
-	static sha3 hash(const char *d, uint32_t dlen, bool is_nist=true) {
+	static sha3 hash_raw(const ContiguousCharSource auto& r, bool is_nist=true) {
 		encoder e;
-		e.write(d, dlen);
-		const auto& sha = e.result(is_nist);
-		return sha;
+		e.write(r.data(), r.size());
+		return e.result(is_nist);
 	}
-	static sha3 hash(const std::string& s, bool is_nist=true) { return hash(s.c_str(), s.size(), is_nist); }
 
 	template <typename T>
 	static sha3 hash(const T &t, bool is_nist=true)

--- a/libraries/libfc/include/fc/crypto/sha3.hpp
+++ b/libraries/libfc/include/fc/crypto/sha3.hpp
@@ -30,7 +30,6 @@ public:
 		return sha;
 	}
 	static sha3 hash(const std::string& s, bool is_nist=true) { return hash(s.c_str(), s.size(), is_nist); }
-	static sha3 hash(const sha3& s, bool is_nist=true) { return hash(s.data(), sizeof(s._hash), is_nist); }
 
 	template <typename T>
 	static sha3 hash(const T &t, bool is_nist=true)

--- a/libraries/libfc/include/fc/crypto/sha3.hpp
+++ b/libraries/libfc/include/fc/crypto/sha3.hpp
@@ -3,7 +3,7 @@
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
 #include <fc/crypto/hash_concepts.hpp>
-#include <fc/io/raw_fwd.hpp>
+#include <fc/io/raw.hpp>
 #include <boost/functional/hash.hpp>
 
 namespace fc
@@ -30,12 +30,25 @@ public:
 		return e.result(is_nist);
 	}
 
-	template <typename T>
-	static sha3 hash(const T &t, bool is_nist=true)
+	struct keccak {};
+	struct nist {};
+
+	template<typename... T>
+	requires ( sizeof...(T) > 0 )
+	static sha3 hash( keccak, const T&... t )
 	{
 		sha3::encoder e;
-		fc::raw::pack(e, t);
-		return e.result(is_nist);
+		fc::raw::pack(e,t...);
+		return e.result(false);
+	}
+
+	template<typename... T>
+	requires ( sizeof...(T) > 0 )
+	static sha3 hash( nist, const T&... t )
+	{
+		sha3::encoder e;
+		fc::raw::pack(e,t...);
+		return e.result(true);
 	}
 
 	class encoder

--- a/libraries/libfc/include/fc/crypto/sha512.hpp
+++ b/libraries/libfc/include/fc/crypto/sha512.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <fc/fwd.hpp>
-#include <fc/string.hpp>
 #include <fc/crypto/hash_concepts.hpp>
+#include <fc/io/raw.hpp>
 
 namespace fc
 {
@@ -25,11 +25,12 @@ class sha512
       return e.result();
     }
 
-    template<typename T>
-    static sha512 hash( const T& t ) 
+    template<typename... T>
+    requires ( sizeof...(T) > 0 )
+    static sha512 hash( const T&... t )
     { 
       sha512::encoder e; 
-      e << t; 
+      fc::raw::pack(e,t...);
       return e.result(); 
     } 
 

--- a/libraries/libfc/include/fc/crypto/sha512.hpp
+++ b/libraries/libfc/include/fc/crypto/sha512.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <fc/fwd.hpp>
 #include <fc/string.hpp>
+#include <fc/crypto/hash_concepts.hpp>
 
 namespace fc
 {
@@ -18,8 +19,11 @@ class sha512
     const char* data()const;
     size_t data_size()const { return 512 / 8; }
 
-    static sha512 hash( const char* d, uint32_t dlen );
-    static sha512 hash( const std::string& );
+    static sha512 hash_raw(const ContiguousCharSource auto& r) {
+      encoder e;
+      e.write(r.data(), r.size());
+      return e.result();
+    }
 
     template<typename T>
     static sha512 hash( const T& t ) 

--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -176,6 +176,7 @@ namespace fc {
     } FC_RETHROW_EXCEPTIONS( warn, "fc::array<${type},${length}>", ("type",fc::get_typename<T>::name())("length",N) ) }
 
     template<typename Stream, typename T, size_t N>
+    requires (!std::is_same_v<std::remove_cv_t<T>, char>)
     inline void pack( Stream& s, T (&v)[N]) {
       fc::raw::pack( s, unsigned_int((uint32_t)N) );
       for (uint64_t i = 0; i < N; ++i)
@@ -183,6 +184,7 @@ namespace fc {
     }
 
     template<typename Stream, typename T, size_t N>
+    requires (!std::is_same_v<std::remove_cv_t<T>, char>)
     inline void unpack( Stream& s, T (&v)[N])
     { try {
       unsigned_int size; fc::raw::unpack( s, size );

--- a/libraries/libfc/src/crypto/elliptic_common.cpp
+++ b/libraries/libfc/src/crypto/elliptic_common.cpp
@@ -112,7 +112,7 @@ namespace fc { namespace ecc {
     unsigned int public_key::fingerprint() const
     {
         public_key_data key = serialize();
-        ripemd160 hash = ripemd160::hash( sha256::hash( key.begin(), key.size() ) );
+        ripemd160 hash = ripemd160::hash( sha256::hash_raw( std::span(key.begin(), key.size()) ) );
         unsigned char* fp = (unsigned char*) hash._hash;
         return (fp[0] << 24) | (fp[1] << 16) | (fp[2] << 8) | fp[3];
     }

--- a/libraries/libfc/src/crypto/elliptic_secp256k1.cpp
+++ b/libraries/libfc/src/crypto/elliptic_secp256k1.cpp
@@ -76,7 +76,7 @@ namespace fc { namespace ecc {
       size_t serialized_result_sz = sizeof(serialized_result);
       secp256k1_ec_pubkey_serialize(detail::_get_context(), (unsigned char*)&serialized_result.data, &serialized_result_sz, &secp_pubkey, SECP256K1_EC_COMPRESSED );
       FC_ASSERT( serialized_result_sz == sizeof(serialized_result) );
-      return fc::sha512::hash( serialized_result.begin() + 1, serialized_result.size() - 1 );
+      return fc::sha512::hash_raw( std::span(serialized_result.begin() + 1, serialized_result.size() - 1) );
     }
 
     private_key private_key::generate()

--- a/libraries/libfc/src/crypto/elliptic_webauthn.cpp
+++ b/libraries/libfc/src/crypto/elliptic_webauthn.cpp
@@ -240,11 +240,11 @@ public_key::public_key(const signature& c, const fc::sha256& digest, bool) {
       user_verification_type = user_presence_t::USER_PRESENCE_VERIFIED;
 
    static_assert(min_auth_data_size >= sizeof(fc::sha256), "auth_data min size not enough to store a sha256");
-   FC_ASSERT(memcmp(c.auth_data.data(), fc::sha256::hash(rpid).data(), sizeof(fc::sha256)) == 0, "webauthn rpid hash doesn't match origin");
+   FC_ASSERT(memcmp(c.auth_data.data(), fc::sha256::hash_raw(rpid).data(), sizeof(fc::sha256)) == 0, "webauthn rpid hash doesn't match origin");
 
    //the signature (and thus public key we need to return) will be over
    // sha256(auth_data || client_data_hash)
-   fc::sha256 client_data_hash = fc::sha256::hash(c.client_json);
+   fc::sha256 client_data_hash = fc::sha256::hash_raw(c.client_json);
    fc::sha256::encoder e;
    e.write((char*)c.auth_data.data(), c.auth_data.size());
    e.write(client_data_hash.data(), client_data_hash.data_size());

--- a/libraries/libfc/src/crypto/private_key.cpp
+++ b/libraries/libfc/src/crypto/private_key.cpp
@@ -67,7 +67,7 @@ namespace fc { namespace crypto {
       char data[size_of_data_to_hash + size_of_hash_bytes];
       data[0] = (char)0x80; // this is the Bitcoin MainNet code
       memcpy(&data[1], (const char*)&secret.serialize(), sizeof(typename Data::data_type));
-      sha256 digest = sha256::hash(data, size_of_data_to_hash);
+      sha256 digest = sha256::hash_raw(std::span(data, size_of_data_to_hash));
       digest = sha256::hash(digest);
       memcpy(data + size_of_data_to_hash, (char*)&digest, size_of_hash_bytes);
       return to_base58(data, sizeof(data), yield);
@@ -79,7 +79,7 @@ namespace fc { namespace crypto {
       auto wif_bytes = from_base58(wif_key);
       FC_ASSERT(wif_bytes.size() >= 5);
       auto key_bytes = vector<char>(wif_bytes.begin() + 1, wif_bytes.end() - 4);
-      fc::sha256 check = fc::sha256::hash(wif_bytes.data(), wif_bytes.size() - 4);
+      fc::sha256 check = fc::sha256::hash_raw(std::span(wif_bytes.data(), wif_bytes.size() - 4));
       fc::sha256 check2 = fc::sha256::hash(check);
 
       FC_ASSERT(memcmp( (char*)&check, wif_bytes.data() + wif_bytes.size() - 4, 4 ) == 0 ||

--- a/libraries/libfc/src/crypto/ripemd160.cpp
+++ b/libraries/libfc/src/crypto/ripemd160.cpp
@@ -41,15 +41,6 @@ ripemd160::encoder::encoder() {
   reset();
 }
 
-ripemd160 ripemd160::hash( const char* d, uint32_t dlen ) {
-  encoder e;
-  e.write(d,dlen);
-  return e.result();
-}
-ripemd160 ripemd160::hash( const std::string& s ) {
-  return hash( s.c_str(), s.size() );
-}
-
 void ripemd160::encoder::write( const char* d, uint32_t dlen ) {
   RIPEMD160_Update( &my->ctx, d, dlen);
 }

--- a/libraries/libfc/src/crypto/ripemd160.cpp
+++ b/libraries/libfc/src/crypto/ripemd160.cpp
@@ -41,14 +41,6 @@ ripemd160::encoder::encoder() {
   reset();
 }
 
-ripemd160 ripemd160::hash( const fc::sha512& h )
-{
-  return hash( (const char*)&h, sizeof(h) );
-}
-ripemd160 ripemd160::hash( const fc::sha256& h )
-{
-  return hash( (const char*)&h, sizeof(h) );
-}
 ripemd160 ripemd160::hash( const char* d, uint32_t dlen ) {
   encoder e;
   e.write(d,dlen);

--- a/libraries/libfc/src/crypto/sha1.cpp
+++ b/libraries/libfc/src/crypto/sha1.cpp
@@ -35,15 +35,6 @@ sha1::encoder::encoder() {
   reset();
 }
 
-sha1 sha1::hash( const char* d, uint32_t dlen ) {
-  encoder e;
-  e.write(d,dlen);
-  return e.result();
-}
-sha1 sha1::hash( const std::string& s ) {
-  return hash( s.c_str(), s.size() );
-}
-
 void sha1::encoder::write( const char* d, uint32_t dlen ) {
   SHA1_Update( &my->ctx, d, dlen);
 }

--- a/libraries/libfc/src/crypto/sha224.cpp
+++ b/libraries/libfc/src/crypto/sha224.cpp
@@ -33,15 +33,6 @@ namespace fc {
       reset();
     }
 
-    sha224 sha224::hash( const char* d, uint32_t dlen ) {
-      encoder e;
-      e.write(d,dlen);
-      return e.result();
-    }
-    sha224 sha224::hash( const std::string& s ) {
-      return hash( s.c_str(), s.size() );
-    }
-
     void sha224::encoder::write( const char* d, uint32_t dlen ) {
       SHA224_Update( &my->ctx, d, dlen);
     }

--- a/libraries/libfc/src/crypto/sha256.cpp
+++ b/libraries/libfc/src/crypto/sha256.cpp
@@ -204,12 +204,6 @@ namespace fc {
         memset( bi.data(), char(0), sizeof(bi) );
   }
 
-  uint64_t hash64(const char* buf, size_t len)
-  {
-    sha256 sha_value = sha256::hash(buf,len);
-    return sha_value._hash[0];
-  }
-
     template<>
     unsigned int hmac<sha256>::internal_block_size() const { return 64; }
 } //end namespace fc

--- a/libraries/libfc/src/crypto/sha256.cpp
+++ b/libraries/libfc/src/crypto/sha256.cpp
@@ -41,16 +41,6 @@ namespace fc {
       reset();
     }
 
-    sha256 sha256::hash( const char* d, uint32_t dlen ) {
-      encoder e;
-      e.write(d,dlen);
-      return e.result();
-    }
-
-    sha256 sha256::hash( const std::string& s ) {
-      return hash( s.c_str(), s.size() );
-    }
-
     void sha256::encoder::write( const char* d, uint32_t dlen ) {
       SHA256_Update( &my->ctx, d, dlen);
     }

--- a/libraries/libfc/src/crypto/sha256.cpp
+++ b/libraries/libfc/src/crypto/sha256.cpp
@@ -51,11 +51,6 @@ namespace fc {
       return hash( s.c_str(), s.size() );
     }
 
-    sha256 sha256::hash( const sha256& s )
-    {
-        return hash( s.data(), sizeof( s._hash ) );
-    }
-
     void sha256::encoder::write( const char* d, uint32_t dlen ) {
       SHA256_Update( &my->ctx, d, dlen);
     }

--- a/libraries/libfc/src/crypto/sha512.cpp
+++ b/libraries/libfc/src/crypto/sha512.cpp
@@ -34,15 +34,6 @@ namespace fc {
       reset();
     }
 
-    sha512 sha512::hash( const char* d, uint32_t dlen ) {
-      encoder e;
-      e.write(d,dlen);
-      return e.result();
-    }
-    sha512 sha512::hash( const std::string& s ) {
-      return hash( s.c_str(), s.size() );
-    }
-
     void sha512::encoder::write( const char* d, uint32_t dlen ) {
       SHA512_Update( &my->ctx, d, dlen);
     }

--- a/libraries/libfc/test/crypto/test_cypher_suites.cpp
+++ b/libraries/libfc/test/crypto/test_cypher_suites.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(test_r1) try {
 
 BOOST_AUTO_TEST_CASE(test_k1_recovery) try {
    auto payload = "Test Cases";
-   auto digest = sha256::hash(payload, const_strlen(payload));
+   auto digest = sha256::hash_raw(std::string_view(payload));
    auto key = private_key::generate<ecc::private_key_shim>();
    auto pub = key.get_public_key();
    auto sig = key.sign(digest);
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(test_k1_recovery) try {
 
 BOOST_AUTO_TEST_CASE(test_r1_recovery) try {
    auto payload = "Test Cases";
-   auto digest = sha256::hash(payload, const_strlen(payload));
+   auto digest = sha256::hash_raw(std::string_view(payload));
    auto key = private_key::generate<r1::private_key_shim>();
    auto pub = key.get_public_key();
    auto sig = key.sign(digest);

--- a/libraries/libfc/test/crypto/test_hash_functions.cpp
+++ b/libraries/libfc/test/crypto/test_hash_functions.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(sha3) try {
    };
 
    for(const auto& test : tests) {
-      BOOST_CHECK_EQUAL(fc::sha3::hash(std::get<0>(test), true).str(), std::get<1>(test));
+      BOOST_CHECK_EQUAL(fc::sha3::hash_raw(std::get<0>(test), true).str(), std::get<1>(test));
    }
 
 } FC_LOG_AND_RETHROW();
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(keccak256) try {
    };
 
    for(const auto& test : tests) {
-      BOOST_CHECK_EQUAL(fc::sha3::hash(std::get<0>(test), false).str(), std::get<1>(test));
+      BOOST_CHECK_EQUAL(fc::sha3::hash_raw(std::get<0>(test), false).str(), std::get<1>(test));
    }
 
 } FC_LOG_AND_RETHROW();

--- a/libraries/libfc/test/crypto/test_webauthn.cpp
+++ b/libraries/libfc/test/crypto/test_webauthn.cpp
@@ -15,7 +15,7 @@ static fc::crypto::webauthn::signature make_webauthn_sig(const fc::crypto::r1::p
                                                          const std::string& json) {
 
    //webauthn signature is sha256(auth_data || client_data_hash)
-   fc::sha256 client_data_hash = fc::sha256::hash(json);
+   fc::sha256 client_data_hash = fc::sha256::hash_raw(json);
    fc::sha256::encoder e;
    e.write((char*)auth_data.data(), auth_data.size());
    e.write(client_data_hash.data(), client_data_hash.data_size());
@@ -38,8 +38,8 @@ static fc::crypto::webauthn::signature make_webauthn_sig(const fc::crypto::r1::p
 //used for many below
 static const r1::private_key priv = fc::crypto::r1::private_key::generate();
 static const r1::public_key pub = priv.get_public_key();
-static const fc::sha256 d = fc::sha256::hash("monkeys"s);
-static const fc::sha256 origin_hash = fc::sha256::hash("fctesting.invalid"s);
+static const fc::sha256 d = fc::sha256::hash_raw("monkeys"s);
+static const fc::sha256 origin_hash = fc::sha256::hash_raw("fctesting.invalid"s);
 
 BOOST_AUTO_TEST_SUITE(webauthn_suite)
 
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(mismatch_origin) try {
    std::string json = "{\"origin\":\"https://mallory.invalid\",\"type\":\"webauthn.get\",\"challenge\":\"" + fc::base64url_encode(d.data(), d.data_size()) + "\"}";
 
    std::vector<uint8_t> auth_data(37);
-   fc::sha256 mallory_origin_hash = fc::sha256::hash("mallory.invalid"s);
+   fc::sha256 mallory_origin_hash = fc::sha256::hash_raw("mallory.invalid"s);
    memcpy(auth_data.data(), mallory_origin_hash.data(), sizeof(mallory_origin_hash));
 
    BOOST_CHECK_NE(wa_pub, make_webauthn_sig(priv, auth_data, json).recover(d, true));
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(challenge_extra_bytes) try {
 //valid signature but with some other digest in the challenge that is not the one we are recovering from
 BOOST_AUTO_TEST_CASE(challenge_wrong) try {
    webauthn::public_key wa_pub(pub.serialize(), webauthn::public_key::user_presence_t::USER_PRESENCE_NONE, "fctesting.invalid");
-   fc::sha256 other_digest = fc::sha256::hash("yo"s);
+   fc::sha256 other_digest = fc::sha256::hash_raw("yo"s);
    std::string json = "{\"origin\":\"https://fctesting.invalid\",\"type\":\"webauthn.get\",\"challenge\":\"" + fc::base64url_encode(other_digest.data(), other_digest.data_size()) + "\"}";
 
    std::vector<uint8_t> auth_data(37);
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(auth_data_rpid_hash_bad) try {
    std::string json = "{\"origin\":\"https://fctesting.invalid\",\"type\":\"webauthn.get\",\"challenge\":\"" + fc::base64url_encode(d.data(), d.data_size()) + "\"}";
 
    std::vector<uint8_t> auth_data(37);
-   fc::sha256 origin_hash_corrupt = fc::sha256::hash("fctesting.invalid"s);
+   fc::sha256 origin_hash_corrupt = fc::sha256::hash_raw("fctesting.invalid"s);
    memcpy(auth_data.data(), origin_hash_corrupt.data(), sizeof(origin_hash_corrupt));
    auth_data[4]++;
 

--- a/libraries/libfc/test/test_bls.cpp
+++ b/libraries/libfc/test/test_bls.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(bls_sig_verif_finality_types) try {
   std::string s_view_number = std::to_string(view_number);
   std::string c_s = cmt + s_view_number;
 
-  fc::sha256 h1 = fc::sha256::hash(c_s);
+  fc::sha256 h1 = fc::sha256::hash_raw(c_s);
   fc::sha256 h2 = fc::sha256::hash( std::make_pair( h1, message_3 ) );
 
   std::vector<unsigned char> v = std::vector<unsigned char>(h2.data(), h2.data() + 32);

--- a/libraries/testing/include/eosio/testing/bls_utils.hpp
+++ b/libraries/testing/include/eosio/testing/bls_utils.hpp
@@ -7,7 +7,7 @@
 namespace eosio::testing {
 
    inline auto get_bls_private_key( eosio::chain::name keyname ) {
-      auto secret = fc::sha256::hash(keyname.to_string());
+      auto secret = fc::sha256::hash_raw(keyname.to_string());
       std::vector<uint8_t> seed(secret.data_size());
       memcpy(seed.data(), secret.data(), secret.data_size());
       return fc::crypto::blslib::bls_private_key(seed);

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -131,7 +131,7 @@ namespace eosio::testing {
             std::vector<uint8_t> auth_data(37);
             memcpy(auth_data.data(), _origin_hash.data(), sizeof(_origin_hash));
 
-            auto client_data_hash = fc::sha256::hash(json);
+            auto client_data_hash = fc::sha256::hash_raw(json);
             fc::sha256::encoder e;
             e.write((char*)auth_data.data(), auth_data.size());
             e.write(client_data_hash.data(), client_data_hash.data_size());
@@ -376,7 +376,7 @@ namespace eosio::testing {
 
          template< typename KeyType = fc::ecc::private_key_shim >
          static auto get_private_key( name keyname, string role = "owner" ) {
-            auto secret = fc::sha256::hash(keyname.to_string() + role);
+            auto secret = fc::sha256::hash_raw(keyname.to_string() + role);
             if constexpr (std::is_same_v<KeyType, mock::webauthn_private_key>) {
                return mock::webauthn_private_key::regenerate(secret);
             } else {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1608,7 +1608,7 @@ namespace eosio::testing {
    }
 
    const std::string mock::webauthn_private_key::_origin = "mock.webauthn.invalid";
-   const sha256 mock::webauthn_private_key::_origin_hash = fc::sha256::hash(mock::webauthn_private_key::_origin);
+   const sha256 mock::webauthn_private_key::_origin_hash = fc::sha256::hash_raw(mock::webauthn_private_key::_origin);
 }  /// eosio::testing
 
 std::ostream& operator<<( std::ostream& osm, const fc::variant& v ) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2412,7 +2412,7 @@ read_only::get_raw_abi_results read_only::get_raw_abi( const get_raw_abi_params&
    const auto& d = db.db();
    const auto& accnt_obj          = d.get<account_object,by_name>(params.account_name);
    const auto& accnt_metadata_obj = d.get<account_metadata_object,by_name>(params.account_name);
-   result.abi_hash = fc::sha256::hash( accnt_obj.abi.data(), accnt_obj.abi.size() );
+   result.abi_hash = fc::sha256::hash_raw( accnt_obj.abi );
    if( accnt_metadata_obj.code_hash != digest_type() )
       result.code_hash = accnt_metadata_obj.code_hash;
    if( !params.abi_hash || *params.abi_hash != result.abi_hash )

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -45,7 +45,7 @@ using namespace eosio::chain_apis;
 using namespace eosio::test::detail;
 
 auto get_private_key( chain::name keyname, std::string role = "owner" ) {
-   auto secret = fc::sha256::hash( keyname.to_string() + role );
+   auto secret = fc::sha256::hash_raw( keyname.to_string() + role );
    return chain::private_key_type::regenerate<fc::ecc::private_key_shim>( secret );
 }
 

--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -86,7 +86,7 @@ private:
 };
 
 auto get_private_key( chain::name keyname, std::string role = "owner" ) {
-   auto secret = fc::sha256::hash( keyname.to_string() + role );
+   auto secret = fc::sha256::hash_raw( keyname.to_string() + role );
    return chain::private_key_type::regenerate<fc::ecc::private_key_shim>( secret );
 }
 

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -5165,11 +5165,11 @@ namespace eosio {
          fc::unique_lock g_conn(c->conn_mtx);
          if (c->unique_conn_node_id.empty()) { // still connecting, use temp id so that non-connected peers are reported
             if (!c->p2p_address.empty()) {
-               c->unique_conn_node_id = fc::sha256::hash(c->p2p_address).str().substr(0, 7);
+               c->unique_conn_node_id = fc::sha256::hash_raw(c->p2p_address).str().substr(0, 7);
             } else if (!c->remote_endpoint_ip.empty()) {
-               c->unique_conn_node_id = fc::sha256::hash(c->remote_endpoint_ip).str().substr(0, 7);
+               c->unique_conn_node_id = fc::sha256::hash_raw(c->remote_endpoint_ip).str().substr(0, 7);
             } else {
-               c->unique_conn_node_id = fc::sha256::hash(std::to_string(c->connection_id)).str().substr(0, 7);
+               c->unique_conn_node_id = fc::sha256::hash_raw(std::to_string(c->connection_id)).str().substr(0, 7);
             }
          }
          std::string conn_node_id = c->unique_conn_node_id;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1266,7 +1266,7 @@ void producer_plugin::set_program_options(
 {
    using namespace std::string_literals;
 
-   auto default_priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("nathan")));
+   auto default_priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash_raw(std::string("nathan")));
    auto private_key_default = std::make_pair(default_priv_key.get_public_key(), default_priv_key );
 
    boost::program_options::options_description producer_options;

--- a/plugins/producer_plugin/test/test_disallow_delayed_trx.cpp
+++ b/plugins/producer_plugin/test/test_disallow_delayed_trx.cpp
@@ -32,7 +32,7 @@ auto make_delayed_trx( const chain_id_type& chain_id ) {
    signed_transaction trx;
    trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}}, testit{0} );
    trx.delay_sec = 10;
-   auto priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("nathan")));
+   auto priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash_raw(std::string("nathan")));
    trx.sign( priv_key, chain_id );
 
    return std::make_shared<packed_transaction>( std::move(trx) );

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -57,10 +57,10 @@ auto make_unique_trx( const chain_id_type& chain_id ) {
                                 testit{ nextid % 7 == 0 ? 0 : nextid} ); // fail some for duplicates
    }
    if( nextid % 13 == 0 ) { // fail some for invalid signature
-      auto bad_priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("kevin")));
+      auto bad_priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash_raw(std::string("kevin")));
       trx.sign( bad_priv_key, chain_id );
    } else {
-      auto priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("nathan")));
+      auto priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash_raw(std::string("nathan")));
       trx.sign( priv_key, chain_id );
    }
 

--- a/plugins/trace_api_plugin/test/include/eosio/trace_api/test_common.hpp
+++ b/plugins/trace_api_plugin/test/include/eosio/trace_api/test_common.hpp
@@ -33,7 +33,7 @@ namespace eosio::trace_api {
       }
 
       inline auto get_private_key( chain::name keyname, std::string role = "owner" ) {
-         auto secret = fc::sha256::hash( keyname.to_string() + role );
+         auto secret = fc::sha256::hash_raw( keyname.to_string() + role );
          return chain::private_key_type::regenerate<fc::ecc::private_key_shim>( secret );
       }
 

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -33,7 +33,7 @@ private_key_type derive_private_key( const std::string& prefix_string,
                                          int sequence_number )
 {
    std::string sequence_string = std::to_string(sequence_number);
-   fc::sha512 h = fc::sha512::hash(prefix_string + " " + sequence_string);
+   fc::sha512 h = fc::sha512::hash_raw(prefix_string + " " + sequence_string);
    return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(h));
 }
 
@@ -350,7 +350,7 @@ void soft_wallet::lock()
 void soft_wallet::unlock(string password)
 { try {
    FC_ASSERT(password.size() > 0);
-   auto pw = fc::sha512::hash(password.c_str(), password.size());
+   auto pw = fc::sha512::hash_raw(password);
    vector<char> decrypted = fc::aes_decrypt(pw, my->_wallet.cipher_keys);
    auto pk = fc::raw::unpack<plain_keys>(decrypted);
    FC_ASSERT(pk.checksum == pw);
@@ -362,7 +362,7 @@ void soft_wallet::unlock(string password)
 void soft_wallet::check_password(string password)
 { try {
    FC_ASSERT(password.size() > 0);
-   auto pw = fc::sha512::hash(password.c_str(), password.size());
+   auto pw = fc::sha512::hash_raw(password);
    vector<char> decrypted = fc::aes_decrypt(pw, my->_wallet.cipher_keys);
    auto pk = fc::raw::unpack<plain_keys>(decrypted);
    FC_ASSERT(pk.checksum == pw);
@@ -373,7 +373,7 @@ void soft_wallet::set_password( string password )
 {
    if( !is_new() )
       EOS_ASSERT( !is_locked(), wallet_locked_exception, "The wallet must be unlocked before the password can be set" );
-   my->_checksum = fc::sha512::hash( password.c_str(), password.size() );
+   my->_checksum = fc::sha512::hash_raw( password );
    lock();
 }
 
@@ -402,7 +402,7 @@ std::optional<signature_type> soft_wallet::try_sign_digest( const digest_type di
 pair<public_key_type,private_key_type> soft_wallet::get_private_key_from_password( string account, string role, string password )const {
    auto seed = account + role + password;
    EOS_ASSERT( seed.size(), wallet_exception, "seed should not be empty" );
-   auto secret = fc::sha256::hash( seed.c_str(), seed.size() );
+   auto secret = fc::sha256::hash_raw( seed );
    auto priv = private_key_type::regenerate<fc::ecc::private_key_shim>( secret );
    return std::make_pair(  priv.get_public_key(), priv );
 }

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3245,7 +3245,7 @@ int main( int argc, char** argv ) {
 
          fc::sha256 hash;
          if(wasm_v.size())
-            hash = fc::sha256::hash(wasm_v.data(), wasm_v.size());
+            hash = fc::sha256::hash_raw(wasm_v);
          code_hash = (string)hash;
 
          wasm = string(wasm_v.begin(), wasm_v.end());
@@ -3668,7 +3668,7 @@ int main( int argc, char** argv ) {
 
       if (!suppress_duplicate_check) {
          if (code_bytes.size()) {
-            new_hash = fc::sha256::hash(&(code_bytes[0]), code_bytes.size());
+            new_hash = fc::sha256::hash_raw(code_bytes);
          }
          duplicate = (old_hash == new_hash);
       }

--- a/tests/block_log.cpp
+++ b/tests/block_log.cpp
@@ -20,7 +20,7 @@ struct block_log_fixture {
       bounce();
    }
 
-   fc::sha256 non_genesis_chain_id = fc::sha256::hash(std::string("spoon was here"));
+   fc::sha256 non_genesis_chain_id = fc::sha256::hash_raw(std::string("spoon was here"));
 
    void startup(uint32_t first) {
       if(first > 1) {

--- a/tests/chain_test_utils.hpp
+++ b/tests/chain_test_utils.hpp
@@ -51,9 +51,9 @@ struct reqactivated {
 
 inline private_key_type get_private_key( name keyname, string role ) {
    if (keyname == config::system_account_name)
-      return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("nathan")));
+      return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash_raw(std::string("nathan")));
 
-   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(keyname.to_string()+role));
+   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash_raw(keyname.to_string()+role));
 }
 
 inline public_key_type  get_public_key( name keyname, string role ){

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -622,7 +622,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    params.lower_bound = "2652d68fbbf6000c703b35fdc607b09cd8218cbeea1d108b5c9e84842cdd5ea5"; // This is hash of "thirdinput"
 
    auto res_6 = get_table_rows_full(plugin, params, fc::time_point::maximum());
-   checksum256_type sec256_expected_value = checksum256_type::hash(std::string("thirdinput"));
+   checksum256_type sec256_expected_value = checksum256_type::hash_raw(std::string("thirdinput"));
    BOOST_REQUIRE(res_6.rows.size() > 0u);
    checksum256_type sec256_res_value = res_6.rows[0].get_object()["sec256"].as<checksum256_type>();
    BOOST_TEST(sec256_res_value == sec256_expected_value);
@@ -630,7 +630,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    BOOST_TEST(res_6.next_key == "3cb93a80b47b9d70c5296be3817d34b48568893b31468e3a76337bb7d3d0c264");
    params.lower_bound = res_6.next_key;
    auto more2_res_6 = get_table_rows_full(plugin, params, fc::time_point::maximum());
-   checksum256_type more2_sec256_expected_value = checksum256_type::hash(std::string("secondinput"));
+   checksum256_type more2_sec256_expected_value = checksum256_type::hash_raw(std::string("secondinput"));
    BOOST_REQUIRE(more2_res_6.rows.size() > 0u);
    checksum256_type more2_sec256_res_value = more2_res_6.rows[0].get_object()["sec256"].as<checksum256_type>();
    BOOST_TEST(more2_sec256_res_value == more2_sec256_expected_value);
@@ -642,7 +642,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    params.lower_bound = "0x2652d68fbbf6000c703b35fdc607b09cd8218cbeea1d108b5c9e84842cdd5ea5"; // This is sha256 hash of "thirdinput" as number
 
    auto res_7 = get_table_rows_full(plugin, params, fc::time_point::maximum());
-   checksum256_type i256_expected_value = checksum256_type::hash(std::string("thirdinput"));
+   checksum256_type i256_expected_value = checksum256_type::hash_raw(std::string("thirdinput"));
    BOOST_REQUIRE(res_7.rows.size() > 0u);
    checksum256_type i256_res_value = res_7.rows[0].get_object()["sec256"].as<checksum256_type>();
    BOOST_TEST(i256_res_value == i256_expected_value);
@@ -650,7 +650,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    BOOST_TEST(res_7.next_key == "0x3cb93a80b47b9d70c5296be3817d34b48568893b31468e3a76337bb7d3d0c264");
    params.lower_bound = res_7.next_key;
    auto more2_res_7 = get_table_rows_full(plugin, params, fc::time_point::maximum());
-   checksum256_type more2_i256_expected_value = checksum256_type::hash(std::string("secondinput"));
+   checksum256_type more2_i256_expected_value = checksum256_type::hash_raw(std::string("secondinput"));
    BOOST_REQUIRE(more2_res_7.rows.size() > 0u);
    checksum256_type more2_i256_res_value = more2_res_7.rows[0].get_object()["sec256"].as<checksum256_type>();
    BOOST_TEST(more2_i256_res_value == more2_i256_expected_value);
@@ -662,7 +662,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    params.lower_bound = "ab4314638b573fdc39e5a7b107938ad1b5a16414"; // This is ripemd160 hash of "thirdinput"
 
    auto res_8 = get_table_rows_full(plugin, params, fc::time_point::maximum());
-   ripemd160 sec160_expected_value = ripemd160::hash(std::string("thirdinput"));
+   ripemd160 sec160_expected_value = ripemd160::hash_raw(std::string("thirdinput"));
    BOOST_REQUIRE(res_8.rows.size() > 0u);
    ripemd160 sec160_res_value = res_8.rows[0].get_object()["sec160"].as<ripemd160>();
    BOOST_TEST(sec160_res_value == sec160_expected_value);
@@ -670,7 +670,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
    BOOST_TEST(res_8.next_key == "fb9d03d3012dc2a6c7b319f914542e3423550c2a");
    params.lower_bound = res_8.next_key;
    auto more2_res_8 = get_table_rows_full(plugin, params, fc::time_point::maximum());
-   ripemd160 more2_sec160_expected_value = ripemd160::hash(std::string("secondinput"));
+   ripemd160 more2_sec160_expected_value = ripemd160::hash_raw(std::string("secondinput"));
    BOOST_REQUIRE(more2_res_8.rows.size() > 0u);
    ripemd160 more2_sec160_res_value = more2_res_8.rows[0].get_object()["sec160"].as<ripemd160>();
    BOOST_TEST(more2_sec160_res_value == more2_sec160_expected_value);

--- a/tests/ship_log.cpp
+++ b/tests/ship_log.cpp
@@ -91,7 +91,7 @@ struct ship_log_fixture {
       a.assign(size, fillchar);
 
       auto block_for_id = [](const uint32_t bnum, const char fillc) {
-         fc::sha256 m = fc::sha256::hash(fc::sha256::hash(std::to_string(bnum)+fillc));
+         fc::sha256 m = fc::sha256::hash(fc::sha256::hash_raw(std::to_string(bnum)+fillc));
          m._hash[0] = fc::endian_reverse_u32(bnum);
          return m;
       };

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -1655,7 +1655,7 @@ void verify_action_equal(const chain::action& exp, const chain::action& act)
 }
 
 private_key_type get_private_key( name keyname, string role ) {
-   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(keyname.to_string()+role));
+   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash_raw(keyname.to_string()+role));
 }
 
 public_key_type  get_public_key( name keyname, string role ) {

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -2710,7 +2710,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_test, T, validating_testers) { try 
          buf2.resize(fc::raw::pack_size(*act_base));
          datastream<char*> ds2(buf2.data(), buf2.size());
          fc::raw::pack(ds2, *act_base);
-         fc::raw::pack(ds, sha256::hash(buf2.data(), buf2.size()));
+         fc::raw::pack(ds, sha256::hash_raw(buf2));
       }
 
       {
@@ -2719,10 +2719,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(action_ordinal_test, T, validating_testers) { try 
          datastream<char*> ds2(buf2.data(), buf2.size());
          fc::raw::pack(ds2, act.data);
          fc::raw::pack(ds2, act_output);
-         fc::raw::pack(ds, sha256::hash(buf2.data(), buf2.size()));
+         fc::raw::pack(ds, sha256::hash_raw(buf2));
       }
 
-      digest_type computed_act_digest = sha256::hash(buf1.data(), ds.tellp());
+      digest_type computed_act_digest = sha256::hash_raw(std::span(buf1.data(), ds.tellp()));
 
       return expected_act_digest == computed_act_digest;
    };

--- a/unittests/finalizer_tests.cpp
+++ b/unittests/finalizer_tests.cpp
@@ -44,12 +44,12 @@ std::vector<FSI> create_random_fsi(size_t count) {
    // but compared to loaded ones which get the default values of 0.
    for (size_t i = 0; i < count; ++i) {
       res.push_back(FSI{
-         .last_vote             = block_ref{sha256::hash("vote"s + std::to_string(i)),
+         .last_vote             = block_ref{sha256::hash_raw("vote"s + std::to_string(i)),
                                             tstamp(i * 100 + 3),
-                                            sha256::hash("vote_digest"s + std::to_string(i)), 0, 0},
-         .lock                  = block_ref{sha256::hash("lock"s + std::to_string(i)),
+                                            sha256::hash_raw("vote_digest"s + std::to_string(i)), 0, 0},
+         .lock                  = block_ref{sha256::hash_raw("lock"s + std::to_string(i)),
                                             tstamp(i * 100),
-                                            sha256::hash("lock_digest"s + std::to_string(i)), 0, 0},
+                                            sha256::hash_raw("lock_digest"s + std::to_string(i)), 0, 0},
          .other_branch_latest_time = block_timestamp_type{}
       });
       if (i)

--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -11,7 +11,7 @@ uint32_t nonce = 0;
 
 inline block_id_type make_block_id(block_num_type block_num) {
    ++nonce;
-   block_id_type id = fc::sha256::hash(std::to_string(block_num) + "-" + std::to_string(nonce));
+   block_id_type id = fc::sha256::hash_raw(std::to_string(block_num) + "-" + std::to_string(nonce));
    id._hash[0] &= 0xffffffff00000000;
    id._hash[0] += fc::endian_reverse_u32(block_num); // store the block num in the ID, 160 bits is plenty for the hash
    return id;

--- a/unittests/fork_test_utilities.cpp
+++ b/unittests/fork_test_utilities.cpp
@@ -1,7 +1,7 @@
 #include "fork_test_utilities.hpp"
 
 private_key_type get_private_key( name keyname, string role ) {
-   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(keyname.to_string()+role));
+   return private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash_raw(keyname.to_string()+role));
 }
 
 public_key_type  get_public_key( name keyname, string role ){

--- a/unittests/merkle_tree_tests.cpp
+++ b/unittests/merkle_tree_tests.cpp
@@ -10,7 +10,7 @@ std::vector<digest_type> create_test_digests(size_t n) {
    std::vector<digest_type> v;
    v.reserve(n);
    for (size_t i=0; i<n; ++i)
-      v.push_back(fc::sha256::hash(std::string{"Node"} + std::to_string(i)));
+      v.push_back(fc::sha256::hash_raw(std::string{"Node"} + std::to_string(i)));
    return v;
 }
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(variant_format_string_limited)
             const std::string key_name_str = permission.actor.to_string() + permission.permission.to_string();
             auto sig_digest = digest_type::hash(std::make_pair("1234", "abcd"));
             const fc::crypto::signature sig = private_key_type::regenerate<fc::ecc::private_key_shim>(
-                  fc::sha256::hash(key_name_str + "active")).sign(sig_digest);
+                  fc::sha256::hash_raw(key_name_str + "active")).sign(sig_digest);
             provided_keys.insert(public_key_type{sig, fc::sha256{digest}, true});
          }
       };


### PR DESCRIPTION
This is another attempt to allow passing `hash()` multiple arguments to concatenate together similar to how `pack()` already does. This can allow some more concise usage of `hash()` without resorting to `make_tuple/pair()` and remembering to avoid the trap of needing to use `cref` along with `make_tuple/pair()` to avoid copies.

Based on this comment chain https://github.com/AntelopeIO/spring/pull/1526#discussion_r2093536377 I have modified the hash impls such that,
* `hash_raw()` takes a `ContiguousCharSource` that it hashes directly -- this is the previous behavior when using these nontemplated call forms:
https://github.com/AntelopeIO/spring/blob/e3caa447b9742bb1bf190f53315cb34522542917/libraries/libfc/include/fc/crypto/sha1.hpp#L20-L21
* `hash()` now is variadic and hashes with the same rules of our serialization format

Of course this means that usage of `hash(std::string())` now has different output between these two revisions so any usages of that which matter (many don't!) need to be migrated to `hash_raw(std::string())`.

So the way I approached this was to first convert all calls to the two forms above to `hash_raw()`, and then go back and make a determination for sites that are fine to transition to simple `hash()` in order to limit the number of `hash_raw()` calls. But that was a huge pain: so this PR just leaves all calls to the two forms above as `hash_raw()` but that means the change set is large.

Ultimately I'm not really all that confident in making such a huge change.