### PR TITLE
[2.0.0-dev] remove use of deprecated python distutils

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -62,7 +62,7 @@ set(CPACK_DEBIAN_BASE_FILE_NAME "${CPACK_DEBIAN_FILE_NAME}.deb")
 string(REGEX REPLACE "^(${CMAKE_PROJECT_NAME})" "\\1-dev" CPACK_DEBIAN_DEV_FILE_NAME "${CPACK_DEBIAN_BASE_FILE_NAME}")
 
 #deb package tooling will be unable to detect deps for the dev package. llvm is tricky since we don't know what package could have been used; try to figure it out
-set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "libgmp-dev, python3-distutils, python3-numpy, zlib1g-dev")
+set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "libgmp-dev, python3-numpy, zlib1g-dev")
 find_program(DPKG_QUERY "dpkg-query")
 if(DPKG_QUERY AND OS_RELEASE MATCHES "\n?ID=\"?ubuntu" AND LLVM_CMAKE_DIR)
    execute_process(COMMAND "${DPKG_QUERY}" -S "${LLVM_CMAKE_DIR}" COMMAND cut -d: -f1 RESULT_VARIABLE LLVM_PKG_FIND_RESULT OUTPUT_VARIABLE LLVM_PKG_FIND_OUTPUT)

--- a/scripts/postinst
+++ b/scripts/postinst
@@ -1,16 +1,7 @@
 #!/bin/sh
 
 set -e
-Python_SITELIB=$(python3 <<EOF
-import sys
-if sys.version_info < (3, 10, 0):
-    from distutils import sysconfig
-    print(sysconfig.get_python_lib(plat_specific=False,standard_lib=False))
-else:
-    from sysconfig import get_path; print(get_path('platlib', 'deb_system'))
-EOF
-)
-
+Python_SITELIB=$(python3 -c "from sysconfig import get_path; print(get_path('platlib', 'deb_system'))")
 mkdir -p $Python_SITELIB
 ln -sf @CMAKE_INSTALL_FULL_DATAROOTDIR@/spring_testing/tests/TestHarness $Python_SITELIB/TestHarness
 

--- a/scripts/prerm
+++ b/scripts/prerm
@@ -1,15 +1,6 @@
 #!/bin/sh
 
 # Cleanup symbolic links created during postinst
-Python_SITELIB=$(python3 <<EOF
-import sys
-if sys.version_info < (3, 10, 0):
-    from distutils import sysconfig
-    print(sysconfig.get_python_lib(plat_specific=False,standard_lib=False))
-else:
-    from sysconfig import get_path; print(get_path('platlib', 'deb_system'))
-EOF
-)
-
+Python_SITELIB=$(python3 -c "from sysconfig import get_path; print(get_path('platlib', 'deb_system'))")
 rm -f $Python_SITELIB/TestHarness
 rm -f @CMAKE_INSTALL_FULL_DATAROOTDIR@/spring_testing/bin


### PR DESCRIPTION
reapply original changes from #931 on to 2.0 since 2.0 branch no longer supports ubuntu20