### PR TITLE
Do not oc interrupt during replay

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5522,6 +5522,10 @@ void controller::set_disable_replay_opts( bool v ) {
    my->conf.disable_replay_opts = v;
 }
 
+bool controller::is_replaying() const {
+   return my->replaying;
+}
+
 block_handle controller::head()const {
    return my->chain_head;
 }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -286,6 +286,8 @@ namespace eosio::chain {
          void   set_key_blacklist( const flat_set<public_key_type>& );
 
          void   set_disable_replay_opts( bool v );
+         // thread safe
+         bool   is_replaying() const;
 
          block_handle         head()const;
          block_handle         fork_db_head()const;

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -171,7 +171,10 @@ struct eosvmoc_tier {
          //   Not allowing interrupt for onblock seems rather harmless, so instead of distinguishing between onerror and
          //   onblock, just disallow for all implicit.
          const bool allow_oc_interrupt = attempt_tierup && context.is_applying_block() &&
-                                         context.trx_context.has_undo() && !context.trx_context.is_implicit() && !context.trx_context.is_scheduled();
+                                         context.trx_context.has_undo() &&
+                                         !context.trx_context.is_implicit() &&
+                                         !context.trx_context.is_scheduled() &&
+                                         !context.control.is_replaying();
          auto ex = fc::make_scoped_exit([&]() {
             if (allow_oc_interrupt) {
                eos_vm_oc_compile_interrupt = false;


### PR DESCRIPTION
The oc interrupt already checked for has undo sessions, but didn't anticipate someone running with `disable-replay-opts`. Explicitly do not allow oc interrupt during replay.

Resolves #1880 