### PR TITLE
[2.0 -> 2.0.0-dev1] Allocate resources required by sync calls up front

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2091,12 +2091,9 @@ struct controller_impl {
 
       protocol_features.init( db );
 
-      // sync_call protocol feature could be already activated.
       // Allocate resources required by nested sync calls.
-      if (is_builtin_activated(builtin_protocol_feature_t::sync_call)) {
-         const auto max_call_depth = db.get<global_property_object>().configuration.max_sync_call_depth;
-         set_max_call_depth_for_call_res_pools(max_call_depth);
-      }
+      const auto max_call_depth = db.get<global_property_object>().configuration.max_sync_call_depth;
+      set_max_call_depth_for_call_res_pools(max_call_depth);
 
       // At startup, no transaction specific logging is possible
       if (auto dm_logger = get_deep_mind_logger(false)) {
@@ -6475,9 +6472,6 @@ void controller_impl::on_activation<builtin_protocol_feature_t::sync_call>() {
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "get_call_data" );
       add_intrinsic_to_whitelist( ps.whitelisted_intrinsics, "set_call_return_value" );
    } );
-
-   const auto max_call_depth = db.get<global_property_object>().configuration.max_sync_call_depth;
-   set_max_call_depth_for_call_res_pools(max_call_depth);
 }
 
 /// End of protocol feature activation handlers

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2091,6 +2091,13 @@ struct controller_impl {
 
       protocol_features.init( db );
 
+      // sync_call protocol feature could be already activated.
+      // Allocate resources required by nested sync calls.
+      if (is_builtin_activated(builtin_protocol_feature_t::sync_call)) {
+         const auto max_call_depth = db.get<global_property_object>().configuration.max_sync_call_depth;
+         set_max_call_depth_for_call_res_pools(max_call_depth);
+      }
+
       // At startup, no transaction specific logging is possible
       if (auto dm_logger = get_deep_mind_logger(false)) {
          dm_logger->on_startup(db, chain_head.block_num());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/production_pause_vote_timeout_test_sh
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/production_restart.py ${CMAKE_CURRENT_BINARY_DIR}/production_restart.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/production_restart_test_shape.json ${CMAKE_CURRENT_BINARY_DIR}/production_restart_test_shape.json COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pause_at_block_test.py ${CMAKE_CURRENT_BINARY_DIR}/pause_at_block_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sync_call_restart.py ${CMAKE_CURRENT_BINARY_DIR}/sync_call_restart.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_test.py ${CMAKE_CURRENT_BINARY_DIR}/trx_finality_status_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_forked_test.py ${CMAKE_CURRENT_BINARY_DIR}/trx_finality_status_forked_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plugin_http_api_test.py ${CMAKE_CURRENT_BINARY_DIR}/plugin_http_api_test.py COPYONLY)
@@ -185,6 +186,7 @@ add_np_test(NAME interrupt-read-only-trx-parallel-if-eos-vm-oc-test COMMAND test
 add_np_test(NAME subjective_billing_test COMMAND tests/subjective_billing_test.py -v -p 2 -n 4 ${UNSHARE})
 add_np_test(NAME get_account_test COMMAND tests/get_account_test.py -v -p 2 -n 3 ${UNSHARE})
 add_np_test(NAME pause_at_block_test COMMAND tests/pause_at_block_test.py -v ${UNSHARE})
+add_np_test(NAME sync_call_restart COMMAND tests/sync_call_restart.py -v ${UNSHARE})
 
 add_np_test(NAME distributed-transactions-test COMMAND tests/distributed-transactions-test.py -d 2 -p 4 -n 6 -v ${UNSHARE})
 add_np_test(NAME distributed-transactions-if-test COMMAND tests/distributed-transactions-test.py -d 2 -p 4 -n 6 --activate-if -v ${UNSHARE})

--- a/tests/sync_call_restart.py
+++ b/tests/sync_call_restart.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+#import os
+#import shutil
+import signal
+import platform
+
+from TestHarness import Account, Cluster, TestHelper, Utils, WalletMgr
+
+###############################################################
+# sync_call_restart
+#
+# Tests restart of a node with sync_call protocol feature already activated.
+#
+# We had a bug that resources required by sync calls (in particular for OC) were
+# not allocated on restart if sync_call protocol feature had already been activated
+# https://github.com/AntelopeIO/spring/issues/1847
+#
+# This test activates sync_call protocol feature, does a snapshot, kills the node,
+# restarts the node, pushes a transaction containing 2-levels of nested sync calls,
+# and verifies node not crashed.
+###############################################################
+
+Print=Utils.Print
+errorExit=Utils.errorExit
+
+args=TestHelper.parse_args({"--keep-logs","--dump-error-details","-v","--leave-running","--unshared"})
+pnodes=1
+debug=args.v
+total_nodes=pnodes
+dumpErrorDetails=args.dump_error_details
+
+Utils.Debug=debug
+testSuccessful=False
+
+cluster=Cluster(unshared=args.unshared, keepRunning=args.leave_running, keepLogs=args.keep_logs)
+walletMgr=WalletMgr(True, keepRunning=args.leave_running, keepLogs=args.keep_logs)
+
+try:
+    if platform.system() != "Linux":
+        Print("OC not run on Linux. Skip the test")
+        exit(True) # Do not fail the test
+
+    TestHelper.printSystemInfo("BEGIN")
+
+    cluster.setWalletMgr(walletMgr)
+
+    # Enable OC so that the test can execute paths invloved OC reources
+    specificExtraNodeosArgs={}
+    specificExtraNodeosArgs[0]=" --eos-vm-oc-enable all "
+
+    Print("Stand up cluster")
+    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, activateIF=True, specificExtraNodeosArgs=specificExtraNodeosArgs) is False:
+        errorExit("Failed to stand up cluster.")
+
+    cluster.waitOnClusterSync(blockAdvancing=5)
+
+    node = cluster.getNode(0)
+
+    def deployContract(account_name, contract_name):
+        acct=Account(account_name)
+        acct.ownerPublicKey = "PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63"
+        acct.activePublicKey = "PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63"
+        cluster.createAccountAndVerify(acct, cluster.eosioAccount)
+        node.publishContract(acct, f"unittests/test-contracts/{contract_name}", f"{contract_name}.wasm", f"{contract_name}.abi", waitForTransBlock=True)
+
+    Print("Create accounts and publish contracts")
+    deployContract("caller", "sync_caller");
+    deployContract("callee", "sync_callee");
+    deployContract("callee1", "sync_callee1");
+
+    Print("Create snapshot");
+    ret = node.createSnapshot()
+    assert ret is not None, "Snapshot creation failed"
+
+    Print("Stopping snapshot");
+    node.kill(signal.SIGTERM)
+    assert not node.verifyAlive(), "Node did not shutdown"
+
+    node.removeState()
+    node.removeReversibleBlks()
+
+    Print("Restart from snapshot");
+    isRelaunchSuccess = node.relaunch(chainArg="--snapshot {}".format(node.getLatestSnapshot()))
+    assert isRelaunchSuccess, "node relaunch from snapshot failed"
+
+    Print("Push a transaction containing 2-levels of a nested sync call");
+    trx={ "actions": [{"account": "caller", "name": "nestedcalls", "authorization": [{"actor": "caller","permission": "active"}], "data": {} }] }
+    results = node.pushTransaction(trx)
+    assert results[0], "pushTransaction failed"
+
+    testSuccessful=True
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, dumpErrorDetails=dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/sync_call_restart.py
+++ b/tests/sync_call_restart.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-#import os
-#import shutil
 import signal
 import platform
 
@@ -45,8 +43,7 @@ try:
     cluster.setWalletMgr(walletMgr)
 
     # Enable OC so that the test can execute paths invloved OC reources
-    specificExtraNodeosArgs={}
-    specificExtraNodeosArgs[0]=" --eos-vm-oc-enable all "
+    specificExtraNodeosArgs={0: " --eos-vm-oc-enable all "}
 
     Print("Stand up cluster")
     if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, activateIF=True, specificExtraNodeosArgs=specificExtraNodeosArgs) is False:
@@ -54,12 +51,12 @@ try:
 
     cluster.waitOnClusterSync(blockAdvancing=5)
 
-    node = cluster.getNode(0)
+    node=cluster.getNode(0)
 
     def deployContract(account_name, contract_name):
         acct=Account(account_name)
-        acct.ownerPublicKey = "PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63"
-        acct.activePublicKey = "PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63"
+        acct.ownerPublicKey="PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63"
+        acct.activePublicKey="PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63"
         cluster.createAccountAndVerify(acct, cluster.eosioAccount)
         node.publishContract(acct, f"unittests/test-contracts/{contract_name}", f"{contract_name}.wasm", f"{contract_name}.abi", waitForTransBlock=True)
 
@@ -69,7 +66,7 @@ try:
     deployContract("callee1", "sync_callee1");
 
     Print("Create snapshot");
-    ret = node.createSnapshot()
+    ret=node.createSnapshot()
     assert ret is not None, "Snapshot creation failed"
 
     Print("Stopping snapshot");
@@ -80,17 +77,17 @@ try:
     node.removeReversibleBlks()
 
     Print("Restart from snapshot");
-    isRelaunchSuccess = node.relaunch(chainArg="--snapshot {}".format(node.getLatestSnapshot()))
+    isRelaunchSuccess=node.relaunch(chainArg=f"--snapshot {node.getLatestSnapshot()}")
     assert isRelaunchSuccess, "node relaunch from snapshot failed"
 
     Print("Push a transaction containing 2-levels of a nested sync call");
-    trx={ "actions": [{"account": "caller", "name": "nestedcalls", "authorization": [{"actor": "caller","permission": "active"}], "data": {} }] }
-    results = node.pushTransaction(trx)
+    trx={"actions": [{"account": "caller", "name": "nestedcalls", "authorization": [{"actor": "caller","permission": "active"}], "data": {}}]}
+    results=node.pushTransaction(trx)
     assert results[0], "pushTransaction failed"
 
     testSuccessful=True
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, dumpErrorDetails=dumpErrorDetails)
 
-exitCode = 0 if testSuccessful else 1
+exitCode=0 if testSuccessful else 1
 exit(exitCode)


### PR DESCRIPTION
Cherry pick https://github.com/AntelopeIO/spring/pull/1848

Currently resources for nested sync calls are allocated only at the time when `sync_call` protocol feature is activated. But when nodeos is restarted, `sync_call` might already have been . We should always allocated the resources.

The PR fixes the problem and adds a test case to show the problem has been fixed (before the fix, the test case failed).

Thanks @ericpassmore for reporting the problem and collecting the core dump.

Resolves https://github.com/AntelopeIO/spring/issues/1847