### PR TITLE
Fix  get_sender()

### DIFF
--- a/libraries/chain/sync_call_context.cpp
+++ b/libraries/chain/sync_call_context.cpp
@@ -49,9 +49,7 @@ void sync_call_context::set_call_return_value(std::span<const char> rv) {
 
 // Returns the sender of any sync call initiated by this apply_context or sync_call_ctx
 action_name sync_call_context::get_sender() const {
-   // The sync call is initiated by this apply_context or its sync_call_ctx.
-   // That's why the context's receiver is the sender of the sync call.
-   return receiver;
+   return sender;
 }
 
 void sync_call_context::console_append(std::string_view val) {

--- a/unittests/test-contracts/sync_callee/sync_callee.cpp
+++ b/unittests/test-contracts/sync_callee/sync_callee.cpp
@@ -9,6 +9,7 @@ using namespace eosio;
 
 [[eosio::call]]
 uint32_t sync_callee::basictest(uint32_t input) {
+   check(get_sender() == "caller"_n, "get_sender() returned an incorrect value");
    eosio::print("I am basictest from sync_callee");
 
    return input;

--- a/unittests/test-contracts/sync_callee1/sync_callee1.cpp
+++ b/unittests/test-contracts/sync_callee1/sync_callee1.cpp
@@ -3,6 +3,7 @@
 
 [[eosio::call]]
 uint32_t sync_callee1::div(uint32_t x, uint32_t y) {
+   check(get_sender() == "callee"_n, "get_sender() returned an incorrect value"); // this is only called from sync_callee
    return x / y;
 }
 


### PR DESCRIPTION
`get_sender()` currently returns the receiver, which is wrong. That was due to overthinking of the reverse role of sender and receiver in call context creation. It should just simply return the sender.

Tests added.