### PR TITLE
[1.2.2] Avoid infinite loop on shutdown of terminate-at-block

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -3062,6 +3062,8 @@ void producer_plugin::process_blocks() {
       try {
          auto r = on_incoming_block();
          if (r == controller::apply_blocks_result::incomplete) {
+            if (app().is_quiting())
+               return;
             app().executor().post(handler_id::process_incoming_block, priority::medium, exec_queue::read_write, [self]() {
                self(self);
             });

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -136,7 +136,7 @@ class Node(Transactions):
                 Utils.Print("account validation failed. account: %s" % (account.name))
                 raise
 
-    def waitForTransactionInBlock(self, transId, timeout=None, exitOnError=True):
+    def waitForTransactionInBlock(self, transId, timeout=None, exitOnError=False):
         """Wait for trans id to appear in a block."""
         assert(isinstance(transId, str))
         lam = lambda: self.isTransInAnyBlock(transId, exitOnError=exitOnError)

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -256,14 +256,14 @@ class NodeosQueries:
         # either it is there or the transaction has timed out
         return self.processCleosCmd(cmd, cmdDesc, silentErrors=silentErrors, exitOnError=exitOnError, exitMsg=msg)
 
-    def isTransInBlock(self, transId, blockId):
+    def isTransInBlock(self, transId, blockId, exitOnError=False):
         """Check if transId is within block identified by blockId"""
         assert(transId)
         assert(isinstance(transId, str))
         assert(blockId)
         assert(isinstance(blockId, int))
 
-        block=self.getBlock(blockId, exitOnError=True)
+        block=self.getBlock(blockId, exitOnError=exitOnError)
 
         transactions=None
         key=""
@@ -271,8 +271,9 @@ class NodeosQueries:
             key="[transactions]"
             transactions=block["transactions"]
         except (AssertionError, TypeError, KeyError) as _:
-            Utils.Print("block%s not found. Block: %s" % (key,block))
-            raise
+            if exitOnError:
+                Utils.Print("block%s not found. Block: %s" % (key,block))
+                raise
 
         if transactions is not None:
             for trans in transactions:
@@ -313,7 +314,7 @@ class NodeosQueries:
         if Utils.Debug: Utils.Print("Reference block num %d, Head block num: %d" % (refBlockNum, headBlockNum))
         for blockNum in range(refBlockNum, headBlockNum + blocksAhead):
             self.waitForBlock(blockNum)
-            if self.isTransInBlock(transId, blockNum):
+            if self.isTransInBlock(transId, blockNum, exitOnError=exitOnError):
                 if Utils.Debug: Utils.Print("Found transaction %s in block %d" % (transId, blockNum))
                 return blockNum
 


### PR DESCRIPTION
It is possible when using `terminate-at-block` to be stuck in an infinite loop on shutdown. Check `is_quiting()` in `producer_plugin::process_blocks()` to break out of the loop.

Resolves #1756 