### PR TITLE
Cleanup use of `fc::scope_exit`

### DIFF
--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -2,7 +2,6 @@
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/pending_snapshot.hpp>
 #include <eosio/chain/snapshot_scheduler.hpp>
-#include <fc/scoped_exit.hpp>
 
 namespace eosio::chain {
 

--- a/libraries/chain/wast_to_wasm.cpp
+++ b/libraries/chain/wast_to_wasm.cpp
@@ -7,7 +7,6 @@
 #include <sstream>
 #include <iomanip>
 #include <fc/exception/exception.hpp>
-#include <fc/scoped_exit.hpp>
 #include <eosio/chain/exceptions.hpp>
 
 namespace eosio { namespace chain {

--- a/libraries/state_history/include/eosio/state_history/log_catalog.hpp
+++ b/libraries/state_history/include/eosio/state_history/log_catalog.hpp
@@ -12,8 +12,6 @@
 #include <eosio/state_history/log.hpp>
 #include <eosio/state_history/log_config.hpp>
 
-#include <fc/scoped_exit.hpp>
-
 namespace eosio::state_history {
 
 using namespace boost::multi_index;

--- a/plugins/http_plugin/tests/unit_tests.cpp
+++ b/plugins/http_plugin/tests/unit_tests.cpp
@@ -9,7 +9,6 @@
 
 #include <boost/asio/basic_stream_socket.hpp>
 #include <boost/asio/local/stream_protocol.hpp>
-#include <fc/scoped_exit.hpp>
 #include <fc/crypto/rand.hpp>
 
 #define BOOST_TEST_MODULE http_plugin unit tests

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -159,12 +159,12 @@ int main(int argc, char** argv)
 
    try {
       appbase::scoped_app app;
-      fc::scoped_exit<std::function<void()>> on_exit = [&]() {
+      auto on_exit = fc::make_scoped_exit([&]() {
          ilog("${name} version ${ver} ${fv}",
               ("name", nodeos::config::node_executable_name)("ver", app->version_string())
               ("fv", app->version_string() == app->full_version_string() ? "" : app->full_version_string()) );
          ::detail::log_non_default_options(app->get_parsed_options());
-      };
+      });
       uint32_t short_hash = 0;
       fc::from_hex(eosio::version::version_hash(), (char*)&short_hash, sizeof(short_hash));
 

--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -122,11 +122,11 @@ void test_trxs_common(std::vector<const char*>& specific_args) {
             } FC_LOG_AND_DROP()
             BOOST_CHECK(!"app threw exception see logged error");
          } );
-         fc::scoped_exit<std::function<void()>> on_except = [&](){
+         auto on_except = fc::make_scoped_exit([&](){
             app->quit();
             if (app_thread.joinable())
                app_thread.join();
-         };
+         });
 
          auto[prod_plug, chain_plug] = plugin_fut.get();
 

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -4,6 +4,8 @@
 #include <eosio/producer_plugin/producer_plugin.hpp>
 #include <eosio/testing/tester.hpp>
 
+#include <fc/scoped_exit.hpp>
+
 #include <regex>
 
 using namespace eosio;

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -9,7 +9,6 @@
 #include <fc/io/json.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/log/logger.hpp>
-#include <fc/scoped_exit.hpp>
 #include <fc/time.hpp>
 
 #include <eosio/chain/contract_types.hpp>


### PR DESCRIPTION
-  Use `fc::make_scope_exit` to avoid `std::function` overhead
- Remove include of `scope_exit.hpp` where not used.