### PR TITLE
avoid accessing currently in progress `emplace()`ing `node_t`

### DIFF
--- a/unittests/savanna_cluster.cpp
+++ b/unittests/savanna_cluster.cpp
@@ -46,15 +46,17 @@ node_t::node_t(size_t node_idx, cluster_t& cluster, setup_policy policy /* = set
       }
    };
 
-   auto node_initialization_fn = [&, node_idx]() {
+   auto node_initialization_fn = [&]() {
       [[maybe_unused]] auto _a = control->voted_block().connect(_voted_block_cb);
       [[maybe_unused]] auto _b = control->accepted_block().connect(_accepted_block_cb);
       tester::set_node_finalizers(_node_finalizers);
-      cluster.get_new_blocks_from_peers(node_idx);
    };
 
-   node_initialization_fn();                  // initialize the node when it is first created
-   set_open_callback(node_initialization_fn); // and do the initalization again every time `open()` is called
+   node_initialization_fn();                                    // initialize the node when it is first created
+   set_open_callback([&, node_initialization_fn, node_idx]() {  // and do the initialization again every time `open()` is called + simulate blocks from peers
+      node_initialization_fn();
+      cluster.get_new_blocks_from_peers(node_idx);
+   });
 }
 
 node_t::~node_t() {}


### PR DESCRIPTION
I am encountering a bizarre problem locally with the savanna cluster. Bizarre in that I can't explain why we're not seeing it in CI etc

When a savanna cluster is created in reserves some space in `_nodes` and then `emplace_back()` the `node_t`s,
https://github.com/AntelopeIO/spring/blob/ecc902d5e54d25ceec8ebde9b2c45e7078421ffb/unittests/savanna_cluster.hpp#L376-L385

During the `node_t` ctor, toward the end it,
https://github.com/AntelopeIO/spring/blob/ecc902d5e54d25ceec8ebde9b2c45e7078421ffb/unittests/savanna_cluster.cpp#L49-L57

So notice it will `cluster.get_new_blocks_from_peers(node_idx)` before completing the ctor. And look what `get_new_blocks_from_peers()` does,
https://github.com/AntelopeIO/spring/blob/ecc902d5e54d25ceec8ebde9b2c45e7078421ffb/unittests/savanna_cluster.hpp#L626-L632
It accesses the currently emplacing `node_t` -- or rather where it _will_ be -- in `_nodes`. But it isn't done being created yet.

Locally on a debug build via gcc I fail at line 627 -- but it's not the `assert()` that fails rather it fails earlier due to the `vector::operator[]` internally asserting because it believes its size is still 0 at this time (indeed looking at vector's source shows it increments its size after the ctor of the emplaced object completes). 

Locally on a release build via the pinned compiler I fail by what I'm pretty sure is `LIBCXX_HARDENING_MODE=fast` asserting.

So I'm just completely perplexed why this is not failing in CI via the pinned builds. Or why it's not failing for anyone else.

I moved the code around a little to not call back in to `cluster` during the ctor to resolve the problem. Not sure if this is best approach or not.