### PR TITLE
[2.0] Remove unused sync_call_ordinal from host_context

### DIFF
--- a/libraries/chain/include/eosio/chain/host_context.hpp
+++ b/libraries/chain/include/eosio/chain/host_context.hpp
@@ -630,7 +630,6 @@ public:
 
    std::vector<char>        last_sync_call_return_value{}; // return value of last sync call initiated by the current code (host context)
    const uint32_t           sync_call_depth = 0; // depth for sync call
-   uint32_t                 sync_call_ordinal = 1;  // the order of a sync call
 
    generic_index<index64_object>                                  idx64;
    generic_index<index128_object>                                 idx128;


### PR DESCRIPTION
`sync_call_ordinal` in `host_context` was a leftover from an earlier development iteration and is not used. Please note `ordinal` in `sync_call_context` is the one used for keeping track sync call ordinals.

Thanks to @greg7mdp for pointing it out.