### PR TITLE
Fix a missed signed comparison waring

### DIFF
--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -430,7 +430,9 @@ public:
             }
          } else {
             auto r = idx.equal_range(peer.producer_name);
-            if (std::distance(r.first, r.second) >= max_bp_gossip_peers_per_producer) {
+            // The static_cast is to prevent the sign-compare compile
+            // warning. It is a safe cast.
+            if (std::distance(r.first, r.second) >= static_cast<std::ptrdiff_t>(max_bp_gossip_peers_per_producer)) {
                // remove entry with min expiration
                auto min_expiration_itr = r.first;
                auto min_expiration = min_expiration_itr->expiration();

--- a/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp
@@ -430,9 +430,7 @@ public:
             }
          } else {
             auto r = idx.equal_range(peer.producer_name);
-            // The static_cast is to prevent the sign-compare compile
-            // warning. It is a safe cast.
-            if (std::distance(r.first, r.second) >= static_cast<std::ptrdiff_t>(max_bp_gossip_peers_per_producer)) {
+            if (std::cmp_greater_equal(std::distance(r.first, r.second), max_bp_gossip_peers_per_producer)) {
                // remove entry with min expiration
                auto min_expiration_itr = r.first;
                auto min_expiration = min_expiration_itr->expiration();


### PR DESCRIPTION
I missed this one in yesterday's https://github.com/AntelopeIO/spring/pull/1791

```
.../plugins/net_plugin/include/eosio/net_plugin/auto_bp_peering.hpp:436:50: warning: comparison of integer expressions of different signedness: ‘std::__iterator_traits<boost::multi_index::detail::bidir_node_iterator<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<eosio::gossip_bp_peers_message::signed_bp_peer, std::allocator<eosio::gossip_bp_peers_message::signed_bp_peer> > > > > >, void>::difference_type’ {aka ‘long int’} and ‘const size_t’ {aka ‘const long unsigned int’} [-Wsign-compare]
  436 |             if (std::distance(r.first, r.second) >= (max_bp_gossip_peers_per_producer)) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```