### PR TITLE
add default spaceship to `add_packhash_to_hash`

### DIFF
--- a/libraries/libfc/include/fc/crypto/packhash.hpp
+++ b/libraries/libfc/include/fc/crypto/packhash.hpp
@@ -19,6 +19,8 @@ struct add_packhash_to_hash {
    static auto packhash(const T&... args) {
       return fc::packhash<typename Derived::encoder>(args...);
    }
+
+   friend auto operator<=>(const add_packhash_to_hash&, const add_packhash_to_hash&) = default;
 };
 
 }


### PR DESCRIPTION
I was adding a new hash type and trying to use just
```cpp
    friend auto operator<=>(const xxh3&, const xxh3&) = default;
```
for it (other hash types don't use this c++20 style). Well the above doesn't work because `add_packhash_to_hash` has no default operators. So add it.