### PR TITLE
[1.2.2 -> main] P2P: Reset sync on rejected block

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -493,7 +493,6 @@ namespace eosio {
 
       void bcast_vote_message( uint32_t exclude_peer, const chain::vote_message_ptr& msg );
 
-      void start_conn_timer(boost::asio::steady_timer::duration du, std::weak_ptr<connection> from_connection);
       void start_expire_timer();
       void start_monitors();
 
@@ -1588,7 +1587,7 @@ namespace eosio {
       if( latest_msg_time > std::chrono::steady_clock::time_point::min() ) {
          if( current_time > latest_msg_time + hb_timeout ) {
             no_retry = go_away_reason::benign_other;
-            if( !peer_address().empty() ) {
+            if( !incoming() ) {
                peer_wlog(p2p_conn_log, this, "heartbeat timed out for peer address");
                close(true);
             } else {
@@ -2415,6 +2414,14 @@ namespace eosio {
    // called from connection strand
    void sync_manager::rejected_block( const connection_ptr& c, uint32_t blk_num, closing_mode mode ) {
       c->block_status_monitor_.rejected();
+      {
+         // reset sync on rejected block
+         fc::lock_guard g( sync_mtx );
+         if (sync_last_requested_num != 0 && blk_num <= sync_next_expected_num-1) { // no need to reset if we already reset and are syncing again
+            sync_last_requested_num = 0;
+            sync_next_expected_num = my_impl->get_fork_db_root_num() + 1;
+         }
+      }
       if( mode == closing_mode::immediately || c->block_status_monitor_.max_events_violated()) {
          peer_wlog(p2p_blk_log, c, "block ${bn} not accepted, closing connection ${d}",
                    ("d", mode == closing_mode::immediately ? "immediately" : "max violations reached")("bn", blk_num));
@@ -2871,7 +2878,7 @@ namespace eosio {
          string                    paddr_desc = paddr_str + ":" + std::to_string(paddr_port);
          connections.for_each_connection([&visitors, &from_addr, &paddr_str](const connection_ptr& conn) {
             if (conn->socket_is_open()) {
-               if (conn->peer_address().empty()) {
+               if (conn->incoming()) {
                   ++visitors;
                   fc::lock_guard g_conn(conn->conn_mtx);
                   if (paddr_str == conn->remote_endpoint_ip) {


### PR DESCRIPTION
Reverts #1676. A recent test failure #1716 demonstrates the need for the reset. The test failed because it timed out waiting for LIB to advance. The node did actually advance LIB but not in the expected 30 second timeout. The issue was that an unlinkable block at transition from LIB catchup to HEAD catchup didn't reset sync and therefore the node didn't know it needed to continue syncing. The handshake was not sufficient because the other node thought it had caught up. This was exasperated by the node syncing was in IRREVERSIBLE mode. It is possible that we could live with only resetting when running in IRREVERSIBLE mode. However, I think the safest and most direct approach is to go back to resetting the sync, but guard against resetting the sync when know we have already reset the sync. Therefore, fixing #1673 in a different way.

Merges `release/1.2` into `main` including #1726 

Resolves #1716  
Resolves #1673 