### PR TITLE
[1.2.2] explictly initialize the atomic `timer_state_t` to fix compile error in some configurations

### DIFF
--- a/libraries/chain/include/eosio/chain/platform_timer.hpp
+++ b/libraries/chain/include/eosio/chain/platform_timer.hpp
@@ -54,7 +54,7 @@ private:
       state_t state = state_t::stopped;
       bool callback_in_flight = false;
    };
-   std::atomic<timer_state_t> _state;
+   std::atomic<timer_state_t> _state{timer_state_t{}};
    bool timer_running_forever = false;
 
    struct impl;


### PR DESCRIPTION
With clang 20 + libstdc++15 this code is erroring out with
```
error: constructor for 'eosio::chain::platform_timer' must explicitly initialize the member '_state' which does not have a default constructor
```
afaict the code is correct for c++20, but this combination of compiler + stdlib seems to be unable to determine that `timer_state_t` is default constructable (well I think that's the problem). The annoying thing is I wasn't able to reproduce this in a smaller test case, so I wonder if something else is goofy. I don't really want to make this change so sending up as draft to see if anyone else has thoughts.