### PR TITLE
[1.2.2] P2P: Reset sync on rejected block

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2400,7 +2400,7 @@ namespace eosio {
       {
          // reset sync on rejected block
          fc::lock_guard g( sync_mtx );
-         if (blk_num <= sync_next_expected_num-1) { // no need to reset if we already reset and are syncing again
+         if (sync_last_requested_num != 0 && blk_num <= sync_next_expected_num-1) { // no need to reset if we already reset and are syncing again
             sync_last_requested_num = 0;
             sync_next_expected_num = my_impl->get_fork_db_root_num() + 1;
          }


### PR DESCRIPTION
Reverts #1676. A recent test failure #1716 demonstrates the need for the reset. The test failed because it timed out waiting for LIB to advance. The node did actually advance LIB but not in the expected 30 second timeout. The issue was that an unlinkable block at transition from LIB catchup to HEAD catchup didn't reset sync and therefore the node didn't know it needed to continue syncing. The handshake was not sufficient because the other node thought it had caught up. This was exasperated by the node syncing was in IRREVERSIBLE mode. It is possible that we could live with only resetting when running in IRREVERSIBLE mode. However, I think the safest and most direct approach is to go back to resetting the sync, but guard against resetting the sync when know we have already reset the sync. Therefore, fixing #1673 in a different way.

Resolves #1716  
Resolves #1673 