### PR TITLE
[1.2.2 -> main] Avoid infinite loop on shutdown of terminate-at-block

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2988,6 +2988,8 @@ void producer_plugin::process_blocks() {
       try {
          auto r = on_incoming_block();
          if (r.status == controller::apply_blocks_result_t::status_t::incomplete) {
+            if (app().is_quiting())
+               return;
             app().executor().post(handler_id::process_incoming_block, priority::medium, exec_queue::read_write, [self]() {
                self(self);
             });


### PR DESCRIPTION
It is possible when using `terminate-at-block` to be stuck in an infinite loop on shutdown. Check `is_quiting()` in `producer_plugin::process_blocks()` to break out of the loop.

Merges `release/1.2` into `main` including #1777

Resolves #1756 