### PR TITLE
P2P: Reduce duplicate trx debug log output

### DIFF
--- a/libraries/libfc/include/fc/exception/exception.hpp
+++ b/libraries/libfc/include/fc/exception/exception.hpp
@@ -4,11 +4,10 @@
  *  @brief Defines exception's used by fc
  */
 #include <fc/log/logger.hpp>
-#include <exception>
-#include <functional>
-#include <unordered_map>
 #include <boost/core/typeinfo.hpp>
 #include <boost/interprocess/exceptions.hpp>
+#include <exception>
+#include <functional>
 
 namespace fc
 {
@@ -94,15 +93,14 @@ namespace fc
 
          /**
           *   Generates a detailed string including file, line, method,
-          *   and other information that is generally only useful for
-          *   developers.
+          *   and other information. Includes newlines.
           */
-         std::string to_detail_string( log_level ll = log_level::all )const;
+         std::string to_detail_string()const;
 
          /**
-          *   Generates a user-friendly error report.
+          *   Generates an error string with no newline
           */
-         std::string to_string( log_level ll = log_level::info  )const;
+         std::string to_string()const;
 
          /**
           *   Generates a user-friendly error report.
@@ -279,7 +277,7 @@ namespace fc
      const char* expr
      );
 
-  extern bool enable_record_assert_trip;
+  extern const bool enable_record_assert_trip;
 } // namespace fc
 
 #if __APPLE__

--- a/libraries/libfc/src/exception.cpp
+++ b/libraries/libfc/src/exception.cpp
@@ -1,9 +1,9 @@
 #include <fc/exception/exception.hpp>
-#include <boost/exception/all.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/io/json.hpp>
 
 #include <iostream>
+#include <boost/exception/diagnostic_information.hpp>
 
 namespace fc
 {
@@ -119,83 +119,45 @@ namespace fc
       my->_elog.emplace_back( std::move(m) );
    }
 
-   /**
-    *   Generates a detailed string including file, line, method,
-    *   and other information that is generally only useful for
-    *   developers.
-    */
-   std::string exception::to_detail_string( log_level ll  )const
+   std::string exception::to_detail_string()const
    {
       const auto deadline = fc::time_point::now() + format_time_limit;
-      std::stringstream ss;
+      std::string r;
       try {
-         try {
-            ss << variant( my->_code ).as_string();
-         } catch( std::bad_alloc& ) {
-            throw;
-         } catch( ... ) {
-            ss << "<- exception in to_detail_string.";
-         }
-         ss << " " << my->_name << ": " << my->_what << "\n";
+         r += std::to_string( my->_code );
+         r += " " + my->_name + ": " + my->_what + "\n";
          for( auto itr = my->_elog.begin(); itr != my->_elog.end(); ++itr ) {
             try {
-               ss << itr->get_message() << "\n"; //fc::format_string( itr->get_format(), itr->get_data() ) <<"\n";
-               ss << "    " << json::to_string( itr->get_data(), deadline ) << "\n";
-               ss << "    " << itr->get_context().to_string() << "\n";
+               r += itr->get_message() += "\n";
+               r += "    " + json::to_string( itr->get_data(), deadline ) + "\n";
+               r += "    " + itr->get_context().to_string() + "\n";
             } catch( std::bad_alloc& ) {
                throw;
             } catch( const fc::timeout_exception& e) {
-               ss << "<- timeout exception in to_detail_string: " << e.what() << "\n";
+               r += "<- timeout exception in to_detail_string: " + e.my->_what + "\n";
                break;
             } catch( ... ) {
-               ss << "<- exception in to_detail_string.\n";
+               r += "<- exception in to_detail_string.\n";
             }
          }
       } catch( std::bad_alloc& ) {
          throw;
       } catch( ... ) {
-         ss << "<- exception in to_detail_string.\n";
+         r += "<- exception in to_detail_string.\n";
       }
-      return ss.str();
+      return r;
    }
 
-   /**
-    *   Generates a user-friendly error report.
-    */
-   std::string exception::to_string( log_level ll   )const
+   std::string exception::to_string()const
    {
-      const auto deadline = fc::time_point::now() + format_time_limit;
-      std::stringstream ss;
-      try {
-         ss << my->_what;
-         try {
-            ss << " (" << variant( my->_code ).as_string() << ")\n";
-         } catch( std::bad_alloc& ) {
-            throw;
-         } catch( ... ) {
-            ss << "<- exception in to_string.\n";
-         }
-         for( auto itr = my->_elog.begin(); itr != my->_elog.end(); ++itr ) {
-            try {
-               FC_CHECK_DEADLINE(deadline);
-               ss << fc::format_string( itr->get_format(), itr->get_data(), true) << "\n";
-               //      ss << "    " << itr->get_context().to_string() <<"\n";
-            } catch( std::bad_alloc& ) {
-               throw;
-            } catch( const fc::timeout_exception& e) {
-               ss << "<- timeout exception in to_string: " << e.what();
-               break;
-            } catch( ... ) {
-               ss << "<- exception in to_string.\n";
-            }
-         }
-         return ss.str();
-      } catch( std::bad_alloc& ) {
-         throw;
-      } catch( ... ) {
-         ss << "<- exception in to_string.\n";
+      std::string r;
+      r += my->_what;
+      r += " (" + std::to_string( my->_code ) + ") ";
+      for( auto itr = my->_elog.begin(); itr != my->_elog.end(); ) {
+         r += fc::format_string( itr->get_format(), itr->get_data(), true);
+         break;
       }
-      return ss.str();
+      return r;
    }
 
    /**
@@ -266,15 +228,12 @@ namespace fc
          ("source_lineno", lineno)
          ("expr", expr)
          ;
-      /* TODO: restore this later
-      std::cout
+      std::cerr
          << "FC_ASSERT triggered:  "
-         << fc::json::to_string( assert_trip_info ) << "\n";
-         */
-      return;
+         << fc::json::to_string( assert_trip_info, fc::time_point::maximum() ) << "\n";
    }
 
-   bool enable_record_assert_trip = false;
+   const bool enable_record_assert_trip = false;
 
    std_exception_wrapper::std_exception_wrapper( log_message&& m, std::exception_ptr e,
                                                  const std::string& name_value,

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -4034,15 +4034,19 @@ namespace eosio {
       trx_in_progress_size += trx_size;
       my_impl->chain_plug->accept_transaction( trx,
          [weak = weak_from_this(), trx_size](const next_function_variant<transaction_trace_ptr>& result) mutable {
+         auto log_failed = [&](const fc::exception& e) {
+            fc_dlog( p2p_trx_log, "bad packed_transaction : ${m}",
+                     ("m", e.code() == tx_duplicate::code_value ? e.to_string() : e.what()) );
+         };
          // next (this lambda) called from application thread
          if (std::holds_alternative<fc::exception_ptr>(result)) {
-            fc_dlog( p2p_trx_log, "bad packed_transaction : ${m}", ("m", std::get<fc::exception_ptr>(result)->what()) );
+            log_failed(*std::get<fc::exception_ptr>(result));
          } else {
             const transaction_trace_ptr& trace = std::get<transaction_trace_ptr>(result);
             if( !trace->except ) {
                fc_dlog( p2p_trx_log, "chain accepted transaction, bcast ${id}", ("id", trace->id) );
             } else {
-               fc_ilog( p2p_trx_log, "bad packed_transaction : ${m}", ("m", trace->except->what()));
+               log_failed(*trace->except);
             }
          }
          connection_ptr conn = weak.lock();
@@ -4324,7 +4328,8 @@ namespace eosio {
       boost::asio::post( thread_pool.get_executor(), [this, results]() {
          const auto& id = results.second->id();
          if (results.first) {
-            fc_dlog( p2p_trx_log, "signaled NACK, trx-id = ${id} : ${why}", ("id", id)( "why", results.first->to_detail_string() ) );
+            fc_dlog( p2p_trx_log, "signaled NACK, trx-id = ${id} : ${why}",
+                     ("id", id)("why", results.first->code() == tx_duplicate::code_value ? results.first->to_string() : results.first->to_detail_string()) );
             dispatcher.rejected_transaction(results.second);
          } else {
             fc_dlog( p2p_trx_log, "signaled ACK, trx-id = ${id}", ("id", id) );


### PR DESCRIPTION
See https://github.com/Wire-Network/wire-sysio/pull/171

Previous:
```
debug 2026-01-02T16:17:42.037 nodeop    net_plugin.cpp:4044           operator()           ] bad packed_transaction : 3040008 tx_duplicate: Duplicate transaction
duplicate transaction 24980a3bd2035890209ac387ef899b217b82f9c2c8c0b9167f3836e9a89159da
    {"id":"24980a3bd2035890209ac387ef899b217b82f9c2c8c0b9167f3836e9a89159da"}
    nodeop  producer_plugin.cpp:1104 process_incoming_transaction_async
```

With PR:
```
debug 2026-01-12T18:41:06.076 nodeop    net_plugin.cpp:4031           operator()           ] bad packed_transaction : Duplicate transaction (3040008) duplicate transaction ea986755390b8fe89ca53c691d68b88869775f400b33c41c0a1dadbb1ae0a435
```

Includes some `exception` implementation cleanup.
- `exception::to_string()` now returns error string without newlines.