### PR TITLE
Optimize block processing - minimize time for block to reach forkdb

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4312,12 +4312,17 @@ struct controller_impl {
          if (qc) {
             verify_qc_future.get();
          }
-         boost::asio::post(thread_pool.get_executor(), [this, bsp=bsp]() {
-            try {
-               integrate_received_qc_to_block(bsp); // Save the received QC as soon as possible, no matter whether the block itself is valid or not
-               consider_voting(bsp, use_thread_pool_t::no);
-            } FC_LOG_AND_DROP()
-         });
+         if (async_voting == async_t::yes) {
+            boost::asio::post(thread_pool.get_executor(), [this, bsp=bsp]() {
+               try {
+                  integrate_received_qc_to_block(bsp); // Save the received QC as soon as possible, no matter whether the block itself is valid or not
+                  consider_voting(bsp, use_thread_pool_t::no);
+               } FC_LOG_AND_DROP()
+            });
+         } else {
+            integrate_received_qc_to_block(bsp);
+            consider_voting(bsp, use_thread_pool_t::no);
+         }
       } else {
          assert(!verify_qc_future.valid());
       }


### PR DESCRIPTION
Use thread pool to minimize time for block to reach forkdb and for apply block to begin.

Current example from CI/CD logs, before this change:

```
debug 2025-07-24T01:02:37.395 net-3     net_plugin.cpp:3123           process_next_block_m ] ["localhost:9884 - b88e201" - 9 127.0.0.1:42616] received block 186, id 2b835b94ce2d1da0..., latency: -104ms, head 185, fhead 185
debug 2025-07-24T01:02:37.395 net-3     controller.cpp:4106           verify_basic_proper_ ] received block: #186 2025-07-24T01:02:37.500 defproduceri 000000ba2b835b94ce2d1da0f1e43761561af3b5a7f2339cb20b57307a2231f6, qc claim: {"block_num":185,"is_strong_qc":true}, qc present, previous: 000000b972fb74cdf0dcfa4d70dd25a3190ad1f36001159de299e399fceb6c84
debug 2025-07-24T01:02:37.429 net-3     net_plugin.cpp:4067           operator()           ] validated block header, forkdb add appended_to_head, broadcasting immediately, connection - 9, blk num = 186, id = 000000ba2b835b94ce2d1da0f1e43761561af3b5a7f2339cb20b57307a2231f6
```

Note the large delay in receiving the block to having the block in the forkdb and being able to then process the block.
`producer_plugin::process_blocks` is not called until  `create_block_state_i` returns. This PR reduces the time from receiving a block to applying the block by moving `integrate_received_qc_to_block` and `consider_voting` to a separate thread; thereby moving the considerable amount of processing of these two actions out of the net threads and on to the chain threads.