### PR TITLE
Add some oc compile logging info

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -147,7 +147,7 @@ struct eosvmoc_tier {
                m.whitelisted = context.is_eos_vm_oc_whitelisted();
                m.high_priority = m.whitelisted && context.is_applying_block();
                m.write_window = context.control.is_write_window();
-               cd = eosvmoc->cc.get_descriptor_for_code(m, code_hash, vm_version, failure);
+               cd = eosvmoc->cc.get_descriptor_for_code(m, context.get_receiver(), code_hash, vm_version, failure);
             } catch (...) {
                // swallow errors here, if EOS VM OC has gone in to the weeds we shouldn't bail: continue to try and run baseline
                // In the future, consider moving bits of EOS VM that can fire exceptions and such out of this call path

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/code_cache.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/code_cache.hpp
@@ -121,8 +121,8 @@ class code_cache_async : public code_cache_base {
       //If code is in cache: returns pointer & bumps to front of MRU list
       //If code is not in cache, and not blacklisted, and not currently compiling: return nullptr and kick off compile
       //otherwise: return nullptr
-      const code_descriptor* const get_descriptor_for_code(mode m, const digest_type& code_id, const uint8_t& vm_version,
-                                                           get_cd_failure& failure);
+      const code_descriptor* const get_descriptor_for_code(mode m, account_name receiver, const digest_type& code_id,
+                                                           const uint8_t& vm_version, get_cd_failure& failure);
 
    private:
       compile_complete_callback _compile_complete_func; // called from async thread, provides executing_action_id
@@ -144,7 +144,8 @@ class code_cache_sync : public code_cache_base {
       ~code_cache_sync();
 
       //Can still fail and return nullptr if, for example, there is an expected instantiation failure
-      const code_descriptor* const get_descriptor_for_code_sync(mode m, const digest_type& code_id, const uint8_t& vm_version);
+      const code_descriptor* const get_descriptor_for_code_sync(mode m, account_name receiver,
+                                                                const digest_type& code_id, const uint8_t& vm_version);
 };
 
 }}}

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/ipc_protocol.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/ipc_protocol.hpp
@@ -21,6 +21,7 @@ struct code_tuple {
 };
 
 struct compile_wasm_message {
+   fc::log_level log_level;
    account_name receiver; // for logging
    code_tuple code;
    fc::time_point queued_time;      // when compilation was queued to begin
@@ -67,7 +68,7 @@ using eosvmoc_message = std::variant<initialize_message,
 FC_REFLECT(eosio::chain::eosvmoc::initialize_message, )
 FC_REFLECT(eosio::chain::eosvmoc::initalize_response_message, (error_message))
 FC_REFLECT(eosio::chain::eosvmoc::code_tuple, (code_id)(vm_version))
-FC_REFLECT(eosio::chain::eosvmoc::compile_wasm_message, (receiver)(code)(queued_time)(limits))
+FC_REFLECT(eosio::chain::eosvmoc::compile_wasm_message, (log_level)(receiver)(code)(queued_time)(limits))
 FC_REFLECT(eosio::chain::eosvmoc::evict_wasms_message, (codes))
 FC_REFLECT(eosio::chain::eosvmoc::code_compilation_result_message, (start)(apply_offset)(starting_memory_pages)(initdata_prologue_size)(queued_time))
 FC_REFLECT(eosio::chain::eosvmoc::compilation_result_unknownfailure, )

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/ipc_protocol.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/ipc_protocol.hpp
@@ -21,6 +21,7 @@ struct code_tuple {
 };
 
 struct compile_wasm_message {
+   account_name receiver; // for logging
    code_tuple code;
    fc::time_point queued_time;      // when compilation was queued to begin
    std::optional<eosvmoc::subjective_compile_limits> limits;
@@ -66,7 +67,7 @@ using eosvmoc_message = std::variant<initialize_message,
 FC_REFLECT(eosio::chain::eosvmoc::initialize_message, )
 FC_REFLECT(eosio::chain::eosvmoc::initalize_response_message, (error_message))
 FC_REFLECT(eosio::chain::eosvmoc::code_tuple, (code_id)(vm_version))
-FC_REFLECT(eosio::chain::eosvmoc::compile_wasm_message, (code)(queued_time)(limits))
+FC_REFLECT(eosio::chain::eosvmoc::compile_wasm_message, (receiver)(code)(queued_time)(limits))
 FC_REFLECT(eosio::chain::eosvmoc::evict_wasms_message, (codes))
 FC_REFLECT(eosio::chain::eosvmoc::code_compilation_result_message, (start)(apply_offset)(starting_memory_pages)(initdata_prologue_size)(queued_time))
 FC_REFLECT(eosio::chain::eosvmoc::compilation_result_unknownfailure, )

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc.cpp
@@ -31,7 +31,7 @@ class eosvmoc_instantiated_module : public wasm_instantiated_module_interface {
          eosio::chain::eosvmoc::code_cache_sync::mode m;
          m.whitelisted = context.is_eos_vm_oc_whitelisted();
          m.write_window = context.control.is_write_window();
-         const code_descriptor* const cd = _eosvmoc_runtime.cc.get_descriptor_for_code_sync(m, _code_hash, _vm_version);
+         const code_descriptor* const cd = _eosvmoc_runtime.cc.get_descriptor_for_code_sync(m, context.get_receiver(), _code_hash, _vm_version);
          EOS_ASSERT(cd, wasm_execution_error, "EOS VM OC instantiation failed");
 
          if ( is_main_thread() )

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
@@ -247,6 +247,7 @@ const code_descriptor* const code_cache_sync::get_descriptor_for_code_sync(mode 
       return nullptr;
 
    auto msg = compile_wasm_message{
+      .log_level = fc::logger::default_logger().get_log_level(),
       .receiver = receiver,
       .code = { code_id, vm_version },
       .queued_time = fc::time_point{}, // could use now() if compile time measurement desired

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
@@ -198,6 +198,7 @@ code_cache_async::get_descriptor_for_code(mode m, account_name receiver, const d
    }
 
    auto msg = compile_wasm_message{
+      .log_level = fc::logger::default_logger().get_log_level(),
       .receiver = receiver,
       .code = { code_id, vm_version },
       .queued_time = fc::time_point::now(),

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
@@ -140,7 +140,7 @@ void run_compile(wrapped_fd&& response_sock, wrapped_fd&& wasm_code, uint64_t st
       // ru_maxrss is in kilobytes
       return usage.ru_maxrss;
    };
-   tlog("receiver ${a}, wasm size: ${ws} KB, oc code size: ${c} KB, compile resident size: ${rs} MB, time ${t} ms, time since queued ${qt} ms",
+   tlog("receiver ${a}, wasm size: ${ws} KB, oc code size: ${c} KB, compile memory usage: ${rs} MB, time: ${t} ms, time since queued: ${qt} ms",
         ("a", receiver)("ws", wasm.size()/1024)("c", code.code.size()/1024)("rs", get_resource_size()/1024)
         ("t", (fc::time_point::now() - start).count()/1000)("qt", (fc::time_point::now() - queued_time).count()/1000));
    std::array<wrapped_fd, 2> fds_to_send{ memfd_for_bytearray(code.code), memfd_for_bytearray(initdata_prep) };

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
@@ -140,7 +140,7 @@ void run_compile(wrapped_fd&& response_sock, wrapped_fd&& wasm_code, uint64_t st
       // ru_maxrss is in kilobytes
       return usage.ru_maxrss;
    };
-   tlog("receiver ${a}, wasm size: ${ws} KB, oc code size: ${c} KB, compile memory usage: ${rs} MB, time: ${t} ms, time since queued: ${qt} ms",
+   tlog("receiver ${a}, wasm size: ${ws} KB, oc code size: ${c} KB, max compile memory usage: ${rs} MB, time: ${t} ms, time since queued: ${qt} ms",
         ("a", receiver)("ws", wasm.size()/1024)("c", code.code.size()/1024)("rs", get_resource_size()/1024)
         ("t", (fc::time_point::now() - start).count()/1000)("qt", (fc::time_point::now() - queued_time).count()/1000));
    std::array<wrapped_fd, 2> fds_to_send{ memfd_for_bytearray(code.code), memfd_for_bytearray(initdata_prep) };

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
@@ -18,7 +18,8 @@ using namespace IR;
 namespace eosio { namespace chain { namespace eosvmoc {
 
 void run_compile(wrapped_fd&& response_sock, wrapped_fd&& wasm_code, uint64_t stack_size_limit,
-                 size_t generated_code_size_limit, fc::time_point queued_time) noexcept {  //noexcept; we'll just blow up if anything tries to cross this boundry
+                 size_t generated_code_size_limit, account_name receiver, fc::time_point queued_time) noexcept {  //noexcept; we'll just blow up if anything tries to cross this boundry
+   fc::time_point start = fc::time_point::now();
    std::vector<uint8_t> wasm = vector_for_memfd(wasm_code);
 
    //ideally we catch exceptions and sent them upstream as strings for easier reporting
@@ -133,6 +134,15 @@ void run_compile(wrapped_fd&& response_sock, wrapped_fd&& wasm_code, uint64_t st
    std::move(prologue_it, prologue.end(), std::back_inserter(initdata_prep));
    std::move(initial_mem.begin(), initial_mem.end(), std::back_inserter(initdata_prep));
 
+   auto get_resource_size = []() {
+      rusage usage{};
+      getrusage(RUSAGE_SELF, &usage);
+      // ru_maxrss is in kilobytes
+      return usage.ru_maxrss;
+   };
+   tlog("receiver ${a}, wasm size: ${ws} KB, oc code size: ${c} KB, compile resident size: ${rs} MB, time ${t} ms, time since queued ${qt} ms",
+        ("a", receiver)("ws", wasm.size()/1024)("c", code.code.size()/1024)("rs", get_resource_size()/1024)
+        ("t", (fc::time_point::now() - start).count()/1000)("qt", (fc::time_point::now() - queued_time).count()/1000));
    std::array<wrapped_fd, 2> fds_to_send{ memfd_for_bytearray(code.code), memfd_for_bytearray(initdata_prep) };
    write_message_with_fds(response_sock, result_message, fds_to_send);
 }
@@ -194,7 +204,7 @@ void run_compile_trampoline(int fd) {
          struct rlimit core_limits = {0u, 0u};
          setrlimit(RLIMIT_CORE, &core_limits);
 
-         run_compile(std::move(fds[0]), std::move(fds[1]), stack_size, generated_code_size_limit, msg.queued_time);
+         run_compile(std::move(fds[0]), std::move(fds[1]), stack_size, generated_code_size_limit, msg.receiver, msg.queued_time);
          _exit(0);
       }
       else if(pid == -1)

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
@@ -134,15 +134,15 @@ void run_compile(wrapped_fd&& response_sock, wrapped_fd&& wasm_code, uint64_t st
    std::move(prologue_it, prologue.end(), std::back_inserter(initdata_prep));
    std::move(initial_mem.begin(), initial_mem.end(), std::back_inserter(initdata_prep));
 
-   auto get_resource_size = []() {
-      rusage usage{};
-      getrusage(RUSAGE_SELF, &usage);
-      // ru_maxrss is in kilobytes
-      return usage.ru_maxrss;
-   };
    if (log_level == fc::log_level::all) {
       // compile trampoline is forked before logging config is loaded, also no SIGHUP support for updating logging,
       // use provided log_level to determine if this should be logged. info level is available by default
+      auto get_resource_size = []() {
+         rusage usage{};
+         getrusage(RUSAGE_SELF, &usage);
+         // ru_maxrss is in kilobytes
+         return usage.ru_maxrss;
+      };
       ilog("receiver ${a}, wasm size: ${ws} KB, oc code size: ${c} KB, max compile memory usage: ${rs} MB, time: ${t} ms, time since queued: ${qt} ms",
            ("a", receiver)("ws", wasm.size()/1024)("c", code.code.size()/1024)("rs", get_resource_size()/1024)
            ("t", (fc::time_point::now() - start).count()/1000)("qt", (fc::time_point::now() - queued_time).count()/1000));

--- a/libraries/libfc/include/fc/log/log_message.hpp
+++ b/libraries/libfc/include/fc/log/log_message.hpp
@@ -139,6 +139,8 @@ namespace fc
 } // namespace fc
 
 FC_REFLECT_TYPENAME( fc::log_message );
+FC_REFLECT_ENUM(fc::log_level::values, (all)(debug)(info)(warn)(error)(off))
+FC_REFLECT(fc::log_level, (value))
 
 #ifndef __func__
 #define __func__ __FUNCTION__


### PR DESCRIPTION
Adds some useful information about oc compiles. Example output:
```
info  2025-07-29T17:33:33.860 nodeos    compile_trampoline.cpp:145    run_compile          ] receiver token.pcash, wasm size: 126 KB, oc code size: 199 KB, compile memory usage: 42 MB, time: 972 ms, time since queued: 1735 ms
info  2025-07-29T17:33:33.905 nodeos    compile_trampoline.cpp:145    run_compile          ] receiver tokensbridge, wasm size: 169 KB, oc code size: 278 KB, compile memory usage: 49 MB, time: 1160 ms, time since queued: 1905 ms
info  2025-07-29T17:33:33.991 nodeos    compile_trampoline.cpp:145    run_compile          ] receiver eosio.fees, wasm size: 16 KB, oc code size: 28 KB, compile memory usage: 26 MB, time: 130 ms, time since queued: 641 ms
info  2025-07-29T17:33:34.085 nodeos    compile_trampoline.cpp:145    run_compile          ] receiver swap.pcash, wasm size: 158 KB, oc code size: 250 KB, compile memory usage: 46 MB, time: 1145 ms, time since queued: 1907 ms
info  2025-07-29T17:33:34.088 nodeos    compile_trampoline.cpp:145    run_compile          ] receiver eosmechanics, wasm size: 10 KB, oc code size: 17 KB, compile memory usage: 25 MB, time: 96 ms, time since queued: 1814 ms
info  2025-07-29T17:33:34.152 nodeos    compile_trampoline.cpp:145    run_compile          ] receiver gwnotary1234, wasm size: 9 KB, oc code size: 14 KB, compile memory usage: 25 MB, time: 63 ms, time since queued: 1346 ms
info  2025-07-29T17:33:34.331 nodeos    compile_trampoline.cpp:145    run_compile          ] receiver oracle.defi, wasm size: 33 KB, oc code size: 58 KB, compile memory usage: 29 MB, time: 245 ms, time since queued: 1987 ms
```

Resolves #729 