### PR TITLE
[2.0.0-dev] bump cmake requirement to 3.21; remove <3.21 workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.16...4.0 )
+cmake_minimum_required( VERSION 3.21...4.0 )
 
 project( antelope-spring )
 include(CTest)
@@ -263,26 +263,14 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/TestHarness DESTINATION ${CM
         PATTERN "__pycache__" EXCLUDE
         PATTERN "CMakeFiles" EXCLUDE)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.21)
-   # Cmake versions < 3.21 did not support installing symbolic links to a directory via install(FILES ...)
-   # Cmake 3.21 fixed this (https://gitlab.kitware.com/cmake/cmake/-/commit/d71a7cc19d6e03f89581efdaa8d63db216184d40)
-   # If/when the lowest cmake version supported becomes >= 3.21, the else block as well as the postinit and prerm scripts
-   # would be a good option to remove in favor of using the facilities in cmake / cpack directly.
+add_custom_target(link_target ALL
+   COMMAND ${CMAKE_COMMAND} -E make_directory lib/python3/dist-packages
+   COMMAND ${CMAKE_COMMAND} -E create_symlink ../../../share/spring_testing/tests/TestHarness lib/python3/dist-packages/TestHarness
+   COMMAND ${CMAKE_COMMAND} -E make_directory share/spring_testing
+   COMMAND ${CMAKE_COMMAND} -E create_symlink ../../bin share/spring_testing/bin)
 
-   add_custom_target(link_target ALL
-      COMMAND ${CMAKE_COMMAND} -E make_directory lib/python3/dist-packages
-      COMMAND ${CMAKE_COMMAND} -E create_symlink ../../../share/spring_testing/tests/TestHarness lib/python3/dist-packages/TestHarness
-      COMMAND ${CMAKE_COMMAND} -E make_directory share/spring_testing
-      COMMAND ${CMAKE_COMMAND} -E create_symlink ../../bin share/spring_testing/bin)
-
-   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/python3/dist-packages/TestHarness DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/python3/dist-packages COMPONENT dev EXCLUDE_FROM_ALL)
-   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/spring_testing/bin DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/spring_testing COMPONENT dev EXCLUDE_FROM_ALL)
-else()
-   # The following install(SCRIPT ...) steps are necessary for `make dev-install` to work on cmake versions < 3.21.
-   install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/scripts/install_testharness_symlinks.cmake COMPONENT dev EXCLUDE_FROM_ALL)
-
-   # The `make package` installation of symlinks happens via the `postinst` script installed in cmake.package via the line below
-endif()
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/python3/dist-packages/TestHarness DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/python3/dist-packages COMPONENT dev EXCLUDE_FROM_ALL)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/spring_testing/bin DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/spring_testing COMPONENT dev EXCLUDE_FROM_ALL)
 
 configure_file(${CMAKE_SOURCE_DIR}/libraries/cli11/bash-completion/completions/spring-util
                ${CMAKE_BINARY_DIR}/programs/spring-util/bash-completion/completions/spring-util COPYONLY)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -2,4 +2,3 @@
 configure_file(abi_is_json.py abi_is_json.py COPYONLY)
 configure_file(postinst . @ONLY)
 configure_file(prerm . @ONLY)
-configure_file(install_testharness_symlinks.cmake .)

--- a/scripts/install_testharness_symlinks.cmake
+++ b/scripts/install_testharness_symlinks.cmake
@@ -1,5 +1,0 @@
-execute_process( COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_FULL_LIBDIR}/python3/dist-packages  ERROR_QUIET RESULT_VARIABLE ret)
-if(ret EQUAL "0")
-    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink ../../../share/spring_testing/tests/TestHarness ${CMAKE_INSTALL_FULL_LIBDIR}/python3/dist-packages/TestHarness)
-    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink ../../bin ${CMAKE_INSTALL_FULL_DATAROOTDIR}/spring_testing/bin)
-endif()


### PR DESCRIPTION
Remove a workaround for cmake <3.21. There doesn't seem to be a compelling reason to keep support for <3.21 since Ubuntu22 is on cmake 3.22. Debian11 has 3.18 out of the box but ships with gcc10 which isn't going to cut it -- so no real argument that keeping support for <3.21 helps Debian any either. EL9 ships with gcc11 and has cmake 3.26 available so that's fine too.