### PR TITLE
Separate transaction queue

### DIFF
--- a/libraries/custom_appbase/include/eosio/chain/application.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/application.hpp
@@ -161,6 +161,8 @@ public:
    bool trx_read_write_queue_empty() { return pri_queue_.empty(exec_queue::trx_read_write); }
    bool read_exclusive_queue_empty() { return pri_queue_.empty(exec_queue::read_exclusive); }
 
+   [[nodiscard]] exec_pri_queue::read_view readable_queue() const { return pri_queue_.readable(); }
+
    // members are ordered taking into account that the last one is destructed first
 private:
    std::thread::id                    main_thread_id_{ std::this_thread::get_id() };

--- a/libraries/custom_appbase/include/eosio/chain/application.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/application.hpp
@@ -85,12 +85,12 @@ public:
       while (true) {
          if ( exec_window_ == exec_window::write ) {
             // During write window only main thread is accessing anything in priority_queue_executor, no locking required
-            size_t before = pri_queue_.execute_highest(exec_queue::read_write, exec_queue::read_only);
-            if (before == 0 && trx_read_write_queue_enabled_.load(std::memory_order_acquire)) {
+            std::optional<size_t> remaining = pri_queue_.execute_highest(exec_queue::read_write, exec_queue::read_only);
+            if (!remaining && trx_read_write_queue_enabled_.load(std::memory_order_acquire)) {
                // locked because any thread can push to the trx_read_write queue
                more = pri_queue_.execute_highest_locked(exec_queue::trx_read_write);
             } else {
-               more = before > 0;
+               more = *remaining > 0;
             }
          } else {
             // When in read window, multiple threads including main app thread are accessing priority_queue_executor, locking required

--- a/libraries/custom_appbase/include/eosio/chain/application.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/application.hpp
@@ -2,9 +2,8 @@
 
 #include <appbase/application_base.hpp>
 #include <eosio/chain/exec_pri_queue.hpp>
+#include <cassert>
 #include <chrono>
-#include <optional>
-#include <mutex>
 
 /*
  * Customize appbase to support two-queue executor.
@@ -47,10 +46,15 @@ public:
 
    template <typename Func>
    void post( handler_id id, int priority, exec_queue q, Func&& func ) {
-      if (q == exec_queue::read_exclusive) {
+      if (q == exec_queue::read_exclusive || q == exec_queue::trx_read_write) {
          // no reason to post to io_context which then places this in the read_exclusive_handlers queue.
          // read_exclusive tasks are run exclusively by read threads by pulling off the read_exclusive handlers queue.
-         pri_queue_.add(id, priority, q, --order_, std::forward<Func>(func));
+         // similarly, trx_read_write trxs are pulled off the queue directly to be executed
+         assert(id == handler_id::unique);
+         if (!pri_queue_.add(priority, q, --order_, std::forward<Func>(func))) {
+            // post required to trigger io_ctx_ run_one
+            boost::asio::post(io_ctx_, pri_queue_.wrap(id, priority, q, --order_, std::forward<Func>(func)));
+         }
       } else {
          // post to io_context as the main thread may be blocked on io_context.run_one() in application::exec()
          boost::asio::post(io_ctx_, pri_queue_.wrap(id, priority, q, --order_, std::forward<Func>(func)));
@@ -59,10 +63,14 @@ public:
 
    template <typename Func>
    void post( int priority, exec_queue q, Func&& func ) {
-      if (q == exec_queue::read_exclusive) {
+      if (q == exec_queue::read_exclusive || q == exec_queue::trx_read_write) {
          // no reason to post to io_context which then places this in the read_exclusive_handlers queue.
          // read_exclusive tasks are run exclusively by read threads by pulling off the read_exclusive handlers queue.
-         pri_queue_.add(priority, q, --order_, std::forward<Func>(func));
+         // similarly, trx_read_write trxs are pulled off the queue directly to be executed
+         if (!pri_queue_.add(priority, q, --order_, std::forward<Func>(func))) {
+            // post required to trigger io_ctx_ run_one
+            boost::asio::post(io_ctx_, pri_queue_.wrap(priority, q, --order_, std::forward<Func>(func)));
+         }
       } else {
          // post to io_context as the main thread may be blocked on io_context.run_one() in application::exec()
          boost::asio::post(io_ctx_, pri_queue_.wrap(priority, q, --order_, std::forward<Func>(func)));
@@ -79,7 +87,7 @@ public:
 
    boost::asio::io_context& get_io_context() { return io_ctx_; }
 
-   // called from main thread, highest read_only and read_write
+   // called from main thread, highest read_only or read_write or trx_read_write
    bool execute_highest() {
       // execute for at least minimum runtime
       const auto end = std::chrono::high_resolution_clock::now() + std::chrono::milliseconds(minimum_runtime_ms);
@@ -88,7 +96,13 @@ public:
       while (true) {
          if ( exec_window_ == exec_window::write ) {
             // During write window only main thread is accessing anything in priority_queue_executor, no locking required
-            more = pri_queue_.execute_highest(exec_queue::read_write, exec_queue::read_only);
+            size_t before = pri_queue_.execute_highest(exec_queue::read_write, exec_queue::read_only);
+            if (before == 0 && trx_read_write_queue_enabled_.load(std::memory_order_acquire)) {
+               // locked because any thread can push to the trx_read_write queue
+               more = pri_queue_.execute_highest_locked(exec_queue::trx_read_write);
+            } else {
+               more = before > 0;
+            }
          } else {
             // When in read window, multiple threads including main app thread are accessing priority_queue_executor, locking required
             more = pri_queue_.execute_highest_locked(exec_queue::read_only);
@@ -145,11 +159,17 @@ public:
       return exec_window_ == exec_window::write;
    }
 
+   void enable_trx_read_write_queue(bool enable) {
+      trx_read_write_queue_enabled_.store(enable, std::memory_order_release);
+   }
+
    size_t read_only_queue_size() { return pri_queue_.size(exec_queue::read_only); }
    size_t read_write_queue_size() { return pri_queue_.size(exec_queue::read_write); }
+   size_t trx_read_write_queue_size() { return pri_queue_.size(exec_queue::trx_read_write); }
    size_t read_exclusive_queue_size() { return pri_queue_.size(exec_queue::read_exclusive); }
    bool read_only_queue_empty() { return pri_queue_.empty(exec_queue::read_only); }
    bool read_write_queue_empty() { return pri_queue_.empty(exec_queue::read_write); }
+   bool trx_read_write_queue_empty() { return pri_queue_.empty(exec_queue::trx_read_write); }
    bool read_exclusive_queue_empty() { return pri_queue_.empty(exec_queue::read_exclusive); }
 
    // members are ordered taking into account that the last one is destructed first
@@ -157,7 +177,10 @@ private:
    std::thread::id                    main_thread_id_{ std::this_thread::get_id() };
    boost::asio::io_context            io_ctx_;
    appbase::exec_pri_queue            pri_queue_;
-   std::atomic<std::size_t>           order_{ std::numeric_limits<size_t>::max() }; // to maintain FIFO ordering in all queues within priority
+   // to maintain FIFO ordering in all queues within priority
+   std::atomic<std::size_t>           order_{ std::numeric_limits<size_t>::max() };
+   // Prevent spinning on popping a trx from the queue only to put it back in because there is no pending block
+   std::atomic<bool>                  trx_read_write_queue_enabled_{true};
    exec_window                        exec_window_{ exec_window::write };
 };
 

--- a/libraries/custom_appbase/include/eosio/chain/application.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/application.hpp
@@ -85,12 +85,12 @@ public:
       while (true) {
          if ( exec_window_ == exec_window::write ) {
             // During write window only main thread is accessing anything in priority_queue_executor, no locking required
-            std::optional<size_t> remaining = pri_queue_.execute_highest(exec_queue::read_write, exec_queue::read_only);
-            if (!remaining && trx_read_write_queue_enabled_.load(std::memory_order_acquire)) {
+            size_t before = pri_queue_.execute_highest(exec_queue::read_write, exec_queue::read_only);
+            if (before == 0 && trx_read_write_queue_enabled_.load(std::memory_order_acquire)) {
                // locked because any thread can push to the trx_read_write queue
                more = pri_queue_.execute_highest_locked(exec_queue::trx_read_write);
             } else {
-               more = *remaining > 0;
+               more = before > 0;
             }
          } else {
             // When in read window, multiple threads including main app thread are accessing priority_queue_executor, locking required

--- a/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
@@ -299,13 +299,6 @@ public:
       return boost::asio::bind_executor( executor(*this, id, priority, order, q), std::forward<Function>(func) );
    }
 
-   template <typename Function>
-   boost::asio::executor_binder<Function, executor>
-   wrap(int priority, exec_queue q, size_t order, Function&& func)
-   {
-      return boost::asio::bind_executor( executor(*this, handler_id::unique, priority, order, q), std::forward<Function>(func) );
-   }
-
 private:
    class queued_handler_base
    {

--- a/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
@@ -202,17 +202,16 @@ public:
    }
 
    // only call when no lock required
-   // returns number of tasks in queues after executing the highest.
-   //  empty optional - none were executed and none remain.
-   //  {0} means 1 was executed and none remain.
-   //  {1} means 1 was executed and 1 remains.
-   //  {x} means 1 was executed and x remain.
-   std::optional<size_t> execute_highest(exec_queue lhs, exec_queue rhs) {
+   // returns number of tasks in queues before executing the highest.
+   //   0 means none were executed.
+   //   1 means there was one executed and none remain.
+   //   > 1 means there was one executed and return-1 remain.
+   size_t execute_highest(exec_queue lhs, exec_queue rhs) {
       prio_queue& lhs_que = priority_que(lhs);
       prio_queue& rhs_que = priority_que(rhs);
       size_t size = lhs_que.size() + rhs_que.size();
       if (size == 0)
-         return {};
+         return size;
       exec_queue q = rhs;
       if (!lhs_que.empty() && (rhs_que.empty() || *rhs_que.top() < *lhs_que.top()))
          q = lhs;
@@ -221,7 +220,7 @@ public:
       // pop, then execute since read_write queue is used to switch to read window and the pop needs to happen before that lambda starts
       auto t = pop(que);
       t->execute();
-      return std::optional{size-1};
+      return size;
    }
 
    bool execute_highest_blocking_locked(exec_queue lhs, exec_queue rhs) {

--- a/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
+++ b/libraries/custom_appbase/include/eosio/chain/exec_pri_queue.hpp
@@ -137,6 +137,7 @@ private:
          }
          que.push( create_handler().release() );
       } else {
+         // no lock required, called only from main thread
          que.push( create_handler().release() );
       }
       return true;
@@ -155,7 +156,8 @@ public:
    void add(handler_id id, int priority, exec_queue q, size_t order, Function&& function) {
       assert( num_read_threads_ > 0 || q != exec_queue::read_exclusive);
       if (id == handler_id::unique) {
-         add(priority, q, order, std::forward<Function>(function), true);
+         constexpr bool force = true; // no need to check return of add, passing force=true
+         add(priority, q, order, std::forward<Function>(function), force);
          return;
       }
       prio_queue& que = priority_que(q);
@@ -200,16 +202,17 @@ public:
    }
 
    // only call when no lock required
-   // returns number of tasks in queues before executing the highest.
-   //   0 means none were executed.
-   //   1 means there was one executed and none remain.
-   //   > 1 means there was one executed and return-1 remain.
-   size_t execute_highest(exec_queue lhs, exec_queue rhs) {
+   // returns number of tasks in queues after executing the highest.
+   //  empty optional - none were executed and none remain.
+   //  {0} means 1 was executed and none remain.
+   //  {1} means 1 was executed and 1 remains.
+   //  {x} means 1 was executed and x remain.
+   std::optional<size_t> execute_highest(exec_queue lhs, exec_queue rhs) {
       prio_queue& lhs_que = priority_que(lhs);
       prio_queue& rhs_que = priority_que(rhs);
       size_t size = lhs_que.size() + rhs_que.size();
       if (size == 0)
-         return size;
+         return {};
       exec_queue q = rhs;
       if (!lhs_que.empty() && (rhs_que.empty() || *rhs_que.top() < *lhs_que.top()))
          q = lhs;
@@ -218,7 +221,7 @@ public:
       // pop, then execute since read_write queue is used to switch to read window and the pop needs to happen before that lambda starts
       auto t = pop(que);
       t->execute();
-      return size;
+      return std::optional{size-1};
    }
 
    bool execute_highest_blocking_locked(exec_queue lhs, exec_queue rhs) {

--- a/libraries/custom_appbase/tests/custom_appbase_tests.cpp
+++ b/libraries/custom_appbase/tests/custom_appbase_tests.cpp
@@ -470,7 +470,7 @@ BOOST_AUTO_TEST_CASE( execute_from_read_only_and_read_write_and_trx_read_write_q
    BOOST_CHECK_LT( rslts[15], rslts[7] );
    BOOST_CHECK_LT( rslts[15], rslts[13] );
 
-   // trx_read_write execute in order or priority
+   // trx_read_write execute in order of priority
    BOOST_CHECK_LT( rslts[2], rslts[13] );
    BOOST_CHECK_LT( rslts[13], rslts[7] );
    BOOST_CHECK_LT( rslts[7], rslts[3] );

--- a/libraries/custom_appbase/tests/custom_appbase_tests.cpp
+++ b/libraries/custom_appbase/tests/custom_appbase_tests.cpp
@@ -350,9 +350,6 @@ BOOST_AUTO_TEST_CASE( execute_from_empty_read_only_queue ) {
 BOOST_AUTO_TEST_CASE( execute_from_read_only_and_read_write_queues ) {
    scoped_app_thread app;
 
-   // set to run functions from both queues
-   app->executor().is_write_window();
-
    // post functions
    std::map<int, int> rslts {};
    int seq_num = 0;
@@ -415,9 +412,6 @@ BOOST_AUTO_TEST_CASE( execute_from_read_only_and_read_write_queues ) {
 // trx_read_write are processed after all read_only and read_write
 BOOST_AUTO_TEST_CASE( execute_from_read_only_and_read_write_and_trx_read_write_queues ) {
    scoped_app_thread app(true);
-
-   // set to run functions from both queues
-   app->executor().is_write_window();
 
    // post functions
    std::map<int, int> rslts {};
@@ -643,6 +637,61 @@ BOOST_AUTO_TEST_CASE( execute_many_from_read_only_and_read_exclusive_queues ) {
 
    // We expect at least one task to run on every thread including main, but nothing guarantees that, just verify they all ran
    BOOST_REQUIRE_EQUAL(run_on_1+run_on_2+run_on_3+run_on_main, num_expected);
+}
+
+BOOST_AUTO_TEST_CASE( test_read_view_iteration ) {
+   scoped_app_thread app(true);
+
+   // post functions
+   const int trx_priority = priority::high+100; // trx priority set via configuration
+   struct functor {
+      void operator()() {}
+      int some_other_function() const { return i; }
+      int i;
+   };
+   app->executor().post( priority::medium, exec_queue::read_only,      functor{ 0 } );
+   app->executor().post( trx_priority+1,   exec_queue::trx_read_write, functor{ 1 } );
+   app->executor().post( trx_priority+5,   exec_queue::trx_read_write, functor{ 2 } );
+   app->executor().post( trx_priority+1,   exec_queue::trx_read_write, functor{ 3 } );
+   app->executor().post( priority::medium, exec_queue::read_write,     functor{ 4 } );
+   app->executor().post( priority::high,   exec_queue::read_write,     functor{ 5 } );
+   app->executor().post( priority::lowest, exec_queue::read_only,      functor{ 6 } );
+   app->executor().post( trx_priority+2,   exec_queue::trx_read_write, functor{ 7 } );
+
+   auto work = make_work_guard(app->get_io_context());
+   while( true ) {
+      app->get_io_context().poll();
+      size_t s = app->executor().read_only_queue_size() +
+                 app->executor().read_exclusive_queue_size() +
+                 app->executor().read_write_queue_size() +
+                 app->executor().trx_read_write_queue_size();
+      if (s == 8)
+         break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+   }
+
+   {
+      auto read_queue = app->executor().readable_queue();
+      auto b = read_queue.begin(exec_queue::trx_read_write);
+      auto e = read_queue.end(exec_queue::trx_read_write);
+      BOOST_REQUIRE(b != e);
+      BOOST_TEST(std::distance(b, e) == 4);
+      BOOST_REQUIRE_EQUAL( app->executor().trx_read_write_queue_size(), 4u );
+      BOOST_REQUIRE_EQUAL( read_queue.size(exec_queue::trx_read_write), 4u );
+      int v = read_queue.function_from_iter<functor>(b).some_other_function();
+      BOOST_CHECK_EQUAL(v, 2);
+      v = read_queue.function_from_iter<functor>(++b).some_other_function();
+      BOOST_CHECK_EQUAL(v, 7);
+      v = read_queue.function_from_iter<functor>(++b).some_other_function();
+      BOOST_CHECK_EQUAL(v, 1);
+      v = read_queue.function_from_iter<functor>(++b).some_other_function();
+      BOOST_CHECK_EQUAL(v, 3);
+   }
+
+   app.start_exec();
+   work.reset();
+   app->quit();
+   app.join();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2125,7 +2125,8 @@ void read_write::push_transaction(const read_write::push_transaction_params& par
          abi_serializer::from_variant(params, *pretty_input, resolver, abi_serializer_max_time);
       } EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction")
 
-      app().get_method<incoming::methods::transaction_async>()(pretty_input, true, transaction_metadata::trx_type::input, false,
+      static incoming::methods::transaction_async::method_type& on_incoming = app().get_method<incoming::methods::transaction_async>();
+      on_incoming(pretty_input, true, transaction_metadata::trx_type::input, false,
             [this, next](const next_function_variant<transaction_trace_ptr>& result) -> void {
          if (std::holds_alternative<fc::exception_ptr>(result)) {
             next(std::get<fc::exception_ptr>(result));
@@ -2261,7 +2262,8 @@ void api_base::send_transaction_gen(API &api, send_transaction_params_t params, 
                      ("e", ptrx->expiration())("m", api.trx_retry->get_max_expiration_time()) );
       }
 
-      app().get_method<incoming::methods::transaction_async>()(ptrx, true, params.trx_type, params.return_failure_trace,
+      static incoming::methods::transaction_async::method_type& on_incoming = app().get_method<incoming::methods::transaction_async>();
+      on_incoming(ptrx, true, params.trx_type, params.return_failure_trace,
             [&api, ptrx, next, retry, retry_num_blocks](const next_function_variant<transaction_trace_ptr>& result) -> void {
             if( std::holds_alternative<fc::exception_ptr>( result ) ) {
                next( std::get<fc::exception_ptr>( result ) );

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -134,7 +134,6 @@ public:
    };
 
    struct get_unapplied_transactions_result {
-      size_t                     size = 0;
       size_t                     unapplied_size = 0;
       size_t                     queued_size = 0;
       std::vector<unapplied_trx> unapplied_trxs;
@@ -179,5 +178,5 @@ FC_REFLECT(eosio::producer_plugin::get_account_ram_corrections_params, (lower_bo
 FC_REFLECT(eosio::producer_plugin::get_account_ram_corrections_result, (rows)(more))
 FC_REFLECT(eosio::producer_plugin::get_unapplied_transactions_params, (lower_bound)(limit)(time_limit_ms))
 FC_REFLECT(eosio::producer_plugin::unapplied_trx, (trx_id)(expiration)(trx_type)(first_auth)(first_receiver)(first_action)(total_actions)(billed_cpu_time_us)(size))
-FC_REFLECT(eosio::producer_plugin::get_unapplied_transactions_result, (size)(unapplied_size)(queued_size)(unapplied_trxs)(queued_trxs)(more))
+FC_REFLECT(eosio::producer_plugin::get_unapplied_transactions_result, (unapplied_size)(queued_size)(unapplied_trxs)(queued_trxs)(more))
 FC_REFLECT(eosio::producer_plugin::pause_at_block_params, (block_num));

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -135,9 +135,11 @@ public:
 
    struct get_unapplied_transactions_result {
       size_t                     size = 0;
-      size_t                     incoming_size = 0;
-      std::vector<unapplied_trx> trxs;
-      string                     more; ///< fill lower_bound with trx id to fetch next set of transactions
+      size_t                     unapplied_size = 0;
+      size_t                     queued_size = 0;
+      std::vector<unapplied_trx> unapplied_trxs;
+      std::vector<unapplied_trx> queued_trxs; ///< returned in priority order
+      string                     more; ///< fill lower_bound with trx id to fetch next set of unapplied trxs
    };
 
    get_unapplied_transactions_result get_unapplied_transactions( const get_unapplied_transactions_params& params, const fc::time_point& deadline ) const;
@@ -177,5 +179,5 @@ FC_REFLECT(eosio::producer_plugin::get_account_ram_corrections_params, (lower_bo
 FC_REFLECT(eosio::producer_plugin::get_account_ram_corrections_result, (rows)(more))
 FC_REFLECT(eosio::producer_plugin::get_unapplied_transactions_params, (lower_bound)(limit)(time_limit_ms))
 FC_REFLECT(eosio::producer_plugin::unapplied_trx, (trx_id)(expiration)(trx_type)(first_auth)(first_receiver)(first_action)(total_actions)(billed_cpu_time_us)(size))
-FC_REFLECT(eosio::producer_plugin::get_unapplied_transactions_result, (size)(incoming_size)(trxs)(more))
+FC_REFLECT(eosio::producer_plugin::get_unapplied_transactions_result, (size)(unapplied_size)(queued_size)(unapplied_trxs)(queued_trxs)(more))
 FC_REFLECT(eosio::producer_plugin::pause_at_block_params, (block_num));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2048,8 +2048,7 @@ producer_plugin_impl::get_unapplied_transactions(const producer_plugin::get_unap
    };
 
    producer_plugin::get_unapplied_transactions_result result;
-   result.size          = ua.size();
-   result.unapplied_size = ua.incoming_size();
+   result.unapplied_size = ua.size();
 
    uint32_t remaining = p.limit ? *p.limit : std::numeric_limits<uint32_t>::max();
    while (itr != ua.end() && remaining > 0) {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1070,9 +1070,9 @@ public:
                     return;
                  }
 
-                 // key recovery complete, continue execution on the main thread
+                 // key recovery complete, post to the trx queue
                  app().executor().post(
-                         priority::low, exec_queue::read_write,
+                         priority::low, exec_queue::trx_read_write,
                          [this, trx_meta{std::move(trx_meta)}, is_transient, next{std::move(next)}, api_trx, return_failure_traces]() {
                             auto start       = fc::time_point::now();
                             auto idle_time   = _time_tracker.add_idle_time(start);
@@ -1125,6 +1125,7 @@ public:
          }
 
          if (!chain.is_building_block()) {
+            fc_dlog(_trx_log, "adding incoming trx ${id} to unapplied queue", ("id", id));
             _unapplied_transactions.add_incoming(trx, api_trx, return_failure_trace, next);
             trx_tracker.cancel();
             return true;
@@ -2360,6 +2361,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    LOG_AND_DROP();
 
    if (chain.is_building_block()) {
+      app().executor().enable_trx_read_write_queue(true);
       const auto& pending_block_signing_authority = chain.pending_block_signing_authority();
 
       if (in_producing_mode() && pending_block_signing_authority != scheduled_producer.authority) {
@@ -2991,6 +2993,7 @@ void producer_plugin_impl::produce_block() {
       _protocol_features_signaled = false;
    }
 
+   app().executor().enable_trx_read_write_queue(false);
    // idump( (fc::time_point::now() - chain.pending_block_time()) );
    chain.assemble_and_complete_block([&](const digest_type& d) {
       auto debug_logger = maybe_make_debug_time_logger();

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -694,6 +694,10 @@ public:
               chain_plug->chain().get_greylist_limit()};
    }
 
+   producer_plugin::get_unapplied_transactions_result
+   get_unapplied_transactions(const producer_plugin::get_unapplied_transactions_params& p,
+                              const fc::time_point& deadline);
+
    void schedule_protocol_feature_activations(const producer_plugin::scheduled_protocol_feature_activations& schedule);
 
    void plugin_shutdown();
@@ -1003,6 +1007,52 @@ public:
       schedule_production_loop();
    }
 
+   struct trx_executor {
+      trx_executor(producer_plugin_impl* self,
+                   transaction_metadata_ptr trx_meta,
+                   bool is_transient,
+                   next_function<transaction_trace_ptr> next,
+                   bool api_trx,
+                   bool return_failure_traces)
+         : self(self)
+         , trx_meta(std::move(trx_meta))
+         , is_transient(is_transient)
+         , next(std::move(next))
+         , api_trx(api_trx)
+         , return_failure_traces(return_failure_traces)
+      {}
+
+      const transaction_metadata_ptr& get_trx_meta() const { return trx_meta; }
+
+      void operator()() {
+         auto start       = fc::time_point::now();
+         auto idle_time   = self->_time_tracker.add_idle_time(start);
+         fc_tlog(_log, "Time since last trx: ${t}us", ("t", idle_time));
+
+         auto exception_handler = [this](fc::exception_ptr ex) {
+            self->log_trx_results(trx_meta->packed_trx(), nullptr, ex, 0, is_transient);
+            next(std::move(ex));
+         };
+         try {
+            if (!self->process_incoming_transaction_async(trx_meta, api_trx, start, return_failure_traces, next)) {
+               if (self->in_producing_mode()) {
+                  self->schedule_maybe_produce_block(true);
+               } else {
+                  self->restart_speculative_block();
+               }
+            }
+         }
+         CATCH_AND_CALL(exception_handler);
+      }
+   private:
+      producer_plugin_impl* self;
+      transaction_metadata_ptr trx_meta;
+      bool is_transient;
+      next_function<transaction_trace_ptr> next;
+      bool api_trx;
+      bool return_failure_traces;
+   };
+
    void on_incoming_transaction_async(const packed_transaction_ptr&        trx,
                                       bool                                 api_trx,
                                       transaction_metadata::trx_type       trx_type,
@@ -1069,29 +1119,10 @@ public:
                     return;
                  }
 
-                 // key recovery complete, post to the trx queue
-                 app().executor().post(
-                         priority::low, exec_queue::trx_read_write,
-                         [this, trx_meta{std::move(trx_meta)}, is_transient, next{std::move(next)}, api_trx, return_failure_traces]() {
-                            auto start       = fc::time_point::now();
-                            auto idle_time   = _time_tracker.add_idle_time(start);
-                            fc_tlog(_log, "Time since last trx: ${t}us", ("t", idle_time));
+                 trx_executor executor{this, std::move(trx_meta), is_transient, std::move(next), api_trx, return_failure_traces};
 
-                            auto exception_handler = [this, is_transient, &next, &trx_meta](fc::exception_ptr ex) {
-                               log_trx_results(trx_meta->packed_trx(), nullptr, ex, 0, is_transient);
-                               next(std::move(ex));
-                            };
-                            try {
-                               if (!process_incoming_transaction_async(trx_meta, api_trx, start, return_failure_traces, next)) {
-                                  if (in_producing_mode()) {
-                                     schedule_maybe_produce_block(true);
-                                  } else {
-                                     restart_speculative_block();
-                                  }
-                               }
-                            }
-                            CATCH_AND_CALL(exception_handler);
-                         });
+                 // key recovery complete, post to the trx queue
+                 app().executor().post(priority::low, exec_queue::trx_read_write, std::move(executor));
               });
    }
 
@@ -1974,13 +2005,14 @@ producer_plugin::get_account_ram_corrections(const get_account_ram_corrections_p
    return result;
 }
 
-producer_plugin::get_unapplied_transactions_result producer_plugin::get_unapplied_transactions(const get_unapplied_transactions_params& p,
-                                                                                               const fc::time_point& deadline) const {
+producer_plugin::get_unapplied_transactions_result
+producer_plugin_impl::get_unapplied_transactions(const producer_plugin::get_unapplied_transactions_params& p,
+                                                 const fc::time_point& deadline) {
 
    fc::time_point params_deadline =
       p.time_limit_ms ? std::min(fc::time_point::now().safe_add(fc::milliseconds(*p.time_limit_ms)), deadline) : deadline;
 
-   auto& ua = my->_unapplied_transactions;
+   auto& ua = _unapplied_transactions;
 
    auto itr = ([&]() {
       if (!p.lower_bound.empty()) {
@@ -2015,15 +2047,13 @@ producer_plugin::get_unapplied_transactions_result producer_plugin::get_unapplie
       return "unknown type";
    };
 
-   get_unapplied_transactions_result result;
+   producer_plugin::get_unapplied_transactions_result result;
    result.size          = ua.size();
-   result.incoming_size = ua.incoming_size();
+   result.unapplied_size = ua.incoming_size();
 
    uint32_t remaining = p.limit ? *p.limit : std::numeric_limits<uint32_t>::max();
-   if (deadline != fc::time_point::maximum() && remaining > 1000)
-      remaining = 1000;
    while (itr != ua.end() && remaining > 0) {
-      auto& r             = result.trxs.emplace_back();
+      auto& r             = result.unapplied_trxs.emplace_back();
       r.trx_id            = itr->id();
       r.expiration        = itr->expiration();
       const auto& pt      = itr->trx_meta->packed_trx();
@@ -2039,16 +2069,54 @@ producer_plugin::get_unapplied_transactions_result producer_plugin::get_unapplie
       r.size               = pt->get_estimated_size();
 
       ++itr;
-      remaining--;
+      --remaining;
       if (fc::time_point::now() >= params_deadline)
          break;
    }
 
+   auto readable_queue = app().executor().readable_queue();
+   result.queued_size = readable_queue.size(exec_queue::trx_read_write);
+
    if (itr != ua.end()) {
       result.more = itr->id();
+      return result;
+   }
+
+   auto qitr = readable_queue.begin(exec_queue::trx_read_write);
+   auto qend = readable_queue.end(exec_queue::trx_read_write);
+   for (; qitr != qend && remaining > 0; ++qitr) {
+      auto& r             = result.queued_trxs.emplace_back();
+      const auto& f = readable_queue.function_from_iter<trx_executor>(qitr);
+      const auto& trx_meta = f.get_trx_meta();
+      const auto& pt = trx_meta->packed_trx();
+      r.trx_id            = pt->id();
+      r.expiration        = pt->expiration();
+      r.trx_type          = "input";
+      r.first_auth        = pt->get_transaction().first_authorizer();
+      const auto& actions = pt->get_transaction().actions;
+      if (!actions.empty()) {
+         r.first_receiver = actions[0].account;
+         r.first_action   = actions[0].name;
+      }
+      r.total_actions      = pt->get_transaction().total_actions();
+      r.billed_cpu_time_us = trx_meta->billed_cpu_time_us;
+      r.size               = pt->get_estimated_size();
+
+      --remaining;
+      if (fc::time_point::now() >= params_deadline)
+         break;
+   }
+
+   if (qitr != qend) {
+      result.more = readable_queue.function_from_iter<trx_executor>(qitr).get_trx_meta()->id();
    }
 
    return result;
+}
+
+producer_plugin::get_unapplied_transactions_result producer_plugin::get_unapplied_transactions(const get_unapplied_transactions_params& p,
+                                                                                               const fc::time_point& deadline) const {
+   return my->get_unapplied_transactions(p, deadline);
 }
 
 block_timestamp_type producer_plugin_impl::calculate_pending_block_time() const {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1008,7 +1008,6 @@ public:
                                       transaction_metadata::trx_type       trx_type,
                                       bool                                 return_failure_traces,
                                       next_function<transaction_trace_ptr> next) {
-
       const transaction& t = trx->get_transaction();
       EOS_ASSERT( t.delay_sec.value == 0, transaction_exception, "transaction cannot be delayed" );
 
@@ -2287,8 +2286,10 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
    const block_num_type head_block_num    = head.block_num();
    const uint32_t       pending_block_num = head_block_num + 1;
 
-   fc_dlog(_log, "Starting block #${n} ${bt} producer ${p}, deadline ${d}",
-           ("n", pending_block_num)("bt", block_time)("p", scheduled_producer.producer_name)("d", _pending_block_deadline));
+   fc_dlog(_log, "Starting block #${n} ${bt} producer ${p}, deadline ${d}, unapplied trxs ${u}, queued trxs ${q}, queued tasks ${t}",
+           ("n", pending_block_num)("bt", block_time)("p", scheduled_producer.producer_name)("d", _pending_block_deadline)
+           ("u", _unapplied_transactions.size())("q", app().executor().readable_queue().size(exec_queue::trx_read_write))
+           ("t", app().executor().read_write_queue_size()));
 
    try {
 

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -1149,11 +1149,11 @@ class PluginHttpTest(unittest.TestCase):
         command = "get_unapplied_transactions"
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
         self.assertIn("size", ret_json["payload"])
-        self.assertIn("incoming_size", ret_json["payload"])
+        self.assertIn("unapplied_size", ret_json["payload"])
         # get_unapplied_transactions with empty content parameter
         ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
         self.assertIn("size", ret_json["payload"])
-        self.assertIn("incoming_size", ret_json["payload"])
+        self.assertIn("unapplied_size", ret_json["payload"])
         # get_unapplied_transactions with invalid parameter
         ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
         self.assertEqual(ret_json["code"], 400)
@@ -1161,7 +1161,8 @@ class PluginHttpTest(unittest.TestCase):
         # get_unapplied_transactions with valid parameter
         payload = {"lower_bound":"", "limit":1, "time_limit_ms":500}
         ret_json = self.nodeos.processUrllibRequest(resource, command, payload, endpoint=endpoint)
-        self.assertIn("trxs", ret_json["payload"])
+        self.assertIn("unapplied_trxs", ret_json["payload"])
+        self.assertIn("queued_trxs", ret_json["payload"])
 
         # place pause and resume tests at the end such that they are not impacted
         # by update_runtime_options

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -1148,12 +1148,12 @@ class PluginHttpTest(unittest.TestCase):
         # get_unapplied_transactions with empty parameter
         command = "get_unapplied_transactions"
         ret_json = self.nodeos.processUrllibRequest(resource, command, endpoint=endpoint)
-        self.assertIn("size", ret_json["payload"])
         self.assertIn("unapplied_size", ret_json["payload"])
+        self.assertIn("queued_size", ret_json["payload"])
         # get_unapplied_transactions with empty content parameter
         ret_json = self.nodeos.processUrllibRequest(resource, command, self.empty_content_dict, endpoint=endpoint)
-        self.assertIn("size", ret_json["payload"])
         self.assertIn("unapplied_size", ret_json["payload"])
+        self.assertIn("queued_size", ret_json["payload"])
         # get_unapplied_transactions with invalid parameter
         ret_json = self.nodeos.processUrllibRequest(resource, command, self.http_post_invalid_param, endpoint=endpoint)
         self.assertEqual(ret_json["code"], 400)


### PR DESCRIPTION
See https://github.com/Wire-Network/wire-sysio/pull/163

Add a separate trx execution queue, `trx_read_write`, that is executed from when there are no `read_write` or `read_only` tasks to execute. This preserves running trxs as the lowest priority task, but allows for individual prioritization of transactions. As of this PR, all transactions have the same priority, however, this adds the framework for specifying different priorities for transactions. The new `trx_read_write` queue is only for non-read-only transactions. Read-only transactions are still executed in FIFO order on multiple threads.

In addition to allowing for different priorities for transactions, this change also reduces the contention on the main `io_context` which in previous benchmarking was demonstrated to be a bottleneck for small transfer like transactions.

See https://github.com/AntelopeIO/leap/issues/1860