### PR TITLE
Test: Calculate block in round correctly

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -278,52 +278,14 @@ class Node(Transactions):
             scheduled_producers.append(prod["producer_name"])
         if Utils.Debug: Utils.Print(f'scheduled_producers {scheduled_producers}')
 
-        self.getInfo()
-        currBlockNum=self.lastRetrievedHeadBlockNum
-        currProducer=self.lastRetrievedHeadBlockProducer
-
-        startOfRoundBlockNum = currBlockNum
-        for i in range(1, currBlockNum-1): # the producer might produce multiple rounds
-            if self.getBlockProducerByNum(currBlockNum-i) == currProducer:
-                startOfRoundBlockNum = currBlockNum-i
-            else:
-                break
-
-        currBlockInRound = ( (currBlockNum - startOfRoundBlockNum) % blocksPerProducer ) + 1
-        blocksRemainedInCurrRound = blocksPerProducer - currBlockInRound
-        if Utils.Debug: Utils.Print(f'currBlockNum {currBlockNum}, currProducer {currProducer}, blocksRemainedInCurrRound {blocksRemainedInCurrRound}, currBlockInRound {currBlockInRound}')
-
-        # find the positions of currProducerPos and nodeProducer in the schedule
-        currProducerPos=0
-        nodeProducerPos=0
-        for i in range(0, len(scheduled_producers)):
-            if scheduled_producers[i] == currProducer:
-                currProducerPos=i
-            if scheduled_producers[i] == self.producerName:
-                nodeProducerPos=i
-
-        # find the number of the blocks to node producer's next scheduled round
-        blocksToNextScheduledRound = 0
-        if currProducerPos < nodeProducerPos:
-            # nodeProducerPos - currProducerPos - 1 is the number of producers
-            # from current producer to the node producer in the schedule
-            blocksToNextScheduledRound = (nodeProducerPos - currProducerPos - 1) * blocksPerProducer + blocksRemainedInCurrRound + 1
-        else:
-            # nodeProducerPos is the number of producers before node producer in the schedule
-            # len(scheduled_producers) - currProducerPos - 1 is the number
-            # of producers after node producer in the schedule
-            blocksToNextScheduledRound = (nodeProducerPos + (len(scheduled_producers)  - currProducerPos - 1)) * blocksPerProducer + blocksRemainedInCurrRound + 1
-
-        # find the block number of the node producer's next scheduled round
-        nextScheduledRoundBlockNum=currBlockNum + blocksToNextScheduledRound
-        timeout=blocksToNextScheduledRound/2 + 2 # leave 2 seconds for avoid flakiness
-        if Utils.Debug: Utils.Print(f'blocksToNextScheduledRound {blocksToNextScheduledRound}, nextScheduledRoundBlockNum {nextScheduledRoundBlockNum}, timeout {timeout}')
-
-        if not self.waitForBlock(nextScheduledRoundBlockNum, timeout=timeout):
-            return True
-        if self.getBlockProducer() != self.producerName:
-            return True
-        return False
+        for i in range(0, len(scheduled_producers)*blocksPerProducer):
+            if not self.waitForNextBlock(timeout=13):
+                if Utils.Debug: Utils.Print(f'Failed to get next block')
+                return True
+            if self.getBlockProducer() == self.producerName:
+                if Utils.Debug: Utils.Print(f'{self.producerName} produced block {self.lastRetrievedHeadBlockNum}')
+                return False
+        return True
 
     def killNodeOnProducer(self, producer, whereInSequence, blockType=BlockType.head, silentErrors=True, exitOnError=False, exitMsg=None, returnType=ReturnType.json):
         assert(isinstance(producer, str))

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -718,7 +718,7 @@ class NodeosQueries:
 
     def getBlockProducer(self, timeout=None, waitForBlock=True, exitOnError=True, blockType=BlockType.head):
         blockNum=self.getBlockNum(blockType=blockType)
-        block=self.getBlock(blockNum, exitOnError=exitOnError, blockType=blockType)
+        block=self.getBlock(blockNum, exitOnError=exitOnError)
         if block is None:
             if exitOnError:
                 Utils.errorExit(f"getBlock returned None for {blockNum}")


### PR DESCRIPTION
Update `production_pause_max_rev_blks_test.py` to be less flakey.
Modified `Node.missedNextProductionRound` to use a simpler more robust approach.
Also fixed `Queries.getBlockProducer` which was calling `getBlock` with an invalid argument `blockType`.