### PR TITLE
Add exhausted count and time to block report

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -306,7 +306,7 @@ struct block_time_tracker {
       using namespace std::string_literals;
       assert(!paused);
       if( _log.is_enabled( fc::log_level::debug ) ) {
-         auto diff = now - clear_time_point - block_idle_time - trx_success_time - trx_fail_time - transient_trx_time - other_time;
+         auto diff = now - clear_time_point - block_idle_time - trx_success_time - trx_exhausted_time - trx_fail_time - transient_trx_time - other_time;
          fc_dlog( _log, "Block #${n} ${p} trx idle: ${i}us out of ${t}us, success: ${sn}, ${s}us, exhausted: ${en}, ${e}us, fail: ${fn}, ${f}us, "
                   "transient: ${ttn}, ${tt}us, other: ${o}us${rest}",
                   ("n", block_num)("p", producer)


### PR DESCRIPTION
Add exhausted count and time to block report.
Also fixes an issue with restarting a block not reporting trx time in the correct block report.

```
debug 2025-07-31T18:37:38.791 nodeos    producer_plugin.cpp:2672      handle_push_result   ] [TRX_TRACE] Speculative execution COULD NOT FIT, elapsed 281920us, tx: b4bf410cc1fe1ded53db38b2d45f2b069800f6607f38adeb3098f36e2dfa074e RETRYING
debug 2025-07-31T18:37:38.791 nodeos    producer_plugin.cpp:1000      restart_speculative_ ] Restarting exhausted speculative block #146
debug 2025-07-31T18:37:38.791 nodeos    producer_plugin.cpp:316       report               ] Block #146 eosio trx idle: 226480us out of 508606us, success: 0, 0us, exhausted: 1, 281692us, fail: 0, 0us, transient: 0, 0us, other: 434us
```

Resolves #1798