### PR TITLE
P2P: Signal controller to apply blocks if sync interrupted

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2178,6 +2178,10 @@ namespace eosio {
          fc_dlog(p2p_blk_log, "sync ahead not allowed. block ${bn}, head ${h}, fhead ${fh}, fhead->lib ${fl}, sync-fetch-span ${sp}, fork_db size ${s}",
                  ("bn", blk_num)("h", head_num)("fh", cc.fork_db_head().block_num())("fl", cc.fork_db_head().irreversible_blocknum())
                  ("sp", sync_fetch_span)("s", cc.fork_db_size()));
+
+         // make sure controller is processing blocks, might have been interrupted and need a kick
+         fc_dlog(p2p_blk_log, "sync post process_incoming_block to app thread, block ${n}", ("n", blk_num));
+         my_impl->producer_plug->process_blocks();
       }
 
       fc_dlog(p2p_blk_log, "sync ahead not allowed. block ${bn}, sync_last_requested_num ${lrn}, sync-fetch-span ${s}",


### PR DESCRIPTION
It is possible due to an interrupt that the controller has stopped applying blocks. Give it a kick to make sure it continues.

I was not able to reproduce the problem, but looking at the logs I think this will fix the issue. Hopeful, to get feedback from reporter if this fixes the issue.

Resolves #1878 