### PR TITLE
Avoid re-using `boost::flat_map::iterator` after `emplace` as it is invalidated.

### DIFF
--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1921,7 +1921,7 @@ fc::variants producer_plugin::get_supported_protocol_features(const get_supporte
          }
       }
 
-      res.first->second = true;
+      visited_protocol_features[pf.feature_digest] = true; // iterator `res.first` invalidated
       results.emplace_back(pf.to_variant(true));
       return true;
    };


### PR DESCRIPTION
Resolves #1811.

Probably happens only in `2.0` because we have 2+ protocol features depending on the `savanna` dependency (causing the flat_map to resize when processing the first `savanna` dependency, so some `savanna` dependencies are incorrectly not marked as `true`, and when processing additional features depending on `savanna` it fails.