### PR TITLE
[1.2.3] validate hash of Debian pinned package repository

### DIFF
--- a/tools/pinned.pl
+++ b/tools/pinned.pl
@@ -1,0 +1,145 @@
+#!/usr/bin/perl
+# An apt method that validates InRelease files are a configured hash value. Useful to ensure the package repo is exactly what is expected.
+use strict;
+use warnings;
+use IPC::Open2;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+
+$| = 1; # disable output buffering
+
+my %expected_hashes;
+my ($http_child_out, $http_child_in);
+my $pid = open2($http_child_out, $http_child_in, "/usr/lib/apt/methods/http");
+
+# get the capabilities from the http method and forward it on to apt unchanged
+print STDOUT read_block($http_child_out);
+
+# read the configuration from apt and forward it to http method unchanged, but also inspect for our configuration
+my @config_block = read_block(*STDIN);
+if (@config_block && $config_block[0] =~ /^601 Configuration/) {
+   for my $line (@config_block) {
+      if ($line =~ /^Config-Item: ?Acquire::pinned::InReleaseHashes::([^=]+)=([^\s]+)/) {
+         my ($key, $hash) = ($1, $2);
+         $expected_hashes{$key} = $hash;
+      }
+   }
+   print $http_child_in @config_block;
+} else {
+   die "did not receive 601 Configuration message from apt as expected.\n";
+}
+
+#main loop: read a block from apt with the command to run
+while (my @command_block = read_block(*STDIN)) {
+   my $original_uri_from_apt = parse_block(@command_block)->{URI} // die "failed to get URI from command block\n";
+   #perform some filtering on the headers before forwarding on to http method
+   @command_block = map { s/(URI: ?)pinned:/$1http:/r }      # replace URI: pinned://... with URI: http://...
+                    grep { !/^Last-Modified:/ }              # scrub Last-Modified because cache hits will not have a file to check hash against
+                    @command_block;
+
+   print $http_child_in @command_block;
+
+   #make note if we're getting an InRelease file and the expected hash of it. We need to track this now because we may encounter a redirect
+   # to a very opaque filename
+   my $expected_hash;
+   if($original_uri_from_apt =~ /InRelease$/) {
+      my ($inrelease_suite) = $original_uri_from_apt =~ m{/([^/]+)/InRelease$} or die "\nInRelease without a suite match\n";
+      unless (exists $expected_hashes{$inrelease_suite}) {
+         die "Unconfigured hash for suite '$inrelease_suite'\n";
+      }
+      $expected_hash = $expected_hashes{$inrelease_suite};
+   }
+   elsif($original_uri_from_apt =~ /Release$/) {  #just paranoia that apt doesn't fetch from this unchecked Release file instead
+      die "Got $original_uri_from_apt which is not expected";
+   }
+
+   #read back all response blocks from http method until seeing a result code that is the end of the request
+   while (my @child_response_block = read_block($http_child_out)) {
+      my $child_response_info = parse_block(@child_response_block);
+
+      #annoyingly, on buster, the http method won't handle redirects itself and expects apt to with this 103. Allowing apt
+      # to handle the redirect makes it much harder to be certain we are validating the file we think we ought to be validating.
+      # So we'll have to deal with the redirect ourselves.
+      if($child_response_info->{Code} == 103) {
+         @command_block = map { s/^URI:.*$/URI: $child_response_info->{'New-URI'}/r } @command_block;
+         print $http_child_in @command_block;
+      }
+      elsif($child_response_info->{Code} < 201) {
+         # an "in progress" notification; forward through
+         print STDOUT inject_original_uri($original_uri_from_apt, @child_response_block);
+      }
+      else {
+         # completion message; check if this is for InRelease and verify hash, or if for any other file just forward through.
+         # for failure cases 'die' which stops apt in its tracks, otherwise it might ignore a failure if a local cached file is still available.
+         if ($child_response_info->{Code} == 201 && $expected_hash) {
+            if (validate_file($child_response_info->{Filename}, $expected_hash)) {
+               print STDOUT inject_original_uri($original_uri_from_apt, @child_response_block);
+            } else {
+               die "\nHash mismatch for $child_response_info->{URI}\n";
+            }
+         }
+         else {
+            print STDOUT inject_original_uri($original_uri_from_apt, @child_response_block);
+         }
+
+         last;
+      }
+   }
+}
+
+close($http_child_in);
+close($http_child_out);
+waitpid($pid, 0);
+
+sub read_block($fh) {
+   my @lines;
+   return @lines unless defined(my $first_line = <$fh>);
+   push @lines, $first_line;
+   while (my $line = <$fh>) {
+      push @lines, $line;
+      last if $line eq "\n";
+   }
+   return @lines;
+}
+
+sub parse_block(@block) {
+   return {} unless @block;
+   my $info = {};
+   if ($block[0] =~ /^(\d+)\s+(.*)/) {
+      $info->{Code} = $1;
+      $info->{Description} = $2;
+   }
+   for my $line (@block[1 .. $#block]) {
+      if ($line =~ /^([^:]+):\s*(.*)/) {
+         $info->{$1} = $2;
+      }
+   }
+   return $info;
+}
+
+#responses need to go back to apt with the URL it originally sent; since we're handling redirects internally need to touch this up
+sub inject_original_uri($original_uri, @response_block) {
+   return map { s/^URI:.*$/URI: $original_uri/r } @response_block;
+}
+
+sub validate_file($file_path, $expected_hash) {
+   return 0 unless defined $file_path && -f $file_path;
+
+   #can't use Digest::SHA as that package is not installed; call off to sha256sum instead
+   my ($sha_out, $sha_in);
+   my $sha_pid = open2($sha_out, $sha_in, 'sha256sum', $file_path);
+   close $sha_in;
+
+   my $output = <$sha_out>;
+   close $sha_out;
+   waitpid($sha_pid, 0);
+
+   return 0 if $? != 0;  #command failed
+   return 0 unless defined $output;
+
+   chomp $output;
+   my ($calculated_hash) = split /\s+/, $output;
+   return 0 unless defined $calculated_hash;
+
+   return $calculated_hash eq $expected_hash;
+}


### PR DESCRIPTION
During discussion of #1834 and its usage of Debian's pinned package archive some security concerns were raised that could be resolved by verifying the hash of the package repository. Fixing the hash of the package repository may also give us leeway to mirror the package archive (for the date we require) without any reduction in security as well.

This PR adds a new "apt method"  -- you can think of this as a URI scheme handler; `pinned://` in this case -- which effectively intercepts all requests from apt and forwards them through to the existing http method. Except, when an `InRelease` file is encountered, it verifies the hash of that file against the configuration defined in the Dockerfile. If this does not match, the method fails. (I experimented with synthesizing a proper error response from the method, but the method self destructing was more reliable in stopping apt in its tracks no matter what)

Ultimately I'm happy with the simplicity of the approach: there is very little "noise" in the Dockerfile. And the pinned apt method is sub 150 lines where over half of it is pretty much boilerplate (i.e. it's reasonably reviewable as not being nefarious). And while arcane, apt methods are fully supported (including through trixie) so we're not really doing anything hacky here.

Now I know what you're thinking: Perl?! Well, the base docker image from Debian (i.e. `docker run --rm -it debian:buster`) has very little already installed. Notably `python` is _not_ installed. I could do something like build a C++ application in a separate build stage and copy it in. That's going to be more gnarly from a Dockerfile standpoint, and it's not clear C++ would be a good fit here anyways -- honestly Perl is not terribly ill-suited for this task.

An example of a bad hash and failure of the docker build is at
https://github.com/AntelopeIO/spring/actions/runs/17197804792/job/48782669614#step:3:1283