### PR TITLE
Test: Add test for max_trx_time and speculative execution interrupt

### DIFF
--- a/unittests/checktime_tests.cpp
+++ b/unittests/checktime_tests.cpp
@@ -151,7 +151,16 @@ BOOST_AUTO_TEST_CASE( checktime_interrupt_test) { try {
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( checktime_speculative_max_trx_test ) { try {
-   savanna_tester t;
+   fc::temp_directory tempdir;
+   auto conf_genesis = tester::default_config( tempdir );
+   auto& cfg = conf_genesis.second.initial_configuration;
+
+   cfg.max_block_cpu_usage        = 350'000;
+   cfg.max_transaction_cpu_usage  = 150'000;
+   cfg.min_transaction_cpu_usage  = 1;
+
+   savanna_tester t( conf_genesis.first, conf_genesis.second );
+   t.execute_setup_policy( setup_policy::full );
    t.produce_block();
    t.create_account( "pause"_n );
    t.set_code( "pause"_n, test_contracts::test_api_wasm() );

--- a/unittests/test_utils.hpp
+++ b/unittests/test_utils.hpp
@@ -93,8 +93,9 @@ void push_trx(Tester& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cpu
    auto fut = transaction_metadata::start_recover_keys( std::move( ptrx ), test.control->get_thread_pool(),
                                                         test.get_chain_id(), fc::microseconds::maximum(),
                                                         trx_type );
+   fc::microseconds max_trx_time = max_cpu_usage_ms == UINT32_MAX ? fc::microseconds::maximum() : fc::milliseconds(max_cpu_usage_ms);
    auto res = test.control->push_transaction( fut.get(), fc::time_point::now() + fc::milliseconds(max_block_cpu_ms),
-                                              fc::milliseconds(max_cpu_usage_ms), billed_cpu_time_us, explicit_bill, 0 );
+                                              max_trx_time, billed_cpu_time_us, explicit_bill, 0 );
    if( res->except_ptr ) std::rethrow_exception( res->except_ptr );
    if( res->except ) throw *res->except;
 };


### PR DESCRIPTION
Add tests:
- Test that verifies that even when maximum is passed to max_trx_time of push_transaction that it is still restricted to on-chain trx maximum.
- Test that verifies speculative trx execution can be interrupted. 

Resolves #1799