### PR TITLE
[experiment] protect against timer "rearm race"

### DIFF
--- a/libraries/chain/include/eosio/chain/platform_timer.hpp
+++ b/libraries/chain/include/eosio/chain/platform_timer.hpp
@@ -58,7 +58,7 @@ private:
    bool timer_running_forever = false;
 
    struct impl;
-   constexpr static size_t fwd_size = 8;
+   constexpr static size_t fwd_size = 16;
    fc::fwd<impl,fwd_size> my;
 
    void call_expiration_callback() {


### PR DESCRIPTION
There appears to be an ABA-like defect in how the timer is managed. I found this while scrutinizing the code more due to #1810. I am not sure it is a smoking gun for #1810 though.

The problem goes something like this,
1) `start()` a timer which starts the kernel timer (i.e. not a 'forever timer'); this also sets `_state = running`
2) the kernel timer expires, and makes some progress between queuing the signal, waking a thread (could be any), and `expire_now()` may even start. But critically `expire_now()` does not reach the CAS yet. https://github.com/AntelopeIO/spring/blob/f38100e4b523c36afb43ade0ff298ea18b98a107/libraries/chain/platform_timer_posix.cpp#L81-L83
3) `stop()` is called. `stop()` identifies that  `_state = running`, sets `_state = interrupted` and disarms the kernel timer. However note that the kernel timer has already expired at this moment due to the criteria specified in line 2.
4) `start()` is called. This sets `_state = running` and potentially arms a kernel timer if non-max
5) The thread in line 2 continues to make progress and reaches the CAS. Here it sees that `_state == running` and triggers the timer expiry via `_state = timed_out` and calls the expiry callbacks. Thus the problem: this expiration was intended for the timer started on line 1, but instead we trigger the timer started on line 4.

Fixing this was a bit elusive. Probably the classical method would be adding a 'generation' for each timer start and verify the expiry matches the current generation. But `timer_settime()` doesn't let us stash anything away indicating what timer generation an expiry corresponds to. The only information we can deliver on expiry signal is the 64-bit value given on timer creation (and the signal number). So we could potentially create and destroy the timer each time we start/stop it. That way we could encode some generation in the 64-bit payload that is delivered to the signal (smuggle the generation in some unused address bits (still need `this`) or something). But I wanted to avoid that it seemed like more headache.

So this approach is to identify if the kernel timer has already expired when stopping the timer, and if that is the case wait for the signal handler to complete. The principle is that if the kernel timer expires the signal handler must eventually be run and we can wait for that to complete as a synchronization mechanism that ensures no pending signals or half-run `expire_now()`s are lingering around after `stop()` to cause potential grief later on.

Unfortunately I fear I may be too trusting of the kernel here. Is it _truly guaranteed_ that if a timer returns a 0 value that a signal was queued? Is it _truly guaranteed_ that if a timer returns a non-0 value that a signal will _not_ be queued? My hunch is these are probably unrealistic expectations and this approach is not viable.