### PR TITLE
Avoid undefined behavior

### DIFF
--- a/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_eosio_injection.hpp
@@ -151,7 +151,8 @@ namespace eosio { namespace chain { namespace wasm_injections {
       static constexpr bool post = false;
       static void init() {}
       static void accept( wasm_ops::instr* inst, wasm_ops::visitor_arg& arg ) {
-         wasm_ops::op_types<>::call_t* call_inst = reinterpret_cast<wasm_ops::op_types<>::call_t*>(inst);
+         // Cast to the exact dynamic type to avoid undefined behavior
+         auto* call_inst = static_cast<wasm_ops::call<fix_call_index>*>(inst);
          auto mapped_index = injector_utils::injected_index_mapping.find(call_inst->field);
 
          if ( mapped_index != injector_utils::injected_index_mapping.end() )  {


### PR DESCRIPTION
Flagged during a test:
```
/home/kevin/ext/wire-sysio/libraries/chain/include/sysio/chain/wasm_sysio_injection.hpp:155:85: runtime error: member access within address 0x5ac3c5c62480 which does not point to an object of type 'wasm_ops::op_types<>::call_t' (aka 'call<sysio::chain::wasm_ops::nop_mutator>')
0x5ac3c5c62480: note: object is of type 'sysio::chain::wasm_ops::call<sysio::chain::wasm_injections::fix_call_index>'
 00 00 00 00  08 c7 39 9c c3 5a 00 00  10 00 00 00 32 00 00 00  00 00 00 00 00 00 00 00  21 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'sysio::chain::wasm_ops::call<sysio::chain::wasm_injections::fix_call_index>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/kevin/ext/wire-sysio/libraries/chain/include/sysio/chain/wasm_sysio_injection.hpp:155:85 
```