### PR TITLE
Fix sign-compare warnings in platform_timer_tests.cpp

### DIFF
--- a/unittests/platform_timer_tests.cpp
+++ b/unittests/platform_timer_tests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(correct_num_callbacks_test)
          break;
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
    }
-   BOOST_TEST_REQUIRE(barrier == 0);
+   BOOST_TEST_REQUIRE(barrier == 0u);
    pool.stop();
 
    BOOST_TEST(calls == num_threads);
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(correct_callback_test)
          break;
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
    }
-   BOOST_TEST_REQUIRE(barrier == 0);
+   BOOST_TEST_REQUIRE(barrier == 0u);
    pool.stop();
 
    std::lock_guard lock(cc_mtx);


### PR DESCRIPTION
Warnings from gcc

```
.../unittests/platform_timer_tests.cpp:100:4:   required from here
.../libraries/boost/libs/test/include/boost/test/tools/assertion.hpp:72:13: warning: comparison of integer expressions of different signedness: ‘std::__atomic_base<long unsigned int>::__int_type’ {aka ‘long unsigned int’} and ‘const int’ [-Wsign-compare]
   72 |     action( ==, EQ, !=, NE )                \
```