### PR TITLE
[2.0.0-dev] remove 'count' from `get_table_by_scope` response

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1651,7 +1651,7 @@ read_only::get_table_by_scope_result read_only::get_table_by_scope( const read_o
       for( unsigned int count = 0; count < limit && itr != end_itr; ++itr, ++count ) {
          if( p.table && itr->table != p.table ) continue;
 
-         result.rows.push_back( {itr->code, itr->scope, itr->table, itr->payer, itr->count} );
+         result.rows.push_back( {itr->code, itr->scope, itr->table, itr->payer} );
 
          if (fc::time_point::now() >= params_deadline)
             break;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -445,7 +445,6 @@ public:
       name        scope;
       name        table;
       name        payer;
-      uint32_t    count = 0;
    };
    struct get_table_by_scope_result {
       vector<get_table_by_scope_result_row> rows;
@@ -1037,7 +1036,7 @@ FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_params, (json)(code)(sc
 FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_result, (rows)(more)(next_key) );
 
 FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_params, (code)(table)(lower_bound)(upper_bound)(limit)(reverse)(time_limit_ms) )
-FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_result_row, (code)(scope)(table)(payer)(count));
+FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_result_row, (code)(scope)(table)(payer));
 FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_result, (rows)(more) );
 
 FC_REFLECT( eosio::chain_apis::read_only::get_currency_balance_params, (code)(account)(symbol));

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -102,7 +102,6 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, validating_tester ) try {
       BOOST_REQUIRE_EQUAL(name("inita"_n), result.rows[0].scope);
       BOOST_REQUIRE_EQUAL(name("accounts"_n), result.rows[0].table);
       BOOST_REQUIRE_EQUAL(name("eosio"_n), result.rows[0].payer);
-      BOOST_REQUIRE_EQUAL(1u, result.rows[0].count);
 
       BOOST_REQUIRE_EQUAL(name("initb"_n), result.rows[1].scope);
       BOOST_REQUIRE_EQUAL(name("initc"_n), result.rows[2].scope);


### PR DESCRIPTION
We've previously decided on removing this in #1858. I am not sure if anything has changed w.r.t. how we want to handle it due to v2 endpoints coming in 2.0.0 too though.