### PR TITLE
protect against timer "rearm race": more timers approach

### DIFF
--- a/libraries/chain/include/eosio/chain/platform_timer.hpp
+++ b/libraries/chain/include/eosio/chain/platform_timer.hpp
@@ -62,7 +62,7 @@ private:
    generation_t generation = 0;
 
    struct impl;
-   constexpr static size_t fwd_size = 32;
+   constexpr static size_t fwd_size = 64;
    fc::fwd<impl,fwd_size> my;
 
    void call_expiration_callback() {

--- a/libraries/chain/platform_timer_posix.cpp
+++ b/libraries/chain/platform_timer_posix.cpp
@@ -19,7 +19,7 @@ namespace eosio::chain {
 static_assert(std::atomic_bool::is_always_lock_free, "Only lock-free atomics AS-safe.");
 
 struct platform_timer::impl {
-   constexpr static unsigned num_timers = 4;
+   constexpr static unsigned num_timers = 8;
    static_assert(std::has_single_bit(num_timers), "num_timers must be a power of two");
 
    std::array<timer_t, num_timers> timerid;


### PR DESCRIPTION
A different solution for the problem described in #1812

This approach uses more kernel timers -- each with a different signal number -- and round robins across them each time the platform_timer is started. It is kind of like storing a per-timer-start payload in the timer. The signal number upon expiration is used as validation that the signal handler corresponds to the currently running timer before taking action to expire it. This solves the ABA like problem, but turns it more in to an ABCDA like problem which is better but not perfect.

The choice of 4 timers is arbitrary. The more used the more resilient against mixups, in theory anyways. I actually don't initially see any technical reasons to not go with something like 16 because these timer handles don't consume e.g. file handle space.